### PR TITLE
REFAC: split R/T functions into P-SV and SH

### DIFF
--- a/pygrt/C_extension/include/common/recursion.h
+++ b/pygrt/C_extension/include/common/recursion.h
@@ -16,51 +16,81 @@
 #include "common/const.h"
 
 
-/**
- * 根据公式(5.5.3(1))进行递推  
- * 
- * @param[in]      RD1             1层 P-SV 下传反射系数矩阵
- * @param[in]      RDL1            1层 SH 下传反射系数
- * @param[in]      RU1             1层 P-SV 上传反射系数矩阵
- * @param[in]      RUL1            1层 SH 上传反射系数
- * @param[in]      TD1             1层 P-SV 下传透射系数矩阵
- * @param[in]      TDL1            1层 SH 下传透射系数
- * @param[in]      TU1             1层 P-SV 上传透射系数矩阵
- * @param[in]      TUL1            1层 SH 上传透射系数
- * @param[in]      RD2             2层 P-SV 下传反射系数矩阵
- * @param[in]      RDL2            2层 SH 下传反射系数
- * @param[out]     RD              1+2层 P-SV 下传反射系数矩阵
- * @param[out]     RDL             1+2层 SH 下传反射系数
- * @param[out]     inv_2x2T        非NULL时，返回公式中的 \f$ (\mathbf{I} - \mathbf{R}_U^1 \mathbf{R}_D^2)^{-1} \mathbf{T}_D^1 \f$ 一项   
- * @param[out]     invT            非NULL时，返回上面inv_2x2T的标量形式    
- * @param[out]     stats           状态代码，是否有除零错误，非0为异常值
- * 
- */
+// 对4个矩阵赋值
+#define GRT_RT_PSV_ASSIGN(suffix) ({\
+    for(MYINT kk=0; kk<2; ++kk){\
+        for(MYINT pp=0; pp<2; ++pp){\
+            RD_##suffix[kk][pp] = RD[kk][pp];\
+            RU_##suffix[kk][pp] = RU[kk][pp];\
+            TD_##suffix[kk][pp] = TD[kk][pp];\
+            TU_##suffix[kk][pp] = TU[kk][pp];\
+        }\
+    }\
+})
+
+#define GRT_RT_SH_ASSIGN(suffix) ({\
+    RDL_##suffix = RDL;\
+    RUL_##suffix = RUL;\
+    TDL_##suffix = TDL;\
+    TUL_##suffix = TUL;\
+})
+
+/*
+#define CMAT_ASSIGN(suffix) ({\
+    cmat2x2_assign(RD, RD_##suffix);  RDL_##suffix = RDL; \
+    cmat2x2_assign(RU, RU_##suffix);  RUL_##suffix = RUL; \
+    cmat2x2_assign(TD, TD_##suffix);  TDL_##suffix = TDL; \
+    cmat2x2_assign(TU, TU_##suffix);  TUL_##suffix = TUL; \
+})
+*/
+
+
+/** 合并 recursion_RD_PSV(SH) */
 void recursion_RD(
     const MYCOMPLEX RD1[2][2], MYCOMPLEX RDL1, const MYCOMPLEX RU1[2][2], MYCOMPLEX RUL1,
     const MYCOMPLEX TD1[2][2], MYCOMPLEX TDL1, const MYCOMPLEX TU1[2][2], MYCOMPLEX TUL1,
     const MYCOMPLEX RD2[2][2], MYCOMPLEX RDL2, 
     MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX inv_2x2T[2][2], MYCOMPLEX *invT, MYINT *stats);
 
-
 /**
- * 根据公式(5.5.3(2))进行递推 
+ * 根据公式(5.5.3(1))进行递推 P-SV
  * 
- * @param[in]     RU1                 1层 P-SV 上传反射系数矩阵
- * @param[in]     RUL1                1层 SH 上传反射系数
- * @param[in]     TD1                 1层 P-SV 下传透射系数矩阵
- * @param[in]     TDL1                1层 SH 下传透射系数
- * @param[in]     RD2                 2层 P-SV 下传反射系数矩阵
- * @param[in]     RDL2                2层 SH 下传反射系数
- * @param[in]     TD2                 2层 P-SV 下传透射系数矩阵
- * @param[in]     TDL2                2层 SH 下传透射系数
- * @param[out]    TD                  1+2层 P-SV 下传透射系数矩阵
- * @param[out]    TDL                 1+2层 SH 下传透射系数
- * @param[out]    inv_2x2T            非NULL时，返回公式中的 \f$ (\mathbf{I} - \mathbf{R}_U^1 \mathbf{R}_D^2)^{-1} \mathbf{T}_D^1 \f$ 一项   
- * @param[out]    invT                非NULL时，返回上面inv_2x2T的标量形式      
- * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
+ * @param[in]      RD1             1层 P-SV 下传反射系数矩阵
+ * @param[in]      RU1             1层 P-SV 上传反射系数矩阵
+ * @param[in]      TD1             1层 P-SV 下传透射系数矩阵
+ * @param[in]      TU1             1层 P-SV 上传透射系数矩阵
+ * @param[in]      RD2             2层 P-SV 下传反射系数矩阵
+ * @param[out]     RD              1+2层 P-SV 下传反射系数矩阵
+ * @param[out]     inv_2x2T        非NULL时，返回公式中的 \f$ (\mathbf{I} - \mathbf{R}_U^1 \mathbf{R}_D^2)^{-1} \mathbf{T}_D^1 \f$ 一项   
+ * @param[out]     stats           状态代码，是否有除零错误，非0为异常值
  * 
  */
+void recursion_RD_PSV(
+    const MYCOMPLEX RD1[2][2], const MYCOMPLEX RU1[2][2],
+    const MYCOMPLEX TD1[2][2], const MYCOMPLEX TU1[2][2],
+    const MYCOMPLEX RD2[2][2],
+    MYCOMPLEX RD[2][2], MYCOMPLEX inv_2x2T[2][2], MYINT *stats);
+
+/**
+ * 根据公式(5.5.3(1))进行递推 SH
+ * 
+ * @param[in]      RDL1            1层 SH 下传反射系数
+ * @param[in]      RUL1            1层 SH 上传反射系数
+ * @param[in]      TDL1            1层 SH 下传透射系数
+ * @param[in]      TUL1            1层 SH 上传透射系数
+ * @param[in]      RDL2            2层 SH 下传反射系数
+ * @param[out]     RDL             1+2层 SH 下传反射系数
+ * @param[out]     invT            非NULL时，返回上面inv_2x2T的标量形式    
+ * @param[out]     stats           状态代码，是否有除零错误，非0为异常值
+ * 
+ */
+void recursion_RD_SH(
+    MYCOMPLEX RDL1, MYCOMPLEX RUL1,
+    MYCOMPLEX TDL1, MYCOMPLEX TUL1,
+    MYCOMPLEX RDL2, MYCOMPLEX *RDL, MYCOMPLEX *invT, MYINT *stats);
+
+
+/** 合并 recursion_TD_PSV(SH) */
 void recursion_TD(
     const MYCOMPLEX RU1[2][2], MYCOMPLEX RUL1,
     const MYCOMPLEX TD1[2][2], MYCOMPLEX TDL1, 
@@ -68,29 +98,42 @@ void recursion_TD(
     const MYCOMPLEX TD2[2][2], MYCOMPLEX TDL2, 
     MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX inv_2x2T[2][2], MYCOMPLEX *invT, MYINT *stats);
 
-
-
-
 /**
- * 根据公式(5.5.3(3))进行递推  
+ * 根据公式(5.5.3(2))进行递推 P-SV
  * 
  * @param[in]     RU1                 1层 P-SV 上传反射系数矩阵
- * @param[in]     RUL1                1层 SH 上传反射系数
+ * @param[in]     TD1                 1层 P-SV 下传透射系数矩阵
  * @param[in]     RD2                 2层 P-SV 下传反射系数矩阵
- * @param[in]     RDL2                2层 SH 下传反射系数
- * @param[in]     RU2                 2层 P-SV 上传反射系数矩阵
- * @param[in]     RUL2                2层 SH 上传反射系数
  * @param[in]     TD2                 2层 P-SV 下传透射系数矩阵
+ * @param[out]    TD                  1+2层 P-SV 下传透射系数矩阵
+ * @param[out]    inv_2x2T            非NULL时，返回公式中的 \f$ (\mathbf{I} - \mathbf{R}_U^1 \mathbf{R}_D^2)^{-1} \mathbf{T}_D^1 \f$ 一项   
+ * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
+ * 
+ */
+void recursion_TD_PSV(
+    const MYCOMPLEX RU1[2][2], const MYCOMPLEX TD1[2][2],
+    const MYCOMPLEX RD2[2][2], const MYCOMPLEX TD2[2][2],
+    MYCOMPLEX TD[2][2], MYCOMPLEX inv_2x2T[2][2], MYINT *stats);
+
+/**
+ * 根据公式(5.5.3(2))进行递推 SH
+ * 
+ * @param[in]     RUL1                1层 SH 上传反射系数
+ * @param[in]     TDL1                1层 SH 下传透射系数
+ * @param[in]     RDL2                2层 SH 下传反射系数
  * @param[in]     TDL2                2层 SH 下传透射系数
- * @param[in]     TU2                 2层 P-SV 上传透射系数矩阵
- * @param[in]     TUL2                2层 SH 上传透射系数
- * @param[out]    RU                  1+2层 P-SV 上传反射系数矩阵
- * @param[out]    RUL                 1+2层 SH 上传反射系数
- * @param[out]    inv_2x2T            非NULL时，返回公式中的 \f$ (\mathbf{I} - \mathbf{R}_D^2 \mathbf{R}_U^1)^{-1} \mathbf{T}_U^2 \f$ 一项   
+ * @param[out]    TDL                 1+2层 SH 下传透射系数
  * @param[out]    invT                非NULL时，返回上面inv_2x2T的标量形式      
  * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
  * 
  */
+void recursion_TD_SH(
+    MYCOMPLEX RUL1, MYCOMPLEX TDL1, 
+    MYCOMPLEX RDL2, MYCOMPLEX TDL2, 
+    MYCOMPLEX *TDL, MYCOMPLEX *invT, MYINT *stats);
+
+
+/** 合并 recursion_RU_PSV(SH) */
 void recursion_RU(
     const MYCOMPLEX RU1[2][2], MYCOMPLEX RUL1,
     const MYCOMPLEX RD2[2][2], MYCOMPLEX RDL2, const MYCOMPLEX RU2[2][2], MYCOMPLEX RUL2,
@@ -98,24 +141,45 @@ void recursion_RU(
     MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, MYCOMPLEX inv_2x2T[2][2], MYCOMPLEX *invT, MYINT *stats);
 
 /**
- * 根据公式(5.5.3(4))进行递推
+ * 根据公式(5.5.3(3))进行递推 P-SV
  * 
  * @param[in]     RU1                 1层 P-SV 上传反射系数矩阵
- * @param[in]     RUL1                1层 SH 上传反射系数
  * @param[in]     RD2                 2层 P-SV 下传反射系数矩阵
- * @param[in]     RDL2                2层 SH 下传反射系数
- * @param[in]     RD2                 2层 P-SV 下传反射系数矩阵
- * @param[in]     RDL2                2层 SH 下传反射系数
+ * @param[in]     RU2                 2层 P-SV 上传反射系数矩阵
+ * @param[in]     TD2                 2层 P-SV 下传透射系数矩阵
  * @param[in]     TU2                 2层 P-SV 上传透射系数矩阵
- * @param[in]     TUL2                2层 SH 上传透射系数
- * @param[out]    TU                  1+2层 P-SV 上传透射系数矩阵
- * @param[out]    TUL                 1+2层 SH 上传透射系数
+ * @param[out]    RU                  1+2层 P-SV 上传反射系数矩阵
  * @param[out]    inv_2x2T            非NULL时，返回公式中的 \f$ (\mathbf{I} - \mathbf{R}_D^2 \mathbf{R}_U^1)^{-1} \mathbf{T}_U^2 \f$ 一项   
+ * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
+ * 
+ */
+void recursion_RU_PSV(
+    const MYCOMPLEX RU1[2][2], const MYCOMPLEX RD2[2][2], 
+    const MYCOMPLEX RU2[2][2], const MYCOMPLEX TD2[2][2], 
+    const MYCOMPLEX TU2[2][2], 
+    MYCOMPLEX RU[2][2], MYCOMPLEX inv_2x2T[2][2], MYINT *stats);
+
+/**
+ * 根据公式(5.5.3(3))进行递推 SH
+ * 
+ * @param[in]     RUL1                1层 SH 上传反射系数
+ * @param[in]     RDL2                2层 SH 下传反射系数
+ * @param[in]     RUL2                2层 SH 上传反射系数
+ * @param[in]     TDL2                2层 SH 下传透射系数
+ * @param[in]     TUL2                2层 SH 上传透射系数
+ * @param[out]    RUL                 1+2层 SH 上传反射系数
  * @param[out]    invT                非NULL时，返回上面inv_2x2T的标量形式      
  * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
  * 
- * 
  */
+void recursion_RU_SH(
+    MYCOMPLEX RUL1, MYCOMPLEX RDL2,
+    MYCOMPLEX RUL2, MYCOMPLEX TDL2, 
+    MYCOMPLEX TUL2,
+    MYCOMPLEX *RUL, MYCOMPLEX *invT, MYINT *stats);
+
+
+/** 合并 recursion_TU_PSV(SH) */
 void recursion_TU(
     const MYCOMPLEX RU1[2][2], MYCOMPLEX RUL1,
     const MYCOMPLEX TU1[2][2], MYCOMPLEX TUL1,
@@ -123,39 +187,45 @@ void recursion_TU(
     const MYCOMPLEX TU2[2][2], MYCOMPLEX TUL2,
     MYCOMPLEX TU[2][2], MYCOMPLEX *TUL, MYCOMPLEX inv_2x2T[2][2], MYCOMPLEX *invT, MYINT *stats);
 
-
-
 /**
- * 根据公式(5.5.3)进行递推，相当于上面四个函数合并
+ * 根据公式(5.5.3(4))进行递推 P-SV
  * 
- * @param[in]     RD1                 1层 P-SV 下传反射系数矩阵
- * @param[in]     RDL1                1层 SH 下传反射系数
  * @param[in]     RU1                 1层 P-SV 上传反射系数矩阵
- * @param[in]     RUL1                1层 SH 上传反射系数
- * @param[in]     TD1                 1层 P-SV 下传透射系数矩阵
- * @param[in]     TDL1                1层 SH 下传透射系数
- * @param[in]     TU1                 1层 P-SV 上传透射系数矩阵
- * @param[in]     TUL1                1层 SH 上传透射系数
  * @param[in]     RD2                 2层 P-SV 下传反射系数矩阵
- * @param[in]     RDL2                2层 SH 下传反射系数
- * @param[in]     RU2                 2层 P-SV 上传反射系数矩阵
- * @param[in]     RUL2                2层 SH 上传反射系数
- * @param[in]     TD2                 2层 P-SV 下传透射系数矩阵
- * @param[in]     TDL2                2层 SH 下传透射系数
+ * @param[in]     RD2                 2层 P-SV 下传反射系数矩阵
  * @param[in]     TU2                 2层 P-SV 上传透射系数矩阵
- * @param[in]     TUL2                2层 SH 上传透射系数
- * @param[out]    RD                  1+2层 P-SV 下传反射系数矩阵
- * @param[out]    RDL                 1+2层 SH 下传反射系数
- * @param[out]    RU                  1+2层 P-SV 上传反射系数矩阵
- * @param[out]    RUL                 1+2层 SH 上传反射系数
- * @param[out]    TD                  1+2层 P-SV 下传透射系数矩阵
- * @param[out]    TDL                 1+2层 SH 下传透射系数
  * @param[out]    TU                  1+2层 P-SV 上传透射系数矩阵
- * @param[out]    TUL                 1+2层 SH 上传透射系数
+ * @param[out]    inv_2x2T            非NULL时，返回公式中的 \f$ (\mathbf{I} - \mathbf{R}_D^2 \mathbf{R}_U^1)^{-1} \mathbf{T}_U^2 \f$ 一项   
  * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
  * 
  */
-void recursion_RT_2x2(
+void recursion_TU_PSV(
+    const MYCOMPLEX RU1[2][2], const MYCOMPLEX TU1[2][2],
+    const MYCOMPLEX RD2[2][2], const MYCOMPLEX TU2[2][2],
+    MYCOMPLEX TU[2][2], MYCOMPLEX inv_2x2T[2][2], MYINT *stats);
+
+/**
+ * 根据公式(5.5.3(4))进行递推 SH
+ * 
+ * @param[in]     RUL1                1层 SH 上传反射系数
+ * @param[in]     RDL2                2层 SH 下传反射系数
+ * @param[in]     RDL2                2层 SH 下传反射系数
+ * @param[in]     TUL2                2层 SH 上传透射系数
+ * @param[out]    TUL                 1+2层 SH 上传透射系数
+ * @param[out]    invT                非NULL时，返回上面inv_2x2T的标量形式      
+ * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
+ * 
+ */
+void recursion_TU_SH(
+    MYCOMPLEX RUL1, MYCOMPLEX TUL1,
+    MYCOMPLEX RDL2, MYCOMPLEX TUL2,
+    MYCOMPLEX *TUL, MYCOMPLEX *invT, MYINT *stats);
+
+
+
+
+/** 合并 recursion_RT_PSV(SH) */
+void recursion_RT(
     const MYCOMPLEX RD1[2][2], MYCOMPLEX RDL1, const MYCOMPLEX RU1[2][2], MYCOMPLEX RUL1,
     const MYCOMPLEX TD1[2][2], MYCOMPLEX TDL1, const MYCOMPLEX TU1[2][2], MYCOMPLEX TUL1,
     const MYCOMPLEX RD2[2][2], MYCOMPLEX RDL2, const MYCOMPLEX RU2[2][2], MYCOMPLEX RUL2,
@@ -163,26 +233,96 @@ void recursion_RT_2x2(
     MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX RU[2][2], MYCOMPLEX *RUL,
     MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL, MYINT *stats);
 
+/**
+ * 根据公式(5.5.3)进行递推 P-SV ，相当于对应四个函数合并，
+ * 内部使用了共有变量防止重复计算
+ * 
+ * @param[in]     RD1                 1层 P-SV 下传反射系数矩阵
+ * @param[in]     RU1                 1层 P-SV 上传反射系数矩阵
+ * @param[in]     TD1                 1层 P-SV 下传透射系数矩阵
+ * @param[in]     TU1                 1层 P-SV 上传透射系数矩阵
+ * @param[in]     RD2                 2层 P-SV 下传反射系数矩阵
+ * @param[in]     RU2                 2层 P-SV 上传反射系数矩阵
+ * @param[in]     TD2                 2层 P-SV 下传透射系数矩阵
+ * @param[in]     TU2                 2层 P-SV 上传透射系数矩阵
+ * @param[out]    RD                  1+2层 P-SV 下传反射系数矩阵
+ * @param[out]    RU                  1+2层 P-SV 上传反射系数矩阵
+ * @param[out]    TD                  1+2层 P-SV 下传透射系数矩阵
+ * @param[out]    TU                  1+2层 P-SV 上传透射系数矩阵
+ * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
+ * 
+ */
+void recursion_RT_PSV(
+    const MYCOMPLEX RD1[2][2], const MYCOMPLEX RU1[2][2],
+    const MYCOMPLEX TD1[2][2], const MYCOMPLEX TU1[2][2],
+    const MYCOMPLEX RD2[2][2], const MYCOMPLEX RU2[2][2],
+    const MYCOMPLEX TD2[2][2], const MYCOMPLEX TU2[2][2],
+    MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2],
+    MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2], MYINT *stats);
 
 /**
- * 对于虚拟层位，即上下层是相同的物性参数，对公式(5.5.3)进行简化，只剩下时间延迟因子
+ * 根据公式(5.5.3)进行递推 SH ，相当于对应四个函数合并，
+ * 内部使用了共有变量防止重复计算
+ * 
+ * @param[in]     RDL1                1层 SH 下传反射系数
+ * @param[in]     RUL1                1层 SH 上传反射系数
+ * @param[in]     TDL1                1层 SH 下传透射系数
+ * @param[in]     TUL1                1层 SH 上传透射系数
+ * @param[in]     RDL2                2层 SH 下传反射系数
+ * @param[in]     RUL2                2层 SH 上传反射系数
+ * @param[in]     TDL2                2层 SH 下传透射系数
+ * @param[in]     TUL2                2层 SH 上传透射系数
+ * @param[out]    RDL                 1+2层 SH 下传反射系数
+ * @param[out]    RUL                 1+2层 SH 上传反射系数
+ * @param[out]    TDL                 1+2层 SH 下传透射系数
+ * @param[out]    TUL                 1+2层 SH 上传透射系数
+ * @param[out]    stats               状态代码，是否有除零错误，非0为异常值
+ * 
+ */
+void recursion_RT_SH(
+    MYCOMPLEX RDL1, MYCOMPLEX RUL1,
+    MYCOMPLEX TDL1, MYCOMPLEX TUL1,
+    MYCOMPLEX RDL2, MYCOMPLEX RUL2,
+    MYCOMPLEX TDL2, MYCOMPLEX TUL2,
+    MYCOMPLEX *RDL, MYCOMPLEX *RUL,
+    MYCOMPLEX *TDL, MYCOMPLEX *TUL, MYINT *stats);
+
+
+
+/** 合并 recursion_RT_PSV(SH)_imaginary */
+void recursion_RT_imaginary(
+    MYCOMPLEX xa1, MYCOMPLEX xb1, MYREAL thk, MYREAL k, // 使用上层的厚度
+    MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
+    MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL);
+
+/**
+ * 递推虚拟层位的 P-SV 矩阵，即上下层是相同的物性参数，对公式(5.5.3)进行简化，只剩下时间延迟因子
  * 
  * @param[in]         xa1            P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
  * @param[in]         xb1            S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
  * @param[in]         thk            厚度
  * @param[in]         k              波数
  * @param[in,out]     RU             上层 P-SV 上传反射系数矩阵
- * @param[in,out]     RUL            上层 SH 上传反射系数
  * @param[in,out]     TD             上层 P-SV 下传透射系数矩阵
- * @param[in,out]     TDL            上层 SH 下传透射系数
  * @param[in,out]     TU             上层 P-SV 上传透射系数矩阵
+ */
+void recursion_RT_PSV_imaginary(
+    MYCOMPLEX xa1, MYCOMPLEX xb1, MYREAL thk, MYREAL k, // 使用上层的厚度
+    MYCOMPLEX RU[2][2], MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2]);
+
+/**
+ * 递推虚拟层位的 SH 矩阵，即上下层是相同的物性参数，对公式(5.5.3)进行简化，只剩下时间延迟因子
+ * 
+ * @param[in]         xb1            S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
+ * @param[in]         thk            厚度
+ * @param[in]         k              波数
+ * @param[in,out]     RUL            上层 SH 上传反射系数
+ * @param[in,out]     TDL            上层 SH 下传透射系数
  * @param[in,out]     TUL            上层 SH 上传透射系数
  */
-void recursion_RT_2x2_imaginary(
-    MYCOMPLEX xa1, MYCOMPLEX xb1, MYREAL thk, MYREAL k, // 使用上层的厚度
-    MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
-    MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL);
-
+void recursion_RT_SH_imaginary(
+    MYCOMPLEX xb1, MYREAL thk, MYREAL k, // 使用上层的厚度
+    MYCOMPLEX *RUL, MYCOMPLEX *TDL, MYCOMPLEX *TUL);
 
 
 /**

--- a/pygrt/C_extension/include/dynamic/layer.h
+++ b/pygrt/C_extension/include/dynamic/layer.h
@@ -3,7 +3,7 @@
  * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
  * @date   2024-07-24
  * 
- * 以下代码实现的是 反射透射系数矩阵 ，参考：
+ * 以下代码实现的是 P-SV 波和 SH 波的反射透射系数矩阵 ，参考：
  * 
  *         1. 姚振兴, 谢小碧. 2022/03. 理论地震图及其应用（初稿）.  
  *         2. Yao Z. X. and D. G. Harkrider. 1983. A generalized refelection-transmission coefficient 
@@ -17,7 +17,7 @@
 #include "common/const.h"
 
 /**
- * 计算自由表面的反射系数，公式(5.3.10-14) 
+ * 计算自由表面的 P-SV 波反射系数，公式(5.3.10-14) 
  * 
  * @param[in]     xa0            表层的P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
  * @param[in]     xb0            表层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
@@ -27,32 +27,42 @@
  * @param[out]    stats          状态代码，是否有除零错误，非0为异常值
  * 
  */
-void calc_R_tilt(
-    MYCOMPLEX xa0, MYCOMPLEX xb0, MYCOMPLEX kbkb0, MYREAL k, MYCOMPLEX R_tilt[2][2], MYINT *stats);
+void calc_R_tilt_PSV(MYCOMPLEX xa0, MYCOMPLEX xb0, MYCOMPLEX kbkb0, MYREAL k, MYCOMPLEX R_tilt[2][2], MYINT *stats);
 
 
 /**
- * 计算接收点位置的接收矩阵，将波场转为位移，公式(5.2.19) + (5.7.7,25)
+ * 计算接收点位置的 P-SV 波接收矩阵，将波场转为位移，公式(5.2.19) + (5.7.7,25)
  * 
  * @param[in]     xa_rcv          接受层的P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
  * @param[in]     xb_rcv          接受层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
  * @param[in]     ircvup          接收点是否浅于震源层
  * @param[in]     k               波数
  * @param[in]     R               P-SV波场
- * @param[in]     RL              SH波场
  * @param[out]    R_EV            P-SV接收函数矩阵
+ * 
+ */
+void calc_R_EV_PSV(
+    MYCOMPLEX xa_rcv, MYCOMPLEX xb_rcv, bool ircvup,
+    MYREAL k, 
+    const MYCOMPLEX R[2][2], MYCOMPLEX R_EV[2][2]);
+
+/**
+ * 计算接收点位置的 SH 波接收矩阵，将波场转为位移，公式(5.2.19) + (5.7.7,25)
+ * 
+ * @param[in]     xb_rcv          接受层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
+ * @param[in]     k               波数
+ * @param[in]     RL              SH波场
  * @param[out]    R_EVL           SH接收函数值
  * 
  */
-void calc_R_EV(
-    MYCOMPLEX xa_rcv, MYCOMPLEX xb_rcv, bool ircvup,
+void calc_R_EV_SH(
+    MYCOMPLEX xb_rcv,
     MYREAL k, 
-    const MYCOMPLEX R[2][2], MYCOMPLEX RL, 
-    MYCOMPLEX R_EV[2][2], MYCOMPLEX *R_EVL);
+    MYCOMPLEX RL, MYCOMPLEX *R_EVL);
 
 
 /**
- * 计算接收点位置的ui_z的接收矩阵，即将波场转为ui_z。
+ * 计算接收点位置的ui_z的 P-SV 波接收矩阵，即将波场转为ui_z。
  * 公式本质是推导ui_z关于q_m, w_m, v_m的连接矩阵（就是应力推导过程的一部分）
  * 
  * @param[in]     xa_rcv          接受层的P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
@@ -60,21 +70,35 @@ void calc_R_EV(
  * @param[in]     ircvup          接收点是否浅于震源层
  * @param[in]     k               波数
  * @param[in]     R               P-SV波场
- * @param[in]     RL              SH波场
  * @param[out]    R_EV            P-SV接收函数矩阵
- * @param[out]    R_EVL           SH接收函数值
  * 
  */
-void calc_uiz_R_EV(
+void calc_uiz_R_EV_PSV(
     MYCOMPLEX xa_rcv, MYCOMPLEX xb_rcv, bool ircvup,
     MYREAL k, 
-    const MYCOMPLEX R[2][2], MYCOMPLEX RL, 
-    MYCOMPLEX R_EV[2][2], MYCOMPLEX *R_EVL);
+    const MYCOMPLEX R[2][2], MYCOMPLEX R_EV[2][2]);
 
 
 /**
- * 计算界面的反射系数RD/RDL/RU/RUL, 透射系数TD/TDL/TU/TUL, 包括时间延迟因子，
- * 后缀L表示SH波的系数, 其余表示P-SV波的系数, 根据公式(5.4.14)和(5.4.31)计算系数   
+ * 计算接收点位置的ui_z的 SH 波接收矩阵，即将波场转为ui_z。
+ * 公式本质是推导ui_z关于q_m, w_m, v_m的连接矩阵（就是应力推导过程的一部分）
+ * 
+ * @param[in]     xb_rcv          接受层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
+ * @param[in]     ircvup          接收点是否浅于震源层
+ * @param[in]     k               波数
+ * @param[in]     RL              SH波场
+ * @param[out]    R_EVL           SH接收函数值
+ * 
+ */
+void calc_uiz_R_EV_SH(
+    MYCOMPLEX xb_rcv, bool ircvup,
+    MYREAL k, 
+    MYCOMPLEX RL, MYCOMPLEX *R_EVL);
+
+
+/**
+ * 计算界面的 P-SV 波反射透射系数RD/RU/TD/TU, 包括时间延迟因子，
+ * 根据公式(5.4.14)计算系数   
  * 
  * @note   对公式(5.4.14)进行了重新整理。原公式各项之间的数量级差别过大，浮点数计算损失精度严重。
  * 
@@ -92,75 +116,172 @@ void calc_uiz_R_EV(
  * @param[in]      omega         角频率
  * @param[in]      k             波数
  * @param[out]     RD            P-SV 下传反射系数矩阵
- * @param[out]     RDL           SH 下传反射系数
  * @param[out]     RU            P-SV 上传反射系数矩阵
- * @param[out]     RUL           SH 上传反射系数
  * @param[out]     TD            P-SV 下传透射系数矩阵
- * @param[out]     TDL           SH 下传透射系数
  * @param[out]     TU            P-SV 上传透射系数矩阵
+ * @param[out]     stats         状态代码，是否有除零错误，非0为异常值
+ * 
+ */
+void calc_RT_PSV(
+    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
+    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
+    MYREAL thk, // 使用上层的厚度
+    MYCOMPLEX omega, MYREAL k, 
+    MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2],
+    MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2], MYINT *stats);
+
+
+/**
+ * 计算界面的 SH 波反射透射系数RDL/RUL/TDL/TUL, 包括时间延迟因子，
+ * 根据公式(5.4.31)计算系数   
+ * 
+ * @param[in]      xb1           上层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
+ * @param[in]      mu1           上层的剪切模量
+ * @param[in]      xb2           下层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
+ * @param[in]      mu2           下层的剪切模量
+ * @param[in]      thk           上层层厚
+ * @param[in]      omega         角频率
+ * @param[in]      k             波数
+ * @param[out]     RDL           SH 下传反射系数
+ * @param[out]     RUL           SH 上传反射系数
+ * @param[out]     TDL           SH 下传透射系数
  * @param[out]     TUL           SH 上传透射系数
  * @param[out]     stats         状态代码，是否有除零错误，非0为异常值
  * 
  */
-void calc_RT_2x2(
-    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
-    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
-    MYREAL thk, MYCOMPLEX omega, MYREAL k, 
-    MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
-    MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL, MYINT *stats);
+void calc_RT_SH(
+    MYCOMPLEX xb1, MYCOMPLEX mu1, 
+    MYCOMPLEX xb2, MYCOMPLEX mu2, 
+    MYREAL thk, // 使用上层的厚度
+    MYCOMPLEX omega, MYREAL k, 
+    MYCOMPLEX *RDL, MYCOMPLEX *RUL, 
+    MYCOMPLEX *TDL, MYCOMPLEX *TUL);
 
-/** 固-固 界面，函数参数与 calc_RT_2x2 函数一致 */
-void calc_RT_ss_2x2(
-    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
-    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
-    MYREAL thk, MYCOMPLEX omega, MYREAL k, 
-    MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
-    MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL, MYINT *stats);
-
-/** 液-液 界面，函数参数与 calc_RT_2x2 函数类似，只是删除了不必要的参数 */
-void calc_RT_ll_2x2(
+/** 液-液 界面，函数参数见 calc_RT_PSV 函数 */
+void calc_RT_ll_PSV(
     MYREAL Rho1, MYCOMPLEX xa1,
     MYREAL Rho2, MYCOMPLEX xa2,
     MYREAL thk, // 使用上层的厚度
     MYCOMPLEX omega, MYREAL k,
-    MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
-    MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL, MYINT *stats);
+    MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2], 
+    MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2], MYINT *stats);
 
-/** 液-固 界面，函数参数与 calc_RT_2x2 函数一致 */
-void calc_RT_ls_2x2(
+/** 液-液 界面，函数参数见 calc_RT_SH 函数 */
+void calc_RT_ll_SH(
+    MYCOMPLEX *RDL, MYCOMPLEX *RUL, 
+    MYCOMPLEX *TDL, MYCOMPLEX *TUL);
+
+/** 液-固 界面，函数参数见 calc_RT_PSV 函数 */
+void calc_RT_ls_PSV(
     MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
     MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
-    MYREAL thk, MYCOMPLEX omega, MYREAL k, 
-    MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
-    MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL, MYINT *stats);
+    MYREAL thk, // 使用上层的厚度
+    MYCOMPLEX omega, MYREAL k, 
+    MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2], 
+    MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2], MYINT *stats);
+
+/** 液-固 界面，函数参数见 calc_RT_SH 函数 */
+void calc_RT_ls_SH(
+    MYCOMPLEX xb1, MYCOMPLEX mu1, MYCOMPLEX mu2, 
+    MYREAL thk, // 使用上层的厚度
+    MYCOMPLEX omega, MYREAL k,
+    MYCOMPLEX *RDL, MYCOMPLEX *RUL, 
+    MYCOMPLEX *TDL, MYCOMPLEX *TUL);
+
+/** 固-固 界面，函数参数见 calc_RT_PSV 函数 */
+void calc_RT_ss_PSV(
+    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
+    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
+    MYREAL thk, // 使用上层的厚度
+    MYCOMPLEX omega, MYREAL k, 
+    MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2],
+    MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2], MYINT *stats);
+
+/** 固-固 界面，函数参数见 calc_RT_SH 函数 */
+void calc_RT_ss_SH(
+    MYCOMPLEX xb1, MYCOMPLEX mu1, 
+    MYCOMPLEX xb2, MYCOMPLEX mu2, 
+    MYREAL thk, // 使用上层的厚度
+    MYCOMPLEX omega, MYREAL k, 
+    MYCOMPLEX *RDL, MYCOMPLEX *RUL, 
+    MYCOMPLEX *TDL, MYCOMPLEX *TUL);
+
 
 /**
- * 【未使用，仅用于代码测试】
- * 被calc_RT_2x2_from_4x4函数调用，生成该层的连接P-SV应力位移矢量与垂直波函数的D矩阵(或其逆矩阵)，
+ * 计算该层的连接 P-SV 应力位移矢量与垂直波函数的D矩阵(或其逆矩阵)，
  * 见公式(5.2.19-20)
  * 
  * @param[in]      xa            P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
  * @param[in]      xb            S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
  * @param[in]      kbkb          S波水平波数的平方 \f$ k_b^2=(\frac{\omega}{V_b})^2 \f$
  * @param[in]      mu            剪切模量
+ * @param[in]      omega         角频率
  * @param[in]      k             波数
- * 
- * @param[out]      D                D矩阵(或其逆矩阵)
- * @param[in]       inverse          是否生成逆矩阵
+ * @param[out]     D             D矩阵(或其逆矩阵)
+ * @param[in]      inverse       是否生成逆矩阵
  * 
  */
 void get_layer_D(
     MYCOMPLEX xa, MYCOMPLEX xb, MYCOMPLEX kbkb, MYCOMPLEX mu, 
     MYCOMPLEX omega, MYREAL k, MYCOMPLEX D[4][4], bool inverse);
 
+/** 子矩阵 D11，函数参数见 get_layer_D 函数 */
+void get_layer_D11(
+    MYCOMPLEX xa, MYCOMPLEX xb, MYREAL k, MYCOMPLEX D[2][2]);
+
+/** 子矩阵 D12，函数参数见 get_layer_D 函数 */
+void get_layer_D12(
+    MYCOMPLEX xa, MYCOMPLEX xb, MYREAL k, MYCOMPLEX D[2][2]);
+
+/** 子矩阵 D21，函数参数见 get_layer_D 函数 */
+void get_layer_D21(
+    MYCOMPLEX xa, MYCOMPLEX xb, MYCOMPLEX kbkb, MYCOMPLEX mu,
+    MYCOMPLEX omega, MYREAL k, MYCOMPLEX D[2][2]);
+
+/** 子矩阵 D22，函数参数见 get_layer_D 函数 */
+void get_layer_D22(
+    MYCOMPLEX xa, MYCOMPLEX xb, MYCOMPLEX kbkb, MYCOMPLEX mu,
+    MYCOMPLEX omega, MYREAL k, MYCOMPLEX D[2][2]);
+
+/** 子矩阵 D11_uiz，后缀uiz表示连接位移对z的偏导和垂直波函数，函数参数见 get_layer_D 函数 */
+void get_layer_D11_uiz(
+    MYCOMPLEX xa, MYCOMPLEX xb, MYREAL k, MYCOMPLEX D[2][2]);
+
+/** 子矩阵 D12_uiz，函数参数见 get_layer_D 函数 */
+void get_layer_D12_uiz(
+    MYCOMPLEX xa, MYCOMPLEX xb, MYREAL k, MYCOMPLEX D[2][2]);
+
+
+/**
+ * 计算该层的连接 SH 应力位移矢量与垂直波函数的 T 矩阵(或其逆矩阵)，
+ * 见公式(5.2.21-22)
+ * 
+ * @param[in]      xb            S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
+ * @param[in]      mu            剪切模量
+ * @param[in]      omega         角频率
+ * @param[in]      k             波数
+ * @param[out]     T             T矩阵(或其逆矩阵)
+ * @param[in]      inverse       是否生成逆矩阵
+ * 
+ */
+void get_layer_T(
+    MYCOMPLEX xb, MYCOMPLEX mu,
+    MYCOMPLEX omega, MYREAL k, MYCOMPLEX T[2][2], bool inverse);
+
+/** 计算 P-SV 型垂直波函数的时间延迟矩阵，公式(5.2.27) */
+void get_layer_E_Rayl(MYCOMPLEX xa1, MYCOMPLEX xb1, MYREAL thk, MYREAL k, MYCOMPLEX E[4][4], bool inverse);
+
+/** 计算 SH 型垂直波函数的时间延迟矩阵，公式(5.2.28) */
+void get_layer_E_Love(MYCOMPLEX xb1, MYREAL thk, MYREAL k, MYCOMPLEX E[2][2], bool inverse);
+
 
 
 /**
  *  【未使用，仅用于代码测试】
- *  和calc_RT_2x2函数解决相同问题，但没有使用显式推导的公式，而是直接做矩阵运算，
- *  函数接口也和 calc_RT_2x2函数 类似
+ *  和 calc_RT_PSV(SH) 函数解决相同问题，但没有使用显式推导的公式，而是直接做矩阵运算，
+ *  函数接口也类似
  */
-void calc_RT_2x2_from_4x4(
+void calc_RT_from_4x4(
     MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
     MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
     MYCOMPLEX omega, MYREAL thk,

--- a/pygrt/C_extension/include/static/static_layer.h
+++ b/pygrt/C_extension/include/static/static_layer.h
@@ -18,54 +18,65 @@
 #include "common/const.h"
 
 /**
- * 计算自由表面的静态反射系数，公式(6.3.12)
+ * 计算自由表面的 P-SV 静态反射系数，公式(6.3.12)
  * 
  * @param[in]     delta1            表层的 \f$ \Delta = \frac{\lambda + \mu}{\lambda + 3\mu} \f$
  * @param[out]    R_tilt            P-SV系数矩阵，SH系数为1
  * 
  */
-void calc_static_R_tilt(MYCOMPLEX delta1, MYCOMPLEX R_tilt[2][2]);
+void calc_static_R_tilt_PSV(MYCOMPLEX delta1, MYCOMPLEX R_tilt[2][2]);
 
 
 /**
- * 计算接收点位置的静态接收矩阵，将波场转为位移，公式(6.3.35,37)
+ * 计算接收点位置的 P-SV 静态接收矩阵，将波场转为位移，公式(6.3.35)
  * 
  * @param[in]      ircvup          接收点是否浅于震源层
- * @param[in]      k               波数
  * @param[in]      R               P-SV波场
- * @param[in]      RL              SH波场
  * @param[out]     R_EV            P-SV接收函数矩阵
+ * 
+ */
+void calc_static_R_EV_PSV(bool ircvup, const MYCOMPLEX R[2][2], MYCOMPLEX R_EV[2][2]);
+
+/**
+ * 计算接收点位置的 SH 静态接收矩阵，将波场转为位移，公式(6.3.37)
+ * 
+ * @param[in]      RL              SH波场
  * @param[out]     R_EVL           SH接收函数值
  * 
  */
-void calc_static_R_EV(
-    bool ircvup,
-    const MYCOMPLEX R[2][2], MYCOMPLEX RL, 
-    MYCOMPLEX R_EV[2][2], MYCOMPLEX *R_EVL);
-
+void calc_static_R_EV_SH(MYCOMPLEX RL, MYCOMPLEX *R_EVL);
 
 /**
- * 计算接收点位置的ui_z的静态接收矩阵，即将波场转为ui_z。
+ * 计算接收点位置的ui_z的 P-SV 静态接收矩阵，即将波场转为ui_z。
  * 公式本质是推导ui_z关于q_m, w_m, v_m的连接矩阵（就是应力推导过程的一部分）
  * 
  * @param[in]      delta1          接收层的 \f$ \Delta \f$
  * @param[in]      ircvup          接收点是否浅于震源层
  * @param[in]      k               波数
  * @param[in]      R               P-SV波场
- * @param[in]      RL              SH波场
  * @param[out]     R_EV            P-SV接收函数矩阵
+ * 
+ */
+void calc_static_uiz_R_EV_PSV(
+    MYCOMPLEX delta1, bool ircvup, MYREAL k, 
+    const MYCOMPLEX R[2][2], MYCOMPLEX R_EV[2][2]);
+
+/**
+ * 计算接收点位置的ui_z的 SH 静态接收矩阵，即将波场转为ui_z。
+ * 公式本质是推导ui_z关于q_m, w_m, v_m的连接矩阵（就是应力推导过程的一部分）
+ * 
+ * @param[in]      ircvup          接收点是否浅于震源层
+ * @param[in]      k               波数
+ * @param[in]      RL              SH波场
  * @param[out]     R_EVL           SH接收函数值
  * 
  */
-void calc_static_uiz_R_EV(
-    MYCOMPLEX delta1, bool ircvup, MYREAL k, 
-    const MYCOMPLEX R[2][2], MYCOMPLEX RL, 
-    MYCOMPLEX R_EV[2][2], MYCOMPLEX *R_EVL);
+void calc_static_uiz_R_EV_SH(bool ircvup, MYREAL k, MYCOMPLEX RL, MYCOMPLEX *R_EVL);
 
 
 /**
- * 计算界面的静态反射系数RD/RDL/RU/RUL, 静态透射系数TD/TDL/TU/TUL, 包括时间延迟因子，
- * 后缀L表示SH波的系数, 其余表示P-SV波的系数, 根据公式(6.3.18)  
+ * 计算界面的 P-SV 波静态反射透射系数RD/RU/TD/TU, 包括时间延迟因子，
+ * 根据公式(6.3.18)  
  * 
  * @param[in]       delta1        上层的 \f$ \Delta \f$
  * @param[in]       mu1           上层的剪切模量
@@ -74,18 +85,32 @@ void calc_static_uiz_R_EV(
  * @param[in]       thk           上层层厚
  * @param[in]       k             波数
  * @param[out]      RD            P-SV 下传反射系数矩阵
- * @param[out]      RDL           SH 下传反射系数
  * @param[out]      RU            P-SV 上传反射系数矩阵
- * @param[out]      RUL           SH 上传反射系数
  * @param[out]      TD            P-SV 下传透射系数矩阵
- * @param[out]      TDL           SH 下传透射系数
  * @param[out]      TU            P-SV 上传透射系数矩阵
- * @param[out]      TUL           SH 上传透射系数
  * 
  */
-void calc_static_RT_2x2(
+void calc_static_RT_PSV(
     MYCOMPLEX delta1, MYCOMPLEX mu1, 
     MYCOMPLEX delta2, MYCOMPLEX mu2, 
     MYREAL thk, MYREAL k,
-    MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
-    MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL);    
+    MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2], MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2]);
+
+/**
+ * 计算界面的 SH 波静态反射透射系数RDL/RUL/TDL/TUL, 包括时间延迟因子，
+ * 根据公式(6.3.18)  
+ * 
+ * @param[in]       mu1           上层的剪切模量
+ * @param[in]       mu2           下层的剪切模量
+ * @param[in]       thk           上层层厚
+ * @param[in]       k             波数
+ * @param[out]      RDL           SH 下传反射系数
+ * @param[out]      RUL           SH 上传反射系数
+ * @param[out]      TDL           SH 下传透射系数
+ * @param[out]      TUL           SH 上传透射系数
+ * 
+ */
+void calc_static_RT_SH(
+    MYCOMPLEX mu1, MYCOMPLEX mu2, 
+    MYREAL thk, MYREAL k,
+    MYCOMPLEX *RDL, MYCOMPLEX *RUL, MYCOMPLEX *TDL, MYCOMPLEX *TUL);

--- a/pygrt/C_extension/src/common/recursion.c
+++ b/pygrt/C_extension/src/common/recursion.c
@@ -19,14 +19,29 @@
 #include "common/matrix.h"
 
 
-
 void recursion_RD(
     const MYCOMPLEX RD1[2][2], MYCOMPLEX RDL1, const MYCOMPLEX RU1[2][2], MYCOMPLEX RUL1,
     const MYCOMPLEX TD1[2][2], MYCOMPLEX TDL1, const MYCOMPLEX TU1[2][2], MYCOMPLEX TUL1,
     const MYCOMPLEX RD2[2][2], MYCOMPLEX RDL2, 
     MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX inv_2x2T[2][2], MYCOMPLEX *invT, MYINT *stats)
 {
-    MYCOMPLEX tmp1[2][2], tmp2[2][2], inv1;
+    recursion_RD_PSV(
+        RD1, RU1, TD1, TU1,
+        RD2,
+        RD, inv_2x2T, stats);
+    recursion_RD_SH(
+        RDL1, RUL1, TDL1, TUL1,
+        RDL2,
+        RDL, invT, stats);
+}
+
+void recursion_RD_PSV(
+    const MYCOMPLEX RD1[2][2], const MYCOMPLEX RU1[2][2],
+    const MYCOMPLEX TD1[2][2], const MYCOMPLEX TU1[2][2],
+    const MYCOMPLEX RD2[2][2],
+    MYCOMPLEX RD[2][2], MYCOMPLEX inv_2x2T[2][2], MYINT *stats)
+{
+    MYCOMPLEX tmp1[2][2], tmp2[2][2];
 
     // RD, RDL
     cmat2x2_mul(RU1, RD2, tmp1);
@@ -38,7 +53,21 @@ void recursion_RD(
     cmat2x2_mul(RD2, tmp2, tmp1);
     cmat2x2_mul(TU1, tmp1, tmp2);
     cmat2x2_add(RD1, tmp2, RD);
-    inv1 = RONE / (RONE - RUL1*RDL2) * TDL1;
+}
+
+void recursion_RD_SH(
+    MYCOMPLEX RDL1, MYCOMPLEX RUL1,
+    MYCOMPLEX TDL1, MYCOMPLEX TUL1,
+    MYCOMPLEX RDL2, MYCOMPLEX *RDL, MYCOMPLEX *invT, MYINT *stats)
+{
+    MYCOMPLEX inv1;
+
+    inv1 = RONE - RUL1*RDL2;
+    if(inv1 == CZERO){
+        *stats=INVERSE_FAILURE;
+        return;
+    }
+    inv1 = RONE / inv1 * TDL1;
     *RDL = RDL1 + TUL1*RDL2*inv1;
     if(invT!=NULL)  *invT = inv1;
 }
@@ -51,7 +80,20 @@ void recursion_TD(
     const MYCOMPLEX TD2[2][2], MYCOMPLEX TDL2, 
     MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX inv_2x2T[2][2], MYCOMPLEX *invT, MYINT *stats)
 {
-    MYCOMPLEX tmp1[2][2], tmp2[2][2], inv1;
+    recursion_TD_PSV(
+        RU1, TD1, RD2, TD2,
+        TD, inv_2x2T, stats);
+    recursion_TD_SH(
+        RUL1, TDL1, RDL2, TDL2,
+        TDL, invT, stats);
+}
+
+void recursion_TD_PSV(
+    const MYCOMPLEX RU1[2][2], const MYCOMPLEX TD1[2][2],
+    const MYCOMPLEX RD2[2][2], const MYCOMPLEX TD2[2][2],
+    MYCOMPLEX TD[2][2], MYCOMPLEX inv_2x2T[2][2], MYINT *stats)
+{
+    MYCOMPLEX tmp1[2][2], tmp2[2][2];
 
     // TD, TDL
     cmat2x2_mul(RU1, RD2, tmp2);
@@ -60,13 +102,24 @@ void recursion_TD(
     cmat2x2_mul(tmp1, TD1, tmp2);
     if(inv_2x2T!=NULL)  cmat2x2_assign(tmp2, inv_2x2T);
     cmat2x2_mul(TD2, tmp2, TD);
-    
-    inv1 = RONE / (RONE - RUL1*RDL2) * TDL1;
-    *TDL = TDL2 * inv1;
-
-    if(invT!=NULL) *invT = inv1;
 }
 
+void recursion_TD_SH(
+    MYCOMPLEX RUL1, MYCOMPLEX TDL1, 
+    MYCOMPLEX RDL2, MYCOMPLEX TDL2, 
+    MYCOMPLEX *TDL, MYCOMPLEX *invT, MYINT *stats)
+{
+    MYCOMPLEX inv1;
+
+    inv1 = RONE - RUL1*RDL2;
+    if(inv1 == CZERO){
+        *stats=INVERSE_FAILURE;
+        return;
+    }
+    inv1 = RONE / inv1 * TDL1;
+    *TDL = TDL2 * inv1;
+    if(invT!=NULL) *invT = inv1;
+}
 
 void recursion_RU(
     const MYCOMPLEX RU1[2][2], MYCOMPLEX RUL1,
@@ -74,7 +127,23 @@ void recursion_RU(
     const MYCOMPLEX TD2[2][2], MYCOMPLEX TDL2, const MYCOMPLEX TU2[2][2], MYCOMPLEX TUL2,
     MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, MYCOMPLEX inv_2x2T[2][2], MYCOMPLEX *invT, MYINT *stats)
 {
-    MYCOMPLEX tmp1[2][2], tmp2[2][2], inv1;
+    recursion_RU_PSV(
+        RU1, RD2, RU2, TD2,
+        TU2,
+        RU, inv_2x2T, stats);
+    recursion_RU_SH(
+        RUL1, RDL2, RUL2, TDL2,
+        TUL2,
+        RUL, invT, stats);
+}
+
+void recursion_RU_PSV(
+    const MYCOMPLEX RU1[2][2], const MYCOMPLEX RD2[2][2], 
+    const MYCOMPLEX RU2[2][2], const MYCOMPLEX TD2[2][2], 
+    const MYCOMPLEX TU2[2][2], 
+    MYCOMPLEX RU[2][2], MYCOMPLEX inv_2x2T[2][2], MYINT *stats)
+{
+    MYCOMPLEX tmp1[2][2], tmp2[2][2];
 
     // RU, RUL
     cmat2x2_mul(RD2, RU1, tmp2);
@@ -86,9 +155,24 @@ void recursion_RU(
     cmat2x2_mul(RU1, tmp2, tmp1); 
     cmat2x2_mul(TD2, tmp1, tmp2);
     cmat2x2_add(RU2, tmp2, RU);
-    inv1 = RONE / (RONE - RUL1*RDL2) * TUL2;
-    *RUL = RUL2 + TDL2*RUL1*inv1; 
+}
 
+
+void recursion_RU_SH(
+    MYCOMPLEX RUL1, MYCOMPLEX RDL2,
+    MYCOMPLEX RUL2, MYCOMPLEX TDL2, 
+    MYCOMPLEX TUL2,
+    MYCOMPLEX *RUL, MYCOMPLEX *invT, MYINT *stats)
+{
+    MYCOMPLEX inv1;
+
+    inv1 = RONE - RUL1*RDL2;
+    if(inv1 == CZERO){
+        *stats=INVERSE_FAILURE;
+        return;
+    }
+    inv1 = RONE / inv1 * TUL2;
+    *RUL = RUL2 + TDL2*RUL1*inv1; 
     if(invT!=NULL)  *invT = inv1;
 }
 
@@ -100,7 +184,21 @@ void recursion_TU(
     const MYCOMPLEX TU2[2][2], MYCOMPLEX TUL2,
     MYCOMPLEX TU[2][2], MYCOMPLEX *TUL, MYCOMPLEX inv_2x2T[2][2], MYCOMPLEX *invT, MYINT *stats)
 {
-    MYCOMPLEX tmp1[2][2], tmp2[2][2], inv1;
+    recursion_TU_PSV(
+        RU1, TU1, RD2, TU2,
+        TU, inv_2x2T, stats);
+    recursion_TU_SH(
+        RUL1, TUL1, RDL2, TUL2,
+        TUL, invT, stats);
+}
+
+
+void recursion_TU_PSV(
+    const MYCOMPLEX RU1[2][2], const MYCOMPLEX TU1[2][2],
+    const MYCOMPLEX RD2[2][2], const MYCOMPLEX TU2[2][2],
+    MYCOMPLEX TU[2][2], MYCOMPLEX inv_2x2T[2][2], MYINT *stats)
+{
+    MYCOMPLEX tmp1[2][2], tmp2[2][2];
 
     // TU, TUL
     cmat2x2_mul(RD2, RU1, tmp2);
@@ -109,18 +207,29 @@ void recursion_TU(
     cmat2x2_mul(tmp1, TU2, tmp2);
     if(inv_2x2T!=NULL) cmat2x2_assign(tmp2, inv_2x2T);
     cmat2x2_mul(TU1, tmp2, TU);
-    
-    inv1 = RONE / (RONE - RUL1*RDL2) * TUL2;
-    *TUL = TUL1 * inv1;
-
-    if(invT!=NULL)  *invT = inv1;
-
 }
 
 
 
+void recursion_TU_SH(
+    MYCOMPLEX RUL1, MYCOMPLEX TUL1,
+    MYCOMPLEX RDL2, MYCOMPLEX TUL2,
+    MYCOMPLEX *TUL, MYCOMPLEX *invT, MYINT *stats)
+{
+    MYCOMPLEX inv1;
 
-void recursion_RT_2x2(
+    inv1 = RONE - RUL1*RDL2;
+    if(inv1 == CZERO){
+        *stats=INVERSE_FAILURE;
+        return;
+    }
+    inv1 = RONE / inv1 * TUL2;
+    *TUL = TUL1 * inv1;
+    if(invT!=NULL)  *invT = inv1;
+}
+
+
+void recursion_RT(
     const MYCOMPLEX RD1[2][2], MYCOMPLEX RDL1, const MYCOMPLEX RU1[2][2], MYCOMPLEX RUL1,
     const MYCOMPLEX TD1[2][2], MYCOMPLEX TDL1, const MYCOMPLEX TU1[2][2], MYCOMPLEX TUL1,
     const MYCOMPLEX RD2[2][2], MYCOMPLEX RDL2, const MYCOMPLEX RU2[2][2], MYCOMPLEX RUL2,
@@ -128,89 +237,106 @@ void recursion_RT_2x2(
     MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX RU[2][2], MYCOMPLEX *RUL,
     MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL, MYINT *stats)
 {
-
-    // 临时矩阵
-    MYCOMPLEX tmp1[2][2], tmp2[2][2];
-    MYCOMPLEX inv0, inv1T;
-
-    inv0 = RONE / (RONE - RUL1*RDL2);
-    // return;
-
-    // Rayleigh RD,TD
-    if( RD!=NULL || TD!=NULL ){
-        cmat2x2_mul(RU1, RD2, tmp1);
-        cmat2x2_one_sub(tmp1);
-        cmat2x2_inv(tmp1, tmp1, stats);  if(*stats==INVERSE_FAILURE)  return;
-        cmat2x2_mul(tmp1, TD1, tmp2);
-
-        // TD
-        if(TD!=NULL){
-            cmat2x2_mul(TD2, tmp2, TD); // 相同的逆阵，节省计算量
-        }
-
-        // RD
-        if(RD!=NULL){
-            cmat2x2_mul(RD2, tmp2, tmp1);
-            cmat2x2_mul(TU1, tmp1, tmp2);
-            cmat2x2_add(RD1, tmp2, RD);
-        }
-    }
-
-    // Rayleigh RU,TU
-    if( RU!=NULL || TU!=NULL ){
-        cmat2x2_mul(RD2, RU1, tmp1);
-        cmat2x2_one_sub(tmp1);
-        cmat2x2_inv(tmp1, tmp1, stats);  if(*stats==INVERSE_FAILURE)  return;
-        cmat2x2_mul(tmp1, TU2, tmp2);
-
-        // TU
-        if(TU!=NULL){
-            cmat2x2_mul(TU1, tmp2, TU);
-        }
-
-        // RU
-        if(RU!=NULL){
-            cmat2x2_mul(RU1, tmp2, tmp1);
-            cmat2x2_mul(TD2, tmp1, tmp2);
-            cmat2x2_add(RU2, tmp2, RU);
-        }
-    }
-
-
-    // Love RDL,TDL
-    if(RDL!=NULL || TDL!=NULL){
-        inv1T = inv0 * TDL1;
-        // TDL
-        if(TDL!=NULL){
-            *TDL = TDL2 * inv1T;
-        }
-        // RDL
-        if(RDL!=NULL){
-            *RDL = RDL1 + TUL1*RDL2*inv1T;
-        }
-    }
-
-    // Love RUL,TUL
-    if(RUL!=NULL || TUL!=NULL){
-        inv1T = inv0 * TUL2;
-        // TUL
-        if(TUL!=NULL){
-            *TUL = TUL1 * inv1T;
-        }
-
-        // RUL
-        if(RUL!=NULL){
-            *RUL = RUL2 + TDL2*RUL1 *inv1T; 
-        }
-    }
-
+    recursion_RT_PSV(
+        RD1, RU1, TD1, TU1,
+        RD2, RU2, TD2, TU2,
+        RD, RU, TD, TU, stats);
+    recursion_RT_SH(
+        RDL1, RUL1, TDL1, TUL1,
+        RDL2, RUL2, TDL2, TUL2,
+        RDL, RUL, TDL, TUL, stats);
 }
 
 
-void recursion_RT_2x2_imaginary(
+void recursion_RT_PSV(
+    const MYCOMPLEX RD1[2][2], const MYCOMPLEX RU1[2][2],
+    const MYCOMPLEX TD1[2][2], const MYCOMPLEX TU1[2][2],
+    const MYCOMPLEX RD2[2][2], const MYCOMPLEX RU2[2][2],
+    const MYCOMPLEX TD2[2][2], const MYCOMPLEX TU2[2][2],
+    MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2],
+    MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2], MYINT *stats)
+{
+    // 临时矩阵
+    MYCOMPLEX tmp1[2][2], tmp2[2][2];
+
+    cmat2x2_mul(RU1, RD2, tmp1);
+    cmat2x2_one_sub(tmp1);
+    cmat2x2_inv(tmp1, tmp1, stats);  if(*stats==INVERSE_FAILURE)  return;
+    cmat2x2_mul(tmp1, TD1, tmp2);
+
+    // TD
+    cmat2x2_mul(TD2, tmp2, TD); // 相同的逆阵，节省计算量
+
+    // RD
+    cmat2x2_mul(RD2, tmp2, tmp1);
+    cmat2x2_mul(TU1, tmp1, tmp2);
+    cmat2x2_add(RD1, tmp2, RD);
+
+    cmat2x2_mul(RD2, RU1, tmp1);
+    cmat2x2_one_sub(tmp1);
+    cmat2x2_inv(tmp1, tmp1, stats);  if(*stats==INVERSE_FAILURE)  return;
+    cmat2x2_mul(tmp1, TU2, tmp2);
+
+    // TU
+    cmat2x2_mul(TU1, tmp2, TU);
+
+    // RU
+    cmat2x2_mul(RU1, tmp2, tmp1);
+    cmat2x2_mul(TD2, tmp1, tmp2);
+    cmat2x2_add(RU2, tmp2, RU);
+}
+
+
+void recursion_RT_SH(
+    MYCOMPLEX RDL1, MYCOMPLEX RUL1,
+    MYCOMPLEX TDL1, MYCOMPLEX TUL1,
+    MYCOMPLEX RDL2, MYCOMPLEX RUL2,
+    MYCOMPLEX TDL2, MYCOMPLEX TUL2,
+    MYCOMPLEX *RDL, MYCOMPLEX *RUL,
+    MYCOMPLEX *TDL, MYCOMPLEX *TUL, MYINT *stats)
+{
+    // 临时
+    MYCOMPLEX inv0, inv1T;
+
+    inv0 = RONE - RUL1*RDL2;
+    if(inv0 == CZERO){
+        *stats=INVERSE_FAILURE;
+        return;
+    }
+    inv0 = RONE / inv0;
+
+    inv1T = inv0 * TDL1;
+    // TDL
+    *TDL = TDL2 * inv1T;
+    // RDL
+    *RDL = RDL1 + TUL1*RDL2*inv1T;
+
+    inv1T = inv0 * TUL2;
+    // TUL
+    *TUL = TUL1 * inv1T;
+
+    // RUL
+    *RUL = RUL2 + TDL2*RUL1 *inv1T; 
+}
+
+
+void recursion_RT_imaginary(
     MYCOMPLEX xa1, MYCOMPLEX xb1, MYREAL thk, MYREAL k, // 使用上层的厚度
     MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
     MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL)
+{
+    recursion_RT_PSV_imaginary(
+        xa1, xb1, thk, k,
+        RU, TD, TU);
+    recursion_RT_SH_imaginary(
+        xb1, thk, k,
+        RUL, TDL, TUL);
+}
+
+
+void recursion_RT_PSV_imaginary(
+    MYCOMPLEX xa1, MYCOMPLEX xb1, MYREAL thk, MYREAL k, // 使用上层的厚度
+    MYCOMPLEX RU[2][2], MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2])
 {
     MYCOMPLEX exa, exb, exab, ex2a, ex2b; 
     exa = exp(-k*thk*xa1);
@@ -230,7 +356,18 @@ void recursion_RT_2x2_imaginary(
 
     TU[0][0] *= exa;     TU[0][1] *= exb; 
     TU[1][0] *= exa;     TU[1][1] *= exb;
+}
 
+
+void recursion_RT_SH_imaginary(
+    MYCOMPLEX xb1, MYREAL thk, MYREAL k, // 使用上层的厚度
+    MYCOMPLEX *RUL, MYCOMPLEX *TDL, MYCOMPLEX *TUL)
+{
+    MYCOMPLEX exb, ex2b; 
+    exb = exp(-k*thk*xb1);
+    ex2b = exb * exb;
+
+    // 虚拟层位不是介质物理间断面
     *RUL *= ex2b;
     *TDL *= exb;
     *TUL *= exb;

--- a/pygrt/C_extension/src/static/static_layer.c
+++ b/pygrt/C_extension/src/static/static_layer.c
@@ -3,7 +3,7 @@
  * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
  * @date   2025-02-18
  * 
- * 以下代码实现的是 静态反射透射系数矩阵 ，参考：
+ * 以下代码实现的是 P-SV 波和 SH 波的静态反射透射系数矩阵 ，参考：
  * 
  *         1. 姚振兴, 谢小碧. 2022/03. 理论地震图及其应用（初稿）.  
  *         2. 谢小碧, 姚振兴, 1989. 计算分层介质中位错点源静态位移场的广义反射、
@@ -19,17 +19,14 @@
 #include "common/model.h"
 #include "common/matrix.h"
 
-void calc_static_R_tilt(MYCOMPLEX delta1, MYCOMPLEX R_tilt[2][2]){
+void calc_static_R_tilt_PSV(MYCOMPLEX delta1, MYCOMPLEX R_tilt[2][2]){
     // 公式(6.3.12)
     R_tilt[0][0] = R_tilt[1][1] = CZERO;
     R_tilt[0][1] = -delta1;
     R_tilt[1][0] = -RONE/delta1;
 }
 
-void calc_static_R_EV(
-    bool ircvup,
-    const MYCOMPLEX R[2][2], MYCOMPLEX RL, 
-    MYCOMPLEX R_EV[2][2], MYCOMPLEX *R_EVL)
+void calc_static_R_EV_PSV(bool ircvup, const MYCOMPLEX R[2][2], MYCOMPLEX R_EV[2][2])
 {
     MYCOMPLEX D11[2][2] = {{RONE, -RONE}, {RONE, RONE}};
     MYCOMPLEX D12[2][2] = {{RONE, -RONE}, {-RONE, -RONE}};
@@ -42,13 +39,16 @@ void calc_static_R_EV(
         cmat2x2_mul(D11, R, R_EV);
         cmat2x2_add(D12, R_EV, R_EV);
     }
+}
+
+void calc_static_R_EV_SH(MYCOMPLEX RL, MYCOMPLEX *R_EVL)
+{
     *R_EVL = (RONE + (RL));
 }
 
-void calc_static_uiz_R_EV(
+void calc_static_uiz_R_EV_PSV(
     MYCOMPLEX delta1, bool ircvup, MYREAL k, 
-    const MYCOMPLEX R[2][2], MYCOMPLEX RL, 
-    MYCOMPLEX R_EV[2][2], MYCOMPLEX *R_EVL)
+    const MYCOMPLEX R[2][2], MYCOMPLEX R_EV[2][2])
 {
     // 新推导公式
     MYCOMPLEX kd2 = RTWO*k*delta1;
@@ -57,31 +57,36 @@ void calc_static_uiz_R_EV(
     if(ircvup){// 震源更深
         cmat2x2_mul(D12, R, R_EV);
         cmat2x2_add(D11, R_EV, R_EV);
-        *R_EVL = (RONE - (RL))*k;
     } else { // 接收点更深
         cmat2x2_mul(D11, R, R_EV);
         cmat2x2_add(D12, R_EV, R_EV);
+    }
+}
+
+void calc_static_uiz_R_EV_SH(bool ircvup, MYREAL k, MYCOMPLEX RL, MYCOMPLEX *R_EVL)
+{
+    // 新推导公式
+    if(ircvup){// 震源更深
+        *R_EVL = (RONE - (RL))*k;
+    } else { // 接收点更深
         *R_EVL = (RL - RONE)*k;
     }
 }
 
 
-void calc_static_RT_2x2(
+void calc_static_RT_PSV(
     MYCOMPLEX delta1, MYCOMPLEX mu1, 
     MYCOMPLEX delta2, MYCOMPLEX mu2, 
     MYREAL thk, MYREAL k,
-    MYCOMPLEX RD[2][2], MYCOMPLEX *RDL, MYCOMPLEX RU[2][2], MYCOMPLEX *RUL, 
-    MYCOMPLEX TD[2][2], MYCOMPLEX *TDL, MYCOMPLEX TU[2][2], MYCOMPLEX *TUL)
+    MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2], MYCOMPLEX TD[2][2], MYCOMPLEX TU[2][2])
 {
     // 公式(6.3.18)
-
     MYCOMPLEX ex, ex2; 
 
     ex = exp(-k*thk);
     ex2 = ex*ex;
 
     MYCOMPLEX dmu = mu1 - mu2;
-    MYCOMPLEX amu = mu1 + mu2;
     MYCOMPLEX A112 = mu1*delta1 + mu2;
     MYCOMPLEX A221 = mu2*delta2 + mu1;
     MYCOMPLEX B = mu1*delta1 - mu2*delta2;
@@ -101,9 +106,6 @@ void calc_static_RT_2x2(
     RU[1][0] = dmu/A221;
     RU[1][1] = RZERO;
 
-    *RDL = dmu/amu * ex2;
-    *RUL = - dmu/amu;
-
     // Transmission
     //------------------ TD -----------------------------------
     TD[0][0] = mu1*(RONE+delta1)/(A112) * ex;
@@ -116,9 +118,6 @@ void calc_static_RT_2x2(
     TU[1][0] = RZERO;
     TU[1][1] = TU[0][0]*A221/A112;
 
-    *TDL = RTWO*mu1/amu * ex;
-    *TUL = (*TDL)*mu2/mu1;
-
     // printf("delta1=%.5e%+.5ej, delta2=%.5e%+.5ej, mu1=%.5e%+.5ej, mu2=%.5e%+.5ej, thk=%e, k=%e\n", 
     //         creal(delta1),cimag(delta1),creal(delta2),cimag(delta2),creal(mu1),cimag(mu1),creal(mu2),cimag(mu2),
     //         thk, k);
@@ -127,4 +126,27 @@ void calc_static_RT_2x2(
     // cmatmxn_print(2, 2, TD);
     // cmatmxn_print(2, 2, TU);
     // printf("-----------------------------\n");
+}
+
+void calc_static_RT_SH(
+    MYCOMPLEX mu1, MYCOMPLEX mu2, 
+    MYREAL thk, MYREAL k,
+    MYCOMPLEX *RDL, MYCOMPLEX *RUL, MYCOMPLEX *TDL, MYCOMPLEX *TUL)
+{
+    // 公式(6.3.18)
+    MYCOMPLEX ex, ex2; 
+
+    ex = exp(-k*thk);
+    ex2 = ex*ex;
+
+    MYCOMPLEX dmu = mu1 - mu2;
+    MYCOMPLEX amu = mu1 + mu2;
+
+    // REFELCTION
+    *RDL = dmu/amu * ex2;
+    *RUL = - dmu/amu;
+
+    // Transmission
+    *TDL = RTWO*mu1/amu * ex;
+    *TUL = (*TDL)*mu2/mu1;
 }

--- a/pygrt/C_extension/src/static/static_propagate.c
+++ b/pygrt/C_extension/src/static/static_propagate.c
@@ -23,8 +23,6 @@
 #include "common/const.h"
 #include "common/matrix.h"
 
-#define CMAT_ASSIGN_SPLIT 0  // 2x2的小矩阵赋值合并为1个循环，程序速度提升微小
-
 
 void static_kernel(
     const MODEL1D *mod1d, MYCOMPLEX omega, MYREAL k, MYCOMPLEX QWV[SRC_M_NUM][QWV_NUM],
@@ -81,48 +79,18 @@ void static_kernel(
     MYCOMPLEX RU_FB[2][2] = INIT_C_ZERO_2x2_MATRIX;
     MYCOMPLEX RUL_FB = CZERO;
 
-    // 抽象指针 
-    // BL
-    MYCOMPLEX *const pRDL_BL = &RDL_BL;
-    MYCOMPLEX *const pRUL_BL = &RUL_BL;
-    MYCOMPLEX *const pTDL_BL = &TDL_BL;
-    MYCOMPLEX *const pTUL_BL = &TUL_BL;
-    // AL
-    MYCOMPLEX *const pRDL_AL = &RDL_AL;
-    // RS
-    MYCOMPLEX *const pRDL_RS = &RDL_RS;
-    MYCOMPLEX *const pRUL_RS = &RUL_RS;
-    MYCOMPLEX *const pTDL_RS = &TDL_RS;
-    MYCOMPLEX *const pTUL_RS = &TUL_RS;
-    // FA
-    MYCOMPLEX *const pRDL_FA = &RDL_FA;
-    MYCOMPLEX *const pRUL_FA = &RUL_FA;
-    MYCOMPLEX *const pTDL_FA = &TDL_FA;
-    MYCOMPLEX *const pTUL_FA = &TUL_FA;
-    // FB 
-    MYCOMPLEX *const pRUL_FB = &RUL_FB;
-
-
     // 定义物理层内的反射透射系数矩阵，相对于界面上的系数矩阵增加了时间延迟因子
     MYCOMPLEX RD[2][2], RDL, TD[2][2], TDL;
     MYCOMPLEX RU[2][2], RUL, TU[2][2], TUL;
-    MYCOMPLEX *const pRDL = &RDL;
-    MYCOMPLEX *const pTDL = &TDL;
-    MYCOMPLEX *const pRUL = &RUL;
-    MYCOMPLEX *const pTUL = &TUL;
-
 
     // 自由表面的反射系数
     MYCOMPLEX R_tilt[2][2] = INIT_C_ZERO_2x2_MATRIX; // SH波在自由表面的反射系数为1，不必定义变量
 
     // 接收点处的接收矩阵
     MYCOMPLEX R_EV[2][2], R_EVL;
-    MYCOMPLEX *const pR_EVL = &R_EVL;
     
     // 接收点处的接收矩阵(转为位移导数ui_z的(B_m, C_m, P_m)系分量)
     MYCOMPLEX uiz_R_EV[2][2], uiz_R_EVL;
-    MYCOMPLEX *const puiz_R_EVL = &uiz_R_EVL;
-
 
     // 模型参数
     // 后缀0，1分别代表上层和下层
@@ -162,123 +130,60 @@ void static_kernel(
         }
 
         // 对第iy层的系数矩阵赋值，加入时间延迟因子(第iy-1界面与第iy界面之间)
-        calc_static_RT_2x2(
+        calc_static_RT_PSV(
             mod1d_delta0, mod1d_mu0,
             mod1d_delta1, mod1d_mu1,
             mod1d_thk0, k, // 使用iy-1层的厚度
-            RD, pRDL, RU, pRUL, 
-            TD, pTDL, TU, pTUL);
+            RD, RU, TD, TU);
+        calc_static_RT_SH(
+            mod1d_mu0, mod1d_mu1,
+            mod1d_thk0, k, // 使用iy-1层的厚度
+            &RDL, &RUL, &TDL, &TUL);
 
         // FA
         if(iy <= imin){
             if(iy == 1){ // 初始化FA
-#if CMAT_ASSIGN_SPLIT == 1
-                cmat2x2_assign(RD, RD_FA);  RDL_FA = RDL;
-                cmat2x2_assign(RU, RU_FA);  RUL_FA = RUL;
-                cmat2x2_assign(TD, TD_FA);  TDL_FA = TDL;
-                cmat2x2_assign(TU, TU_FA);  TUL_FA = TUL;
-#else 
-                for(MYINT kk=0; kk<2; ++kk){
-                    for(MYINT pp=0; pp<2; ++pp){
-                        RD_FA[kk][pp] = RD[kk][pp];
-                        RU_FA[kk][pp] = RU[kk][pp];
-                        TD_FA[kk][pp] = TD[kk][pp];
-                        TU_FA[kk][pp] = TU[kk][pp];
-                    }
-                }
-                RDL_FA = RDL;
-                RUL_FA = RUL;
-                TDL_FA = TDL;
-                TUL_FA = TUL;
-#endif
+                GRT_RT_PSV_ASSIGN(FA);
+                GRT_RT_SH_ASSIGN(FA);
             } else { // 递推FA
-
-                recursion_RT_2x2(
+                recursion_RT(
                     RD_FA, RDL_FA, RU_FA, RUL_FA, 
                     TD_FA, TDL_FA, TU_FA, TUL_FA,
                     RD, RDL, RU, RUL, 
                     TD, TDL, TU, TUL,
-                    RD_FA, pRDL_FA, RU_FA, pRUL_FA, 
-                    TD_FA, pTDL_FA, TU_FA, pTUL_FA, stats);  
+                    RD_FA, &RDL_FA, RU_FA, &RUL_FA, 
+                    TD_FA, &TDL_FA, TU_FA, &TUL_FA, stats);  
             }
-
         }
         // RS
         else if(iy <= imax){
             if(iy == imin+1){// 初始化RS
-#if CMAT_ASSIGN_SPLIT == 1
-                cmat2x2_assign(RD, RD_RS);  RDL_RS = RDL;
-                cmat2x2_assign(RU, RU_RS);  RUL_RS = RUL;
-                cmat2x2_assign(TD, TD_RS);  TDL_RS = TDL;
-                cmat2x2_assign(TU, TU_RS);  TUL_RS = TUL;
-#else
-                for(MYINT kk=0; kk<2; ++kk){
-                    for(MYINT pp=0; pp<2; ++pp){
-                        RD_RS[kk][pp] = RD[kk][pp];
-                        RU_RS[kk][pp] = RU[kk][pp];
-                        TD_RS[kk][pp] = TD[kk][pp];
-                        TU_RS[kk][pp] = TU[kk][pp];
-                    }
-                }
-                RDL_RS = RDL;
-                RUL_RS = RUL;
-                TDL_RS = TDL;
-                TUL_RS = TUL;
-#endif
+                GRT_RT_PSV_ASSIGN(RS);
+                GRT_RT_SH_ASSIGN(RS);
             } else { // 递推RS
-                recursion_RT_2x2(
+                recursion_RT(
                     RD_RS, RDL_RS, RU_RS, RUL_RS, 
                     TD_RS, TDL_RS, TU_RS, TUL_RS,
                     RD, RDL, RU, RUL, 
                     TD, TDL, TU, TUL,
-                    RD_RS, pRDL_RS, RU_RS, pRUL_RS, 
-                    TD_RS, pTDL_RS, TU_RS, pTUL_RS, stats);  // 写入原地址
+                    RD_RS, &RDL_RS, RU_RS, &RUL_RS, 
+                    TD_RS, &TDL_RS, TU_RS, &TUL_RS, stats);  // 写入原地址
             }
         } 
         // BL
         else {
             if(iy == imax+1){// 初始化BL
-#if CMAT_ASSIGN_SPLIT == 1
-                cmat2x2_assign(RD, RD_BL);  RDL_BL = RDL;
-                cmat2x2_assign(RU, RU_BL);  RUL_BL = RUL;
-                cmat2x2_assign(TD, TD_BL);  TDL_BL = TDL;
-                cmat2x2_assign(TU, TU_BL);  TUL_BL = TUL;
-#else 
-                for(MYINT kk=0; kk<2; ++kk){
-                    for(MYINT pp=0; pp<2; ++pp){
-                        RD_BL[kk][pp] = RD[kk][pp];
-                        RU_BL[kk][pp] = RU[kk][pp];
-                        TD_BL[kk][pp] = TD[kk][pp];
-                        TU_BL[kk][pp] = TU[kk][pp];
-                    }
-                }
-                RDL_BL = RDL;
-                RUL_BL = RUL;
-                TDL_BL = TDL;
-                TUL_BL = TUL;
-#endif
+                GRT_RT_PSV_ASSIGN(BL);
+                GRT_RT_SH_ASSIGN(BL);
             } else { // 递推BL
-
-                // 这个IF纯粹是为了优化，因为不论是SL还是RL，只有RD矩阵最终会被使用到
-                // 这里最终只把RD矩阵的值记录下来，其它的舍去，以减少部分运算
-                if(iy < mod1d->n - 1){
-                    recursion_RT_2x2(
-                        RD_BL, RDL_BL, RU_BL, RUL_BL, 
-                        TD_BL, TDL_BL, TU_BL, TUL_BL,
-                        RD, RDL, RU, RUL, 
-                        TD, TDL, TU, TUL,
-                        RD_BL, pRDL_BL, RU_BL, pRUL_BL, 
-                        TD_BL, pTDL_BL, TU_BL, pTUL_BL, stats);  // 写入原地址
-                } else {
-                    recursion_RT_2x2(
-                        RD_BL, RDL_BL, RU_BL, RUL_BL, 
-                        TD_BL, TDL_BL, TU_BL, TUL_BL,
-                        RD, RDL, RU, RUL, 
-                        TD, TDL, TU, TUL,
-                        RD_BL, pRDL_BL, NULL, NULL, 
-                        NULL, NULL, NULL, NULL, stats);  // 写入原地址
-                }
-                
+                // 只有 RD 矩阵最终会被使用到
+                recursion_RT(
+                    RD_BL, RDL_BL, RU_BL, RUL_BL, 
+                    TD_BL, TDL_BL, TU_BL, TUL_BL,
+                    RD, RDL, RU, RUL, 
+                    TD, TDL, TU, TUL,
+                    RD_BL, &RDL_BL, RU_BL, &RUL_BL, 
+                    TD_BL, &TDL_BL, TU_BL, &TUL_BL, stats);  // 写入原地址
             }
 
         } // END if
@@ -296,19 +201,20 @@ void static_kernel(
     MYCOMPLEX inv_2x2T[2][2], invT;
 
     // 递推RU_FA
-    calc_static_R_tilt(top_delta, R_tilt);
+    calc_static_R_tilt_PSV(top_delta, R_tilt);
     recursion_RU(
         R_tilt, RONE, 
         RD_FA, RDL_FA,
         RU_FA, RUL_FA, 
         TD_FA, TDL_FA,
         TU_FA, TUL_FA,
-        RU_FA, pRUL_FA, NULL, NULL, stats);
+        RU_FA, &RUL_FA, NULL, NULL, stats);
 
     // 根据震源和台站相对位置，计算最终的系数
     if(ircvup){ // A接收  B震源
         // 计算R_EV
-        calc_static_R_EV(ircvup, RU_FA, RUL_FA, R_EV, pR_EVL);
+        calc_static_R_EV_PSV(ircvup, RU_FA, R_EV);
+        calc_static_R_EV_SH(RUL_FA, &R_EVL);
 
         // 递推RU_FS
         recursion_RU(
@@ -317,7 +223,7 @@ void static_kernel(
             RU_RS, RUL_RS, 
             TD_RS, TDL_RS,
             TU_RS, TUL_RS,
-            RU_FB, pRUL_FB, inv_2x2T, &invT, stats);
+            RU_FB, &RUL_FB, inv_2x2T, &invT, stats);
         
         // 公式(5.7.12-14)
         cmat2x2_mul(RD_BL, RU_FB, tmpR2);
@@ -336,7 +242,8 @@ void static_kernel(
         
 
         if(calc_uiz){
-            calc_static_uiz_R_EV(rcv_delta, ircvup, k, RU_FA, RUL_FA, uiz_R_EV, puiz_R_EVL);
+            calc_static_uiz_R_EV_PSV(rcv_delta, ircvup, k, RU_FA, uiz_R_EV);
+            calc_static_uiz_R_EV_SH(ircvup, k, RUL_FA, &uiz_R_EVL);
             cmat2x2_mul(uiz_R_EV, tmp2x2_uiz, tmp2x2_uiz);
             tmpRL_uiz = tmpRL / R_EVL * uiz_R_EVL;
             
@@ -348,7 +255,8 @@ void static_kernel(
     else { // A震源  B接收
 
         // 计算R_EV
-        calc_static_R_EV(ircvup, RD_BL, RDL_BL, R_EV, pR_EVL);    
+        calc_static_R_EV_PSV(ircvup, RD_BL, R_EV);    
+        calc_static_R_EV_SH(RDL_BL, &R_EVL);    
 
         // 递推RD_SL
         recursion_RD(
@@ -357,7 +265,7 @@ void static_kernel(
             TD_RS, TDL_RS,
             TU_RS, TUL_RS,
             RD_BL, RDL_BL,
-            RD_AL, pRDL_AL, inv_2x2T, &invT, stats);
+            RD_AL, &RDL_AL, inv_2x2T, &invT, stats);
         
         // 公式(5.7.26-27)
         cmat2x2_mul(RU_FA, RD_AL, tmpR2);
@@ -375,7 +283,8 @@ void static_kernel(
         }
 
         if(calc_uiz){
-            calc_static_uiz_R_EV(rcv_delta, ircvup, k, RD_BL, RDL_BL, uiz_R_EV, puiz_R_EVL);    
+            calc_static_uiz_R_EV_PSV(rcv_delta, ircvup, k, RD_BL, uiz_R_EV);    
+            calc_static_uiz_R_EV_SH(ircvup, k, RDL_BL, &uiz_R_EVL);    
             cmat2x2_mul(uiz_R_EV, tmp2x2_uiz, tmp2x2_uiz);
             tmpRL_uiz = tmpRL / R_EVL * uiz_R_EVL;
             


### PR DESCRIPTION
The original code of R/T matrix combine the P-SV and SH, not convenient for latter development of normal mode. So I split all the related functions into two parts.