### PR TITLE
FIX: add some warning about source in liquid

### DIFF
--- a/pygrt/C_extension/src/common/model.c
+++ b/pygrt/C_extension/src/common/model.c
@@ -398,12 +398,23 @@ PYMODEL1D * read_pymod_from_file(const char *command, const char *modelpath, dou
     pymod->deprcv = deprcv;
 
     // 检查，接收点不能位于液-液、固-液界面
-    if(isrc < nlay-1 && pymod->Thk[ircv] == 0.0 && pymod->Vb[ircv]*pymod->Vb[ircv+1] == 0.0){
+    if(ircv < nlay-1 && pymod->Thk[ircv] == 0.0 && pymod->Vb[ircv]*pymod->Vb[ircv+1] == 0.0){
         fprintf(stderr, 
             "[%s] " BOLD_RED "The receiver is located on the interface where there is liquid on one side. "
             "Due to the discontinuity of the tangential displacement on this interface, "
-            "to reduce ambiguity, it is recommended that you add a small offset to the receiver depth, "
-            "thereby explicitly placing the receiver within a specific layer. \n"
+            "to reduce ambiguity, you should add a small offset to the receiver depth, "
+            "thereby explicitly placing it within a specific layer. \n"
+            DEFAULT_RESTORE, command);
+        return NULL;
+    }
+
+    // 检查 --> 源点不能位于液-液、固-液界面
+    if(isrc < nlay-1 && pymod->Thk[isrc] == 0.0 && pymod->Vb[isrc]*pymod->Vb[isrc+1] == 0.0){
+        fprintf(stderr, 
+            "[%s] " BOLD_RED "The source is located on the interface where there is liquid on one side. "
+            "Due to the discontinuity of the tangential displacement on this interface, "
+            "to reduce ambiguity, you should add a small offset to the source depth, "
+            "thereby explicitly placing it within a specific layer. \n"
             DEFAULT_RESTORE, command);
         return NULL;
     }

--- a/pygrt/C_extension/src/dynamic/grt_main.c
+++ b/pygrt/C_extension/src/dynamic/grt_main.c
@@ -995,6 +995,12 @@ int main(int argc, char **argv) {
         exit(EXIT_FAILURE);
     }
 
+    // 当震源位于液体层中时，仅允许计算爆炸源对应的格林函数
+    // 程序结束前会输出对应警告
+    if(pymod->Vb[pymod->isrc]==0.0){
+        doHF = doVF = doDC = false;
+    }
+
     // 最大最小速度
     get_pymod_vmin_vmax(pymod, &vmin, &vmax);
 
@@ -1203,6 +1209,14 @@ int main(int argc, char **argv) {
         }
 
         free(s_output_subdir);
+    }
+
+    // 输出警告：当震源位于液体层中时，仅允许计算爆炸源对应的格林函数
+    if(pymod->Vb[pymod->isrc]==0.0){
+        fprintf(stderr, "[%s] " BOLD_YELLOW 
+            "The source is located in the liquid layer, "
+            "therefore only the Green's Funtions for the Explosion source will be computed.\n" 
+            DEFAULT_RESTORE, command);
     }
     
 


### PR DESCRIPTION
+ source can't locate on the interface where there is liquid on one side. 
+ only compyte GF of explosion if source is located in liquid.