### PR TITLE
CI: use macos-15 for intel and arm64 arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
             arch: x86_64                  # windows x86_6
           - os: ubuntu-22.04
             arch: x86_64                  # Ubuntu x86_64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64                  # macOS Intel
-          - os: macos-14
+          - os: macos-15
             arch: arm64                   # macOS Apple Silicon
       
       fail-fast: true
@@ -283,9 +283,9 @@ jobs:
             arch: x86_64                  # windows x86_6
           - os: ubuntu-22.04
             arch: x86_64                  # Ubuntu x86_64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64                  # macOS Intel
-          - os: macos-14
+          - os: macos-15
             arch: arm64                   # macOS Apple Silicon
 
       fail-fast: true

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -22,9 +22,9 @@ jobs:
             arch: x86_64                  # windows x86_6
           - os: ubuntu-22.04
             arch: x86_64                  # Ubuntu x86_64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64                  # macOS Intel
-          - os: macos-14
+          - os: macos-15
             arch: arm64                   # macOS Apple Silicon
       
       fail-fast: true
@@ -240,9 +240,9 @@ jobs:
             arch: x86_64                  # windows x86_6
           - os: ubuntu-22.04
             arch: x86_64                  # Ubuntu x86_64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64                  # macOS Intel
-          - os: macos-14
+          - os: macos-15
             arch: arm64                   # macOS Apple Silicon
 
       fail-fast: true


### PR DESCRIPTION
macos-13 image will be retired. See announcements https://github.com/actions/runner-images/issues/13046