### PR TITLE
FEAT: use `c` instead of `k` in definition of vertical wavenumber `a` and `b`

### DIFF
--- a/pygrt/C_extension/include/grt/common/model.h
+++ b/pygrt/C_extension/include/grt/common/model.h
@@ -36,8 +36,8 @@ typedef struct {
     MYCOMPLEX *mu;       ///< mu[n] \f$ V_b^2 * \rho \f$
     MYCOMPLEX *lambda;   ///< lambda[n] \f$ V_a^2 * \rho - 2*\mu \f$
     MYCOMPLEX *delta;    ///< delta[n] \f$ (\lambda+\mu)/(\lambda+3*\mu) \f$
-    MYCOMPLEX *kaka;     ///< kaka[n] \f$ (\omega/V_a)^2 \f$
-    MYCOMPLEX *kbkb;     ///< kbkb[n] \f$ (\omega/V_b)^2 \f$
+    MYCOMPLEX *atna;
+    MYCOMPLEX *atnb;
 
 } GRT_MODEL1D;
 

--- a/pygrt/C_extension/include/grt/dynamic/layer.h
+++ b/pygrt/C_extension/include/grt/dynamic/layer.h
@@ -21,13 +21,13 @@
  * 
  * @param[in]     xa0            表层的P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
  * @param[in]     xb0            表层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
- * @param[in]     kbkb0          表层的S波水平波数的平方 \f$ k_b^2=(\frac{\omega}{V_b})^2 \f$
+ * @param[in]     cbcb0          相速度与表层的S波速度比值的平方 \f$ c_b^2=(\frac{c}{V_b})^2 \f$
  * @param[in]     k              波数
  * @param[out]    R_tilt         P-SV系数矩阵，SH系数为1
  * @param[out]    stats          状态代码，是否有除零错误，非0为异常值
  * 
  */
-void grt_calc_R_tilt_PSV(MYCOMPLEX xa0, MYCOMPLEX xb0, MYCOMPLEX kbkb0, MYREAL k, MYCOMPLEX R_tilt[2][2], MYINT *stats);
+void grt_calc_R_tilt_PSV(MYCOMPLEX xa0, MYCOMPLEX xb0, MYCOMPLEX cbcb0, MYREAL k, MYCOMPLEX R_tilt[2][2], MYINT *stats);
 
 
 /**
@@ -105,12 +105,12 @@ void grt_calc_uiz_R_EV_SH(
  * @param[in]      Rho1          上层的密度
  * @param[in]      xa1           上层的P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
  * @param[in]      xb1           上层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
- * @param[in]      kbkb1         上层的S波水平波数的平方 \f$ k_b^2=(\frac{\omega}{V_b})^2 \f$
+ * @param[in]      cbcb1         相速度与上层的S波速度比值的平方 \f$ c_b^2=(\frac{c}{V_b})^2 \f$
  * @param[in]      mu1           上层的剪切模量
  * @param[in]      Rho2          下层的密度
  * @param[in]      xa2           下层的P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
  * @param[in]      xb2           下层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
- * @param[in]      kbkb2         下层的S波水平波数的平方 \f$ k_b^2=(\frac{\omega}{V_b})^2 \f$
+ * @param[in]      cbcb2         相速度与下层的S波速度比值的平方 \f$ c_b^2=(\frac{c}{V_b})^2 \f$
  * @param[in]      mu2           下层的剪切模量
  * @param[in]      thk           上层层厚
  * @param[in]      omega         角频率
@@ -123,8 +123,8 @@ void grt_calc_uiz_R_EV_SH(
  * 
  */
 void grt_calc_RT_PSV(
-    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
-    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
+    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX cbcb1, MYCOMPLEX mu1, 
+    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX cbcb2, MYCOMPLEX mu2, 
     MYREAL thk, // 使用上层的厚度
     MYCOMPLEX omega, MYREAL k, 
     MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2],
@@ -173,8 +173,8 @@ void grt_calc_RT_ll_SH(
 
 /** 液-固 界面，函数参数见 calc_RT_PSV 函数 */
 void grt_calc_RT_ls_PSV(
-    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
-    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
+    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX cbcb1, MYCOMPLEX mu1, 
+    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX cbcb2, MYCOMPLEX mu2, 
     MYREAL thk, // 使用上层的厚度
     MYCOMPLEX omega, MYREAL k, 
     MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2], 
@@ -190,8 +190,8 @@ void grt_calc_RT_ls_SH(
 
 /** 固-固 界面，函数参数见 calc_RT_PSV 函数 */
 void grt_calc_RT_ss_PSV(
-    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
-    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
+    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX cbcb1, MYCOMPLEX mu1, 
+    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX cbcb2, MYCOMPLEX mu2, 
     MYREAL thk, // 使用上层的厚度
     MYCOMPLEX omega, MYREAL k, 
     MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2],

--- a/pygrt/C_extension/include/grt/dynamic/source.h
+++ b/pygrt/C_extension/include/grt/dynamic/source.h
@@ -22,19 +22,19 @@
  * 
  * @param[in]     src_xa       震源层的P波归一化垂直波数 \f$ \sqrt{1 - (k_a/k)^2} \f$
  * @param[in]     src_xb       震源层的S波归一化垂直波数 \f$ \sqrt{1 - (k_b/k)^2} \f$
- * @param[in]     src_kaka     震源层的P波水平波数的平方 \f$ k_a^2=(\frac{\omega}{V_a})^2 \f$
- * @param[in]     src_kbkb     震源层的S波水平波数的平方 \f$ k_b^2=(\frac{\omega}{V_b})^2 \f$
+ * @param[in]     src_caca     相速度与震源层的P波速度比值的平方 \f$ c_a^2=(\frac{c}{V_a})^2 \f$
+ * @param[in]     src_cbcb     相速度与震源层的S波速度比值的平方 \f$ c_b^2=(\frac{c}{V_b})^2 \f$
  * @param[in]     k            波数
  * @param[out]    coef         震源系数 \f$ P_m, SV_m, SH_m \f$
  * 
  */
 void grt_source_coef_PSV(
-    MYCOMPLEX src_xa, MYCOMPLEX src_xb, MYCOMPLEX src_kaka, MYCOMPLEX src_kbkb, 
+    MYCOMPLEX src_xa, MYCOMPLEX src_xb, MYCOMPLEX src_caca, MYCOMPLEX src_cbcb, 
     MYREAL k,
     MYCOMPLEX coef[GRT_SRC_M_NUM][GRT_QWV_NUM-1][2]);
 
 /* SH 波的震源系数，参数见 source_coef_PSV  */
 void grt_source_coef_SH(
-    MYCOMPLEX src_xb, MYCOMPLEX src_kbkb, 
+    MYCOMPLEX src_xb, MYCOMPLEX src_cbcb, 
     MYREAL k,
     MYCOMPLEX coef[GRT_SRC_M_NUM][2]);

--- a/pygrt/C_extension/src/common/model.c
+++ b/pygrt/C_extension/src/common/model.c
@@ -34,8 +34,8 @@
     X(mu, MYCOMPLEX)\
     X(lambda, MYCOMPLEX)\
     X(delta, MYCOMPLEX)\
-    X(kaka, MYCOMPLEX)\
-    X(kbkb, MYCOMPLEX)\
+    X(atna, MYCOMPLEX)\
+    X(atnb, MYCOMPLEX)\
 
 
 void grt_print_mod1d(const GRT_MODEL1D *mod1d){
@@ -147,7 +147,7 @@ GRT_MODEL1D * grt_copy_mod1d(const GRT_MODEL1D *mod1d1){
 
 void grt_update_mod1d_omega(GRT_MODEL1D *mod1d, MYCOMPLEX omega){
     MYREAL Va0, Vb0;
-    MYCOMPLEX ka0, kb0;
+    // MYCOMPLEX ka0, kb0;
     MYCOMPLEX atna, atnb;
     for(MYINT i=0; i<mod1d->n; ++i){
         Va0 = mod1d->Va[i];
@@ -155,11 +155,9 @@ void grt_update_mod1d_omega(GRT_MODEL1D *mod1d, MYCOMPLEX omega){
 
         atna = (mod1d->Qainv[i] > 0.0)? grt_attenuation_law(mod1d->Qainv[i], omega) : 1.0;
         atnb = (mod1d->Qbinv[i] > 0.0)? grt_attenuation_law(mod1d->Qbinv[i], omega) : 1.0;
-        
-        ka0 = omega/(Va0*atna);
-        kb0 = (Vb0>0.0)? omega/(Vb0*atnb) : 0.0;
-        mod1d->kaka[i] = ka0*ka0;
-        mod1d->kbkb[i] = kb0*kb0;
+
+        mod1d->atna[i] = atna;
+        mod1d->atnb[i] = atnb;
         
         mod1d->mu[i] = (Vb0*atnb)*(Vb0*atnb)*(mod1d->Rho[i]);
         mod1d->lambda[i] = (Va0*atnb)*(Va0*atnb)*(mod1d->Rho[i]) - 2*mod1d->mu[i];

--- a/pygrt/C_extension/src/dynamic/layer.c
+++ b/pygrt/C_extension/src/dynamic/layer.c
@@ -23,25 +23,24 @@
 
 #include "grt/common/checkerror.h"
 
-void grt_calc_R_tilt_PSV(MYCOMPLEX xa0, MYCOMPLEX xb0, MYCOMPLEX kbkb0, MYREAL k, MYCOMPLEX R_tilt[2][2], MYINT *stats)
+void grt_calc_R_tilt_PSV(MYCOMPLEX xa0, MYCOMPLEX xb0, MYCOMPLEX cbcb0, MYREAL k, MYCOMPLEX R_tilt[2][2], MYINT *stats)
 {
-    if(kbkb0 != 0.0){
+    if(cbcb0 != 0.0){
         // 固体表面
         // 公式(5.3.10-14)
         MYCOMPLEX Delta = 0.0;
-        MYREAL kk = k*k; 
-        MYCOMPLEX kbkb_k2inv = kbkb0/kk;
-        MYCOMPLEX kbkb_k4inv = 0.25*kbkb_k2inv*kbkb_k2inv;
+        // MYREAL kk = k*k; 
+        MYCOMPLEX cbcb02 = 0.25*cbcb0*cbcb0;
 
         // 对公式(5.3.10-14)进行重新整理，对浮点数友好一些
-        Delta = -1.0 + xa0*xb0 + kbkb_k2inv - kbkb_k4inv;
+        Delta = -1.0 + xa0*xb0 + cbcb0 - cbcb02;
         if(Delta == 0.0){
             *stats = GRT_INVERSE_FAILURE;
             return;
         }
-        R_tilt[0][0] = (1.0 + xa0*xb0 - kbkb_k2inv + kbkb_k4inv) / Delta;
-        R_tilt[0][1] = 2.0 * xb0 * (1.0 - 0.5*kbkb_k2inv) / Delta;
-        R_tilt[1][0] = 2.0 * xa0 * (1.0 - 0.5*kbkb_k2inv) / Delta;
+        R_tilt[0][0] = (1.0 + xa0*xb0 - cbcb0 + cbcb02) / Delta;
+        R_tilt[0][1] = 2.0 * xb0 * (1.0 - 0.5*cbcb0) / Delta;
+        R_tilt[1][0] = 2.0 * xa0 * (1.0 - 0.5*cbcb0) / Delta;
         R_tilt[1][1] = R_tilt[0][0];
     }
     else {
@@ -190,8 +189,8 @@ void grt_calc_RT_ll_SH(MYCOMPLEX *RDL, MYCOMPLEX *RUL, MYCOMPLEX *TDL, MYCOMPLEX
 
 
 void grt_calc_RT_ls_PSV(
-    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
-    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
+    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX cbcb1, MYCOMPLEX mu1, 
+    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX cbcb2, MYCOMPLEX mu2, 
     MYREAL thk, // 使用上层的厚度
     MYCOMPLEX omega, MYREAL k, 
     MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2], 
@@ -229,7 +228,7 @@ void grt_calc_RT_ls_PSV(
         GRT_SWAP(MYREAL, Rho1, Rho2);
         GRT_SWAP(MYCOMPLEX, xa1, xa2);
         GRT_SWAP(MYCOMPLEX, xb1, xb2);
-        GRT_SWAP(MYCOMPLEX, kbkb1, kbkb2);
+        GRT_SWAP(MYCOMPLEX, cbcb1, cbcb2);
         GRT_SWAP(MYCOMPLEX, mu1, mu2);
         sgn = -1;
     }
@@ -238,7 +237,7 @@ void grt_calc_RT_ls_PSV(
     // 定义一些中间变量来简化运算和书写
     MYREAL k2 = k*k;
     MYCOMPLEX lamka1k = Rho1*omega*omega/k2;
-    MYCOMPLEX kb2k = kbkb2/k2;
+    MYCOMPLEX kb2k = cbcb2;
     MYCOMPLEX Og2k = 1.0 - 0.5*kb2k;
     MYCOMPLEX Og2k2 = Og2k*Og2k;
     MYCOMPLEX A = 2.0*Og2k2*xa1*mu2 + 0.5*lamka1k*kb2k*xa2 - 2.0*mu2*xa1*xa2*xb2;
@@ -325,8 +324,8 @@ void grt_calc_RT_ls_SH(
 
 
 void grt_calc_RT_ss_PSV(
-    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
-    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
+    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX cbcb1, MYCOMPLEX mu1, 
+    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX cbcb2, MYCOMPLEX mu2, 
     MYREAL thk, // 使用上层的厚度
     MYCOMPLEX omega, MYREAL k, 
     MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2],
@@ -345,12 +344,12 @@ void grt_calc_RT_ss_PSV(
     
 
     // 定义一些中间变量来简化运算和书写
-    MYREAL kk = k*k;
+    // MYREAL kk = k*k;
     MYCOMPLEX dmu = mu1/mu2 - 1.0; // mu1 - mu2; 分子分母同除mu2
     MYCOMPLEX dmu2 = dmu*dmu;
 
-    MYCOMPLEX mu1kb1_k2 = mu1/mu2*kbkb1/kk;// mu1*kb1_k2;
-    MYCOMPLEX mu2kb2_k2 = kbkb2/kk; // mu2*kb2_k2;
+    MYCOMPLEX mu1cbcb1 = mu1/mu2*cbcb1;// mu1*kb1_k2;
+    MYCOMPLEX mu2cbcb2 = cbcb2; // mu2*kb2_k2;
 
     MYREAL rho12 = Rho1 / Rho2;
     MYREAL rho21 = Rho2 / Rho1;
@@ -362,8 +361,8 @@ void grt_calc_RT_ss_PSV(
     // 
     // 以下对公式重新整理，提出k的高阶项，以避免上述问题
     MYCOMPLEX Delta;
-    Delta =   dmu2*(1.0-xa1*xb1)*(1.0-xa2*xb2) + mu1kb1_k2*dmu*(rho21*(1.0-xa1*xb1) - (1.0-xa2*xb2)) 
-            + 0.25*mu1kb1_k2*mu2kb2_k2*(rho12*(1.0-xa2*xb2) + rho21*(1.0-xa1*xb1) - 2.0 - (xa1*xb2+xa2*xb1));
+    Delta =   dmu2*(1.0-xa1*xb1)*(1.0-xa2*xb2) + mu1cbcb1*dmu*(rho21*(1.0-xa1*xb1) - (1.0-xa2*xb2)) 
+            + 0.25*mu1cbcb1*mu2cbcb2*(rho12*(1.0-xa2*xb2) + rho21*(1.0-xa1*xb1) - 2.0 - (xa1*xb2+xa2*xb1));
 
     if( Delta == 0.0 ){
         // printf("# zero Delta_inv=%e+%eJ\n", creal(Delta_inv), cimag(Delta_inv));
@@ -374,37 +373,37 @@ void grt_calc_RT_ss_PSV(
     // REFELCTION
     //------------------ RD -----------------------------------
     // rpp+
-    RD[0][0] = ( - dmu2*(1.0+xa1*xb1)*(1.0-xa2*xb2) - mu1kb1_k2*dmu*(rho21*(1.0+xa1*xb1) - (1.0-xa2*xb2))
-                    - 0.25*mu1kb1_k2*mu2kb2_k2*(rho12*(1.0-xa2*xb2) + rho21*(1.0+xa1*xb1) - 2.0 + (xa1*xb2-xa2*xb1))) / Delta * ex2a;
+    RD[0][0] = ( - dmu2*(1.0+xa1*xb1)*(1.0-xa2*xb2) - mu1cbcb1*dmu*(rho21*(1.0+xa1*xb1) - (1.0-xa2*xb2))
+                    - 0.25*mu1cbcb1*mu2cbcb2*(rho12*(1.0-xa2*xb2) + rho21*(1.0+xa1*xb1) - 2.0 + (xa1*xb2-xa2*xb1))) / Delta * ex2a;
     // rsp+
-    RD[0][1] = ( - dmu2*(1.0-xa2*xb2) + 0.5*mu1kb1_k2*dmu*((1.0-xa2*xb2) - 2.0*rho21) 
-                    + 0.25*mu1kb1_k2*mu2kb2_k2*(1.0-rho21)) / Delta * (-2.0*xb1) * exab;
+    RD[0][1] = ( - dmu2*(1.0-xa2*xb2) + 0.5*mu1cbcb1*dmu*((1.0-xa2*xb2) - 2.0*rho21) 
+                    + 0.25*mu1cbcb1*mu2cbcb2*(1.0-rho21)) / Delta * (-2.0*xb1) * exab;
     // rps+
     RD[1][0] = RD[0][1]*(xa1/xb1);
     // rss+
-    RD[1][1] = ( - dmu2*(1.0+xa1*xb1)*(1.0-xa2*xb2) - mu1kb1_k2*dmu*(rho21*(1.0+xa1*xb1) - (1.0-xa2*xb2))
-                    - 0.25*mu1kb1_k2*mu2kb2_k2*(rho12*(1.0-xa2*xb2) + rho21*(1.0+xa1*xb1) - 2.0 - (xa1*xb2-xa2*xb1))) / Delta * ex2b;
+    RD[1][1] = ( - dmu2*(1.0+xa1*xb1)*(1.0-xa2*xb2) - mu1cbcb1*dmu*(rho21*(1.0+xa1*xb1) - (1.0-xa2*xb2))
+                    - 0.25*mu1cbcb1*mu2cbcb2*(rho12*(1.0-xa2*xb2) + rho21*(1.0+xa1*xb1) - 2.0 - (xa1*xb2-xa2*xb1))) / Delta * ex2b;
     //------------------ RU -----------------------------------
     // rpp-
-    RU[0][0] = ( - dmu2*(1.0-xa1*xb1)*(1.0+xa2*xb2) - mu1kb1_k2*dmu*(rho21*(1.0-xa1*xb1) - (1.0+xa2*xb2))
-                    - 0.25*mu1kb1_k2*mu2kb2_k2*(rho12*(1.0+xa2*xb2) + rho21*(1.0-xa1*xb1) - 2.0 - (xa1*xb2-xa2*xb1))) / Delta;
+    RU[0][0] = ( - dmu2*(1.0-xa1*xb1)*(1.0+xa2*xb2) - mu1cbcb1*dmu*(rho21*(1.0-xa1*xb1) - (1.0+xa2*xb2))
+                    - 0.25*mu1cbcb1*mu2cbcb2*(rho12*(1.0+xa2*xb2) + rho21*(1.0-xa1*xb1) - 2.0 - (xa1*xb2-xa2*xb1))) / Delta;
     // rsp-
-    RU[0][1] = ( - dmu2*(1.0-xa1*xb1) - 0.5*mu1kb1_k2*dmu*(rho21*(1.0-xa1*xb1) - 2.0)
-                    + 0.25*mu1kb1_k2*mu2kb2_k2*(1.0-rho12)) / Delta * (2.0*xb2);
+    RU[0][1] = ( - dmu2*(1.0-xa1*xb1) - 0.5*mu1cbcb1*dmu*(rho21*(1.0-xa1*xb1) - 2.0)
+                    + 0.25*mu1cbcb1*mu2cbcb2*(1.0-rho12)) / Delta * (2.0*xb2);
     // rps-
     RU[1][0] = RU[0][1]*(xa2/xb2);
     // rss-
-    RU[1][1] = ( - dmu2*(1.0-xa1*xb1)*(1.0+xa2*xb2) - mu1kb1_k2*dmu*(rho21*(1.0-xa1*xb1) - (1.0+xa2*xb2))
-                    - 0.25*mu1kb1_k2*mu2kb2_k2*(rho12*(1.0+xa2*xb2) + rho21*(1.0-xa1*xb1) - 2.0 + (xa1*xb2-xa2*xb1))) / Delta;
+    RU[1][1] = ( - dmu2*(1.0-xa1*xb1)*(1.0+xa2*xb2) - mu1cbcb1*dmu*(rho21*(1.0-xa1*xb1) - (1.0+xa2*xb2))
+                    - 0.25*mu1cbcb1*mu2cbcb2*(rho12*(1.0+xa2*xb2) + rho21*(1.0-xa1*xb1) - 2.0 + (xa1*xb2-xa2*xb1))) / Delta;
 
     // REFRACTION
-    tmp = mu1kb1_k2*xa1*(dmu*(xb2-xb1) - 0.5*mu1kb1_k2*(rho21*xb1+xb2)) / Delta * exa;
+    tmp = mu1cbcb1*xa1*(dmu*(xb2-xb1) - 0.5*mu1cbcb1*(rho21*xb1+xb2)) / Delta * exa;
     TD[0][0] = tmp;     TU[0][0] = (rho21*xa2/xa1) * tmp;
-    tmp = mu1kb1_k2*xb1*(dmu*(1.0-xa1*xb2) - 0.5*mu1kb1_k2*(1.0-rho21)) / Delta * exb;
+    tmp = mu1cbcb1*xb1*(dmu*(1.0-xa1*xb2) - 0.5*mu1cbcb1*(1.0-rho21)) / Delta * exb;
     TD[0][1] = tmp;     TU[1][0] = (rho21*xa2/xb1) * tmp;
-    tmp = mu1kb1_k2*xa1*(dmu*(1.0-xa2*xb1) - 0.5*mu1kb1_k2*(1.0-rho21)) / Delta * exa;
+    tmp = mu1cbcb1*xa1*(dmu*(1.0-xa2*xb1) - 0.5*mu1cbcb1*(1.0-rho21)) / Delta * exa;
     TD[1][0] = tmp;     TU[0][1] = (rho21*xb2/xa1) * tmp;
-    tmp = mu1kb1_k2*xb1*(dmu*(xa2-xa1) - 0.5*mu1kb1_k2*(rho21*xa1+xa2)) / Delta * exb;
+    tmp = mu1cbcb1*xb1*(dmu*(xa2-xa1) - 0.5*mu1cbcb1*(rho21*xa1+xa2)) / Delta * exb;
     TD[1][1] = tmp;     TU[1][1] = (rho21*xb2/xb1) * tmp;
 }
 
@@ -436,8 +435,8 @@ void grt_calc_RT_ss_SH(
 
 
 void grt_calc_RT_PSV(
-    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX kbkb1, MYCOMPLEX mu1, 
-    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX kbkb2, MYCOMPLEX mu2, 
+    MYREAL Rho1, MYCOMPLEX xa1, MYCOMPLEX xb1, MYCOMPLEX cbcb1, MYCOMPLEX mu1, 
+    MYREAL Rho2, MYCOMPLEX xa2, MYCOMPLEX xb2, MYCOMPLEX cbcb2, MYCOMPLEX mu2, 
     MYREAL thk, // 使用上层的厚度
     MYCOMPLEX omega, MYREAL k, 
     MYCOMPLEX RD[2][2], MYCOMPLEX RU[2][2],
@@ -446,8 +445,8 @@ void grt_calc_RT_PSV(
     // 根据界面两侧的具体情况选择函数
     if(mu1 != 0.0 && mu2 != 0.0){
         grt_calc_RT_ss_PSV(
-            Rho1, xa1, xb1, kbkb1, mu1, 
-            Rho2, xa2, xb2, kbkb2, mu2, 
+            Rho1, xa1, xb1, cbcb1, mu1, 
+            Rho2, xa2, xb2, cbcb2, mu2, 
             thk, omega, k, 
             RD, RU, TD, TU, stats);
     }
@@ -460,8 +459,8 @@ void grt_calc_RT_PSV(
     }
     else{
         grt_calc_RT_ls_PSV(
-            Rho1, xa1, xb1, kbkb1, mu1, 
-            Rho2, xa2, xb2, kbkb2, mu2, 
+            Rho1, xa1, xb1, cbcb1, mu1, 
+            Rho2, xa2, xb2, cbcb2, mu2, 
             thk, omega, k, 
             RD, RU, TD, TU, stats);
     }

--- a/pygrt/C_extension/src/dynamic/source.c
+++ b/pygrt/C_extension/src/dynamic/source.c
@@ -19,7 +19,7 @@
 
 
 void grt_source_coef_PSV(
-    MYCOMPLEX src_xa, MYCOMPLEX src_xb, MYCOMPLEX src_kaka, MYCOMPLEX src_kbkb, 
+    MYCOMPLEX src_xa, MYCOMPLEX src_xb, MYCOMPLEX src_caca, MYCOMPLEX src_cbcb, 
     MYREAL k,
     MYCOMPLEX coef[GRT_SRC_M_NUM][GRT_QWV_NUM-1][2])
 {
@@ -32,42 +32,42 @@ void grt_source_coef_PSV(
         }
     }
 
-    MYCOMPLEX a = k*src_xa;
-    MYCOMPLEX b = k*src_xb;
-    MYREAL kk = k*k;
+    // MYCOMPLEX a = k*src_xa;
+    // MYCOMPLEX b = k*src_xb;
+    // MYREAL kk = k*k;
     MYCOMPLEX tmp;
 
 
     // 爆炸源， 通过(4.9.8)的矩张量源公式，提取各向同性的量(M11+M22+M33)，-a+k^2/a -> ka^2/a
-    coef[0][0][0] = tmp = src_kaka / a;         coef[0][0][1] = tmp;    
+    coef[0][0][0] = tmp = (src_caca / src_xa) * k;         coef[0][0][1] = tmp;    
     
     // 垂直力源 (4.6.15)
     coef[1][0][0] = tmp = -1.0;                 coef[1][0][1] = - tmp;
-    coef[1][1][0] = tmp = -k / b;                coef[1][1][1] = tmp;
+    coef[1][1][0] = tmp = -1.0 / src_xb;         coef[1][1][1] = tmp;
 
     // 水平力源 (4.6.21,26), 这里可以把x1,x2方向的力转到r,theta方向
     // 推导可发现，r方向的力形成P,SV波, theta方向的力形成SH波
     // 方向性因子包含水平力方向与震源台站连线方向的夹角
-    coef[2][0][0] = tmp = -k / a;              coef[2][0][1] = tmp;
+    coef[2][0][0] = tmp = -1.0 / src_xa;       coef[2][0][1] = tmp;
     coef[2][1][0] = tmp = -1.0;               coef[2][1][1] = - tmp;
 
     // 剪切位错 (4.8.34)
     // m=0
-    coef[3][0][0] = tmp = (2.0*src_kaka - 3.0*kk) / a;    coef[3][0][1] = tmp;
+    coef[3][0][0] = tmp = ((2.0*src_caca - 3.0) / src_xa) * k;    coef[3][0][1] = tmp;
     coef[3][1][0] = tmp = -3.0*k;                          coef[3][1][1] = - tmp;
     // m=1
     coef[4][0][0] = tmp = 2.0*k;                      coef[4][0][1] = - tmp;
-    coef[4][1][0] = tmp = (2.0*kk - src_kbkb) / b;    coef[4][1][1] = tmp;
+    coef[4][1][0] = tmp = ((2.0 - src_cbcb) / src_xb) * k;    coef[4][1][1] = tmp;
 
     // m=2
-    coef[5][0][0] = tmp = - kk / a;                    coef[5][0][1] = tmp;
+    coef[5][0][0] = tmp = - (1.0 / src_xa) * k;                    coef[5][0][1] = tmp;
     coef[5][1][0] = tmp = - k;                         coef[5][1][1] = - tmp;
 
 }
 
 
 void grt_source_coef_SH(
-    MYCOMPLEX src_xb, MYCOMPLEX src_kbkb, 
+    MYCOMPLEX src_xb, MYCOMPLEX src_cbcb, 
     MYREAL k,
     MYCOMPLEX coef[GRT_SRC_M_NUM][2])
 {
@@ -79,20 +79,20 @@ void grt_source_coef_SH(
     }
 
 
-    MYCOMPLEX b = k*src_xb;
+    // MYCOMPLEX b = k*src_xb;
     MYCOMPLEX tmp;
     
     // 水平力源 (4.6.21,26), 这里可以把x1,x2方向的力转到r,theta方向
     // 推导可发现，r方向的力形成P,SV波, theta方向的力形成SH波
     // 方向性因子包含水平力方向与震源台站连线方向的夹角
-    coef[2][0] = tmp = src_kbkb / k / b;    coef[2][1] = tmp;
+    coef[2][0] = tmp = src_cbcb / src_xb;    coef[2][1] = tmp;
 
     // 剪切位错 (4.8.34)
     // m=1
-    coef[4][0] = tmp = - src_kbkb / k;              coef[4][1] = - tmp;
+    coef[4][0] = tmp = - src_cbcb * k;              coef[4][1] = - tmp;
 
     // m=2
-    coef[5][0] = tmp = src_kbkb / b;                coef[5][1] = tmp;
+    coef[5][0] = tmp = (src_cbcb / src_xb) * k;                coef[5][1] = tmp;
 
 }
 

--- a/pygrt/C_extension/src/static/static_propagate.c
+++ b/pygrt/C_extension/src/static/static_propagate.c
@@ -94,9 +94,9 @@ void grt_static_kernel(
 
     // 模型参数
     // 后缀0，1分别代表上层和下层
-    MYREAL mod1d_thk0, mod1d_thk1;
-    MYCOMPLEX mod1d_mu0, mod1d_mu1;
-    MYCOMPLEX mod1d_delta0, mod1d_delta1;
+    MYREAL thk0, thk1;
+    MYCOMPLEX mu0, mu1;
+    MYCOMPLEX delta0, delta1;
     MYCOMPLEX top_delta = 0.0;
     MYCOMPLEX src_delta = 0.0;
     MYCOMPLEX rcv_delta = 0.0;
@@ -105,36 +105,36 @@ void grt_static_kernel(
     // 从顶到底进行矩阵递推, 公式(5.5.3)
     for(MYINT iy=0; iy<mod1d->n; ++iy){ // 因为n>=3, 故一定会进入该循环
         // 赋值上层 
-        mod1d_thk0 = mod1d_thk1;
-        mod1d_mu0 = mod1d_mu1;
-        mod1d_delta0 = mod1d_delta1;
+        thk0 = thk1;
+        mu0 = mu1;
+        delta0 = delta1;
 
         // 更新模型参数
-        mod1d_thk1 = mod1d->Thk[iy];
-        mod1d_mu1 = mod1d->mu[iy];
-        mod1d_delta1 = mod1d->delta[iy];
+        thk1 = mod1d->Thk[iy];
+        mu1 = mod1d->mu[iy];
+        delta1 = mod1d->delta[iy];
 
         if(0==iy){
-            top_delta = mod1d_delta1;
+            top_delta = delta1;
             continue;
         }
 
         // 确定上下层的物性参数
         if(ircv==iy){
-            rcv_delta = mod1d_delta1;
+            rcv_delta = delta1;
         } else if(isrc==iy){
-            src_delta = mod1d_delta1;
+            src_delta = delta1;
         }
 
         // 对第iy层的系数矩阵赋值，加入时间延迟因子(第iy-1界面与第iy界面之间)
         grt_calc_static_RT_PSV(
-            mod1d_delta0, mod1d_mu0,
-            mod1d_delta1, mod1d_mu1,
-            mod1d_thk0, k, // 使用iy-1层的厚度
+            delta0, mu0,
+            delta1, mu1,
+            thk0, k, // 使用iy-1层的厚度
             RD, RU, TD, TU);
         grt_calc_static_RT_SH(
-            mod1d_mu0, mod1d_mu1,
-            mod1d_thk0, k, // 使用iy-1层的厚度
+            mu0, mu1,
+            thk0, k, // 使用iy-1层的厚度
             &RDL, &RUL, &TDL, &TUL);
 
         // FA

--- a/pygrt/c_structures.py
+++ b/pygrt/c_structures.py
@@ -100,6 +100,6 @@ class c_GRT_MODEL1D(Structure):
         ('mu', PCPLX),
         ('lambda', PCPLX),
         ('delta', PCPLX),
-        ('kaka', PCPLX),
-        ('kbkb', PCPLX),
+        ('atna', PCPLX),
+        ('atnb', PCPLX),
     ]


### PR DESCRIPTION
In wavenumber loop, we need to define the vertical wavenumber (normalized),
``` C
ka = omega/va;
xa = sqrt(1.0 - ka*ka / (k*k));
```
In this PR, we use phase velocity to gain more numerical stability,
``` C
c = omega/k;
xa = sqrt(1.0 - (c/va)*(c/va));
```