### PR TITLE
REFAC: remove type `MYINT`, use `int` and `size_t`

### DIFF
--- a/pygrt/C_extension/include/grt/common/RT_matrix.h
+++ b/pygrt/C_extension/include/grt/common/RT_matrix.h
@@ -30,7 +30,7 @@ typedef struct {
     cplx_t invTL;
 
     /* 状态变量 */
-    MYINT stats;   ///< 是否有除零错误，非0为异常值
+    int stats;   ///< 是否有除零错误，非0为异常值
 } RT_MATRIX;
 
 

--- a/pygrt/C_extension/include/grt/common/const.h
+++ b/pygrt/C_extension/include/grt/common/const.h
@@ -32,14 +32,9 @@
 #endif
 
 
-typedef int MYINT;  ///< 整数 
-
+// 使用双精度
 typedef double real_t;
 typedef double complex cplx_t;
-
-#define GRT_NC_MYINT  NC_INT
-#define GRT_NC_FUNC_MYINT(func)  func##_int
-
 #define NC_REAL  NC_DOUBLE
 #define NC_FUNC_REAL(func)  func##_double
 
@@ -94,7 +89,7 @@ typedef double complex cplx_t;
 // 释放指针数组
 #define GRT_SAFE_FREE_PTR_ARRAY(ptr, count) ({\
     if(ptr!=NULL){\
-        for(MYINT i=0; i<count; ++i){\
+        for(size_t i=0; i<count; ++i){\
             GRT_SAFE_FREE_PTR((ptr)[i]);\
             (ptr)[i] = NULL;\
         }\
@@ -139,10 +134,10 @@ enum {
 };
 
 /** 分别对应爆炸源(0阶)，垂直力源(0阶)，水平力源(1阶)，剪切源(0,1,2阶) */ 
-extern const MYINT GRT_SRC_M_ORDERS[GRT_SRC_M_NUM];
+extern const int GRT_SRC_M_ORDERS[GRT_SRC_M_NUM];
 
 /** 不同震源类型使用的格林函数类型，0为Gij，1为格林函数导数Gij,k */
-extern const MYINT GRT_SRC_M_GTYPES[GRT_SRC_M_NUM];
+extern const int GRT_SRC_M_GTYPES[GRT_SRC_M_NUM];
 
 /** 不同震源，不同阶数的名称简写，用于命名 */
 extern const char *GRT_SRC_M_NAME_ABBR[GRT_SRC_M_NUM];
@@ -158,7 +153,7 @@ extern const char GRT_ZNE_CODES[];
 
 
 /** 波数积分方法 */
-enum {
+enum GRT_K_INTEG_METHOD {
     GRT_K_INTEG_METHOD_DWM = 0,  // 离散波数法
     GRT_K_INTEG_METHOD_FIM,      // 固定间隔 Filon 积分
     GRT_K_INTEG_METHOD_SAFIM,    // 自适应 Filon 积分

--- a/pygrt/C_extension/include/grt/common/dwm.h
+++ b/pygrt/C_extension/include/grt/common/dwm.h
@@ -43,7 +43,7 @@
  */
 real_t grt_discrete_integ(
     GRT_MODEL1D *mod1d, real_t dk, real_t kmax, real_t keps,
-    MYINT nr, real_t *rs,
+    size_t nr, real_t *rs,
     cplx_t sum_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool calc_upar,
     cplx_t sum_uiz_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],

--- a/pygrt/C_extension/include/grt/common/fim.h
+++ b/pygrt/C_extension/include/grt/common/fim.h
@@ -50,7 +50,7 @@
  */
 real_t grt_linear_filon_integ(
     GRT_MODEL1D *mod1d, real_t k0, real_t dk0, real_t filondk, real_t kmax, real_t keps,
-    MYINT nr, real_t *rs,
+    size_t nr, real_t *rs,
     cplx_t sum_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool calc_upar,
     cplx_t sum_uiz_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],

--- a/pygrt/C_extension/include/grt/common/iostats.h
+++ b/pygrt/C_extension/include/grt/common/iostats.h
@@ -38,7 +38,7 @@ void grt_write_stats(
  * 
  * @return   0表示读取成功，-1表示读取结果/失败
  */
-MYINT grt_extract_stats(FILE *bf0, FILE *af0);
+int grt_extract_stats(FILE *bf0, FILE *af0);
 
 
 
@@ -67,5 +67,5 @@ void grt_write_stats_ptam(
  * 
  * @return   0表示读取成功，-1表示读取结果/失败
  */
-MYINT grt_extract_stats_ptam(FILE *bf0, FILE *af0);
+int grt_extract_stats_ptam(FILE *bf0, FILE *af0);
 

--- a/pygrt/C_extension/include/grt/common/matrix.h
+++ b/pygrt/C_extension/include/grt/common/matrix.h
@@ -20,7 +20,7 @@
  * @param[out]     invM     逆矩阵
  * @param[out]     stats    状态代码，是否有除零错误，非0为异常值
  */ 
-inline GCC_ALWAYS_INLINE void grt_cmat2x2_inv(const cplx_t M[2][2], cplx_t invM[2][2], MYINT *stats) {
+inline GCC_ALWAYS_INLINE void grt_cmat2x2_inv(const cplx_t M[2][2], cplx_t invM[2][2], int *stats) {
     cplx_t M00 = M[0][0];
     cplx_t M01 = M[0][1];
     cplx_t M10 = M[1][0];
@@ -155,8 +155,8 @@ inline GCC_ALWAYS_INLINE void grt_cmat2x2_assign(const cplx_t M1[2][2], cplx_t M
  * @param[in]     M2            M2矩阵 
  * @param[out]    M             积矩阵 M1 * M2
  */
-inline GCC_ALWAYS_INLINE void grt_cmatmxn_mul(MYINT m1, MYINT n1, MYINT p1, const cplx_t M1[m1][n1], const cplx_t M2[n1][p1], cplx_t M[m1][p1]){
-    MYINT m, n, k;
+inline GCC_ALWAYS_INLINE void grt_cmatmxn_mul(size_t m1, size_t n1, size_t p1, const cplx_t M1[m1][n1], const cplx_t M2[n1][p1], cplx_t M[m1][p1]){
+    size_t m, n, k;
     cplx_t M0[m1][p1];
     for(m=0; m<m1; ++m){
         for(n=0; n<p1; ++n){
@@ -183,8 +183,8 @@ inline GCC_ALWAYS_INLINE void grt_cmatmxn_mul(MYINT m1, MYINT n1, MYINT p1, cons
  * @param[in]     M1            M1矩阵 
  * @param[out]    M2            M2矩阵 (M1^T)
  */
-inline GCC_ALWAYS_INLINE void grt_cmatmxn_transpose(MYINT m1, MYINT n1, const cplx_t M1[m1][n1], cplx_t M2[n1][m1]){
-    MYINT m, n;
+inline GCC_ALWAYS_INLINE void grt_cmatmxn_transpose(size_t m1, size_t n1, const cplx_t M1[m1][n1], cplx_t M2[n1][m1]){
+    size_t m, n;
     cplx_t M0[n1][m1];
     for(m=0; m<m1; ++m){
         for(n=0; n<n1; ++n){
@@ -212,9 +212,9 @@ inline GCC_ALWAYS_INLINE void grt_cmatmxn_transpose(MYINT m1, MYINT n1, const cp
  * @param[in]     ln           子矩阵列数
  * @param[out]    Q            子矩阵
  */
-inline GCC_ALWAYS_INLINE void grt_cmatmxn_block(MYINT m1, MYINT n1, const cplx_t M[m1][n1], MYINT im, MYINT in, MYINT lm, MYINT ln, cplx_t Q[lm][ln]){
-    for(MYINT m=0; m<lm; ++m){
-        for(MYINT n=0; n<ln; ++n){
+inline GCC_ALWAYS_INLINE void grt_cmatmxn_block(size_t m1, size_t n1, const cplx_t M[m1][n1], size_t im, size_t in, size_t lm, size_t ln, cplx_t Q[lm][ln]){
+    for(size_t m=0; m<lm; ++m){
+        for(size_t n=0; n<ln; ++n){
             Q[m][n] = M[im+m][in+n];
         }
     }
@@ -233,9 +233,9 @@ inline GCC_ALWAYS_INLINE void grt_cmatmxn_block(MYINT m1, MYINT n1, const cplx_t
  * @param[in]     ln           子矩阵列数
  * @param[out]    Q            子矩阵
  */
-inline GCC_ALWAYS_INLINE void grt_cmatmxn_block_assign(MYINT m1, MYINT n1, cplx_t M[m1][n1], MYINT im, MYINT in, MYINT lm, MYINT ln, const cplx_t Q[lm][ln]){
-    for(MYINT m=0; m<lm; ++m){
-        for(MYINT n=0; n<ln; ++n){
+inline GCC_ALWAYS_INLINE void grt_cmatmxn_block_assign(size_t m1, size_t n1, cplx_t M[m1][n1], size_t im, size_t in, size_t lm, size_t ln, const cplx_t Q[lm][ln]){
+    for(size_t m=0; m<lm; ++m){
+        for(size_t n=0; n<ln; ++n){
             M[im+m][in+n] = Q[m][n];
         }
     }
@@ -250,9 +250,9 @@ inline GCC_ALWAYS_INLINE void grt_cmatmxn_block_assign(MYINT m1, MYINT n1, cplx_
  * @param[in]     M1          M1矩阵 
  * 
  */
-inline GCC_ALWAYS_INLINE void grt_cmatmxn_print(MYINT m1, MYINT n1, const cplx_t M1[m1][n1]){
-    for(MYINT i=0; i<m1; ++i){
-        for(MYINT j=0; j<n1; ++j){
+inline GCC_ALWAYS_INLINE void grt_cmatmxn_print(size_t m1, size_t n1, const cplx_t M1[m1][n1]){
+    for(size_t i=0; i<m1; ++i){
+        for(size_t j=0; j<n1; ++j){
             fprintf(stderr, " %15.5e + J%-15.5e ", creal(M1[i][j]), cimag(M1[i][j]));
         }
         fprintf(stderr, "\n");
@@ -267,15 +267,15 @@ inline GCC_ALWAYS_INLINE void grt_cmatmxn_print(MYINT m1, MYINT n1, const cplx_t
  * @param[in]      M2     向量
  * @param[out]     M      积矩阵, M1 * M2
  */
-inline GCC_ALWAYS_INLINE void grt_cmatmx1_mul(MYINT m1, MYINT n1, const cplx_t M1[m1][n1], const cplx_t M2[n1], cplx_t M[n1]){
+inline GCC_ALWAYS_INLINE void grt_cmatmx1_mul(size_t m1, size_t n1, const cplx_t M1[m1][n1], const cplx_t M2[n1], cplx_t M[n1]){
     cplx_t M0[n1];
-    for(MYINT i=0; i<m1; ++i){
+    for(size_t i=0; i<m1; ++i){
         M0[i] = 0.0;
-        for(MYINT j=0; j<n1; ++j){
+        for(size_t j=0; j<n1; ++j){
             M0[i] += M1[i][j] * M2[j];
         }
     }
-    for(MYINT i=0; i<n1; ++i){
+    for(size_t i=0; i<n1; ++i){
         M[i] = M0[i];
     }
 }

--- a/pygrt/C_extension/include/grt/common/model.h
+++ b/pygrt/C_extension/include/grt/common/model.h
@@ -15,11 +15,11 @@
 
 /** 1D 模型结构体，包括多个水平层，以及复数形式的弹性参数 */
 typedef struct {
-    MYINT n;  ///< 层数，注意包括了震源和接收点的虚拟层，(n>=3)
+    size_t n;  ///< 层数，注意包括了震源和接收点的虚拟层，(n>=3)
     real_t depsrc; ///< 震源深度 km
     real_t deprcv; ///< 接收点深度 km
-    MYINT isrc; ///< 震源所在虚拟层位, isrc>=1
-    MYINT ircv; ///< 接收点所在虚拟层位, ircv>=1, ircv != isrc
+    size_t isrc; ///< 震源所在虚拟层位, isrc>=1
+    size_t ircv; ///< 接收点所在虚拟层位, ircv>=1, ircv != isrc
     bool ircvup; ///< 接收点位于浅层, ircv < isrc
     bool io_depth; ///< 读取的模型首列为每层顶界面深度
 
@@ -48,7 +48,7 @@ typedef struct {
     cplx_t *cbcb;
 
     /* 状态变量，非 0 为异常值 */
-    MYINT stats;
+    int stats;
 
 } GRT_MODEL1D;
 
@@ -76,7 +76,7 @@ void grt_free_mod1d(GRT_MODEL1D *mod1d);
  * @return    `GRT_MODEL1D` 结构体指针
  * 
  */
-GRT_MODEL1D * grt_init_mod1d(MYINT n);
+GRT_MODEL1D * grt_init_mod1d(size_t n);
 
 /**
  * 复制 `GRT_MODEL1D` 结构体
@@ -110,7 +110,7 @@ void grt_mod1d_xa_xb(GRT_MODEL1D *mod1d, const real_t k);
  * @param[in,out]     mod1d     `MODEL1D` 结构体指针
  * @param[in]         n         新层数
  */
-void grt_realloc_mod1d(GRT_MODEL1D *mod1d, MYINT n);
+void grt_realloc_mod1d(GRT_MODEL1D *mod1d, size_t n);
 
 /**
  * 从文件中读取模型文件
@@ -135,7 +135,7 @@ GRT_MODEL1D * grt_read_mod1d_from_file(const char *command, const char *modelpat
  * @param[out]   diglen         每一列的最大字符串长度
  * 
  */
-void grt_get_model_diglen_from_file(const char *command, const char *modelpath, MYINT diglen[6]);
+void grt_get_model_diglen_from_file(const char *command, const char *modelpath, size_t diglen[6]);
 
 /**
  * 浮点数比较，检查模型中是否存在该速度（不论Vp,Vs）

--- a/pygrt/C_extension/include/grt/common/myfftw.h
+++ b/pygrt/C_extension/include/grt/common/myfftw.h
@@ -35,13 +35,13 @@
 #define X(T, s, S) \
 typedef struct {\
     /*时间序列长度*/ \
-    MYINT nt; \
+    size_t nt; \
     /* 时间间隔 */ \
     real_t dt; \
     /*有效频谱长度*/\
-    MYINT nf_valid; \
+    size_t nf_valid; \
     /*总频谱长度 nf = nt/2+1*/\
-    MYINT nf; \
+    size_t nf; \
     /*频率间隔*/\
     real_t df; \
     /*时间域实序列*/\
@@ -68,9 +68,9 @@ typedef struct {\
  * @return    FFTW_HOLDER 结构体指针
  * 
  */\
-GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_C2R_1D(const MYINT nt, const real_t dt, const MYINT nf_valid, const real_t df); \
+GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_C2R_1D(const size_t nt, const real_t dt, const size_t nf_valid, const real_t df); \
 /** 初始化 FFTW_HOLDER 结构体指针，进行实数序列到复数频谱的正变换 */\
-GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_R2C_1D(const MYINT nt, const real_t dt, const MYINT nf_valid, const real_t df); \
+GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_R2C_1D(const size_t nt, const real_t dt, const size_t nf_valid, const real_t df); \
 \
 /** 将内部数据全部置零  */\
 void grt_reset_fftw##s##_holder_zero(GRT_FFTW##S##_HOLDER *fh);\

--- a/pygrt/C_extension/include/grt/common/progressbar.h
+++ b/pygrt/C_extension/include/grt/common/progressbar.h
@@ -19,4 +19,4 @@
  * @param[in]    prefix         进度条前缀字符串
  * @param[in]    percentage     百分比(整数)
  */
-void grt_printprogressBar(const char *prefix, MYINT percentage);
+void grt_printprogressBar(const char *prefix, int percentage);

--- a/pygrt/C_extension/include/grt/common/ptam.h
+++ b/pygrt/C_extension/include/grt/common/ptam.h
@@ -46,7 +46,7 @@
  */
 void grt_PTA_method(
     GRT_MODEL1D *mod1d, real_t k0, real_t predk,
-    MYINT nr, real_t *rs,
+    size_t nr, real_t *rs,
     cplx_t sum_J0[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool calc_upar,
     cplx_t sum_uiz_J0[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
@@ -71,8 +71,8 @@ void grt_PTA_method(
  * @return    波峰(1)，波谷(-1)，其它(0)
  *  
  */
-MYINT grt_cplx_peak_or_trough(
-    MYINT idx1, MYINT idx2, const cplx_t arr[GRT_PTAM_WINDOW_SIZE][GRT_SRC_M_NUM][GRT_INTEG_NUM], 
+int grt_cplx_peak_or_trough(
+    int idx1, int idx2, const cplx_t arr[GRT_PTAM_WINDOW_SIZE][GRT_SRC_M_NUM][GRT_INTEG_NUM], 
     real_t k, real_t dk, real_t *pk, cplx_t *value);
 
 
@@ -86,4 +86,4 @@ MYINT grt_cplx_peak_or_trough(
  * @param[in,out]     arr         振荡的数组，最终收敛值在第一个，arr[0] 
  * 
  */
-void grt_cplx_shrink(MYINT n1, cplx_t *arr);
+void grt_cplx_shrink(size_t n1, cplx_t *arr);

--- a/pygrt/C_extension/include/grt/common/safim.h
+++ b/pygrt/C_extension/include/grt/common/safim.h
@@ -51,7 +51,7 @@
  */
 real_t grt_sa_filon_integ(
     GRT_MODEL1D *mod1d, real_t k0, real_t dk0, real_t tol, real_t kmax, real_t kref, 
-    MYINT nr, real_t *rs,
+    size_t nr, real_t *rs,
     cplx_t sum_J0[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool calc_upar,
     cplx_t sum_uiz_J0[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],

--- a/pygrt/C_extension/include/grt/common/search.h
+++ b/pygrt/C_extension/include/grt/common/search.h
@@ -12,9 +12,11 @@
 #include "grt/common/const.h"
 
 // 定义 X 宏，为多个类型定义查找函数
-#define __FOR_EACH_TYPE \
-    X(MYINT)  X(real_t)  X(float)  X(double)
+#define __FOR_EACH_REAL \
+    X(real_t)  X(float)  X(double)
 
+#define __FOR_EACH_INT \
+    X(size_t)
 
 /**
  * 该函数对输入数组进行线性搜索，找到目标值时返回其索引。
@@ -30,9 +32,10 @@
  * 
  */
 #define X(T) \
-MYINT grt_findElement_##T(const T *array, MYINT size, T target);
+ssize_t grt_findElement_##T(const T *array, size_t size, T target);
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
+__FOR_EACH_INT
 #undef X
 
 
@@ -51,9 +54,9 @@ __FOR_EACH_TYPE
  * 
  */
 #define X(T) \
-MYINT grt_findLessEqualClosest_##T(const T *array, MYINT size, T target);
+ssize_t grt_findLessEqualClosest_##T(const T *array, size_t size, T target);
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
 #undef X
 
 
@@ -71,9 +74,9 @@ __FOR_EACH_TYPE
  * 
  */
 #define X(T) \
-MYINT grt_findClosest_##T(const T *array, MYINT size, T target);
+size_t grt_findClosest_##T(const T *array, size_t size, T target);
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
 #undef X
 
 
@@ -89,10 +92,11 @@ __FOR_EACH_TYPE
  * 
  */
 #define X(T) \
-MYINT grt_findMin_##T(const T *array, MYINT size);\
-MYINT grt_findMax_##T(const T *array, MYINT size);\
+size_t grt_findMin_##T(const T *array, size_t size);\
+size_t grt_findMax_##T(const T *array, size_t size);\
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
+__FOR_EACH_INT
 #undef X
 
 
@@ -107,9 +111,11 @@ __FOR_EACH_TYPE
 #define X(T) \
 int grt_compare_##T(const void *a, const void *b);
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
+__FOR_EACH_INT
 #undef X
-#undef __FOR_EACH_TYPE
+#undef __FOR_EACH_REAL
+#undef __FOR_EACH_INT
 
 
 
@@ -126,6 +132,6 @@ __FOR_EACH_TYPE
  * 
  * @return pos   插入位置的索引
  */
-MYINT grt_insertOrdered(
-    void *arr, MYINT *size, MYINT capacity, const void *target, size_t elementSize, bool ascending,
+ssize_t grt_insertOrdered(
+    void *arr, size_t *size, size_t capacity, const void *target, size_t elementSize, bool ascending,
     int (*compare)(const void *, const void *));

--- a/pygrt/C_extension/include/grt/common/util.h
+++ b/pygrt/C_extension/include/grt/common/util.h
@@ -24,7 +24,7 @@
  * 
  * @return   子字符串数组
  */
-char ** grt_string_split(const char *string, const char *delim, int *size);
+char ** grt_string_split(const char *string, const char *delim, size_t *size);
 
 /**
  * 从文本文件中，将每行内容读入字符串数组
@@ -35,7 +35,7 @@ char ** grt_string_split(const char *string, const char *delim, int *size);
  * @return   字符串数组
  * 
  */
-char ** grt_string_from_file(FILE *fp, int *size);
+char ** grt_string_from_file(FILE *fp, size_t *size);
 
 /**
  * 判断字符串是否由特定的若个字符组成（充分条件）
@@ -126,7 +126,7 @@ void grt_GF_freq2time_write_to_file(
     const char *command, const GRT_MODEL1D *mod1d, 
     const char *s_output_dir, const char *s_modelname, const char *s_depsrc, const char *s_deprcv,    
     const real_t wI, GRT_FFTW_HOLDER *pt_fh,
-    const MYINT nr, char *s_dists[nr], const real_t dists[nr], real_t travtPS[nr][2],
+    const size_t nr, char *s_dists[nr], const real_t dists[nr], real_t travtPS[nr][2],
     const real_t depsrc, const real_t deprcv,
     const real_t delayT0, const real_t delayV0, const bool calc_upar,
     const bool doEX, const bool doVF, const bool doHF, const bool doDC, 

--- a/pygrt/C_extension/include/grt/dynamic/grn.h
+++ b/pygrt/C_extension/include/grt/dynamic/grn.h
@@ -49,8 +49,8 @@
  * 
  */ 
 void grt_integ_grn_spec(
-    GRT_MODEL1D *mod1d, MYINT nf1, MYINT nf2, real_t *freqs,  
-    MYINT nr, real_t *rs, real_t wI, 
+    GRT_MODEL1D *mod1d, size_t nf1, size_t nf2, real_t *freqs,  
+    size_t nr, real_t *rs, real_t wI, 
     real_t vmin_ref, real_t keps, real_t ampk, real_t k0, real_t Length, real_t filonLength, real_t safilonTol, real_t filonCut,             
     bool print_progressbar, 
 
@@ -62,8 +62,8 @@ void grt_integ_grn_spec(
     cplx_t *grn_uir[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
 
     const char *statsstr, // 积分过程输出
-    MYINT  nstatsidxs, // 仅输出特定频点
-    MYINT *statsidxs
+    size_t  nstatsidxs, // 仅输出特定频点
+    size_t *statsidxs
 );
 
 

--- a/pygrt/C_extension/include/grt/dynamic/layer.h
+++ b/pygrt/C_extension/include/grt/dynamic/layer.h
@@ -83,7 +83,7 @@ void grt_wave2qwv_z_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL);
  * @param[out]     M             R/T矩阵
  * 
  */
-void grt_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 
 /**
@@ -95,25 +95,25 @@ void grt_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
  * @param[out]     M             R/T矩阵
  * 
  */
-void grt_RT_matrix_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_RT_matrix_SH(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 /** 液-液 界面 */
-void grt_RT_matrix_ll_PSV(const GRT_MODEL1D *mod1d, MYINT iy, RT_MATRIX *M);
+void grt_RT_matrix_ll_PSV(const GRT_MODEL1D *mod1d, size_t iy, RT_MATRIX *M);
 
 /** 液-液 界面 */
 void grt_RT_matrix_ll_SH(RT_MATRIX *M);
 
 /** 液-固 界面 */
-void grt_RT_matrix_ls_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_RT_matrix_ls_PSV(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 /** 液-固 界面 */
-void grt_RT_matrix_ls_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_RT_matrix_ls_SH(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 /** 固-固 界面 */
-void grt_RT_matrix_ss_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_RT_matrix_ss_PSV(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 /** 固-固 界面 */
-void grt_RT_matrix_ss_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_RT_matrix_ss_SH(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 /**
  * 为 R/T 矩阵添加时间延迟因子
@@ -123,7 +123,7 @@ void grt_RT_matrix_ss_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
  * @param[out]     M             R/T矩阵    
  * 
  */
-void grt_delay_RT_matrix(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_delay_RT_matrix(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 
 /**
@@ -148,7 +148,7 @@ void grt_delay_RT_matrix(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
  */
 void grt_get_layer_D(
     cplx_t xa, cplx_t xb, cplx_t kbkb, cplx_t mu, 
-    cplx_t omega, real_t rho, real_t k, cplx_t D[4][4], bool inverse, MYINT liquid_invtype);
+    cplx_t omega, real_t rho, real_t k, cplx_t D[4][4], bool inverse, int liquid_invtype);
 
 /** 子矩阵 D11，函数参数见 get_layer_D 函数 */
 void grt_get_layer_D11(
@@ -212,4 +212,4 @@ void grt_RT_matrix_from_4x4(
     cplx_t omega, real_t thk,
     real_t k, 
     cplx_t RD[2][2], cplx_t *RDL, cplx_t RU[2][2], cplx_t *RUL, 
-    cplx_t TD[2][2], cplx_t *TDL, cplx_t TU[2][2], cplx_t *TUL, MYINT *stats);
+    cplx_t TD[2][2], cplx_t *TDL, cplx_t TU[2][2], cplx_t *TUL, int *stats);

--- a/pygrt/C_extension/include/grt/static/static_grn.h
+++ b/pygrt/C_extension/include/grt/static/static_grn.h
@@ -42,7 +42,7 @@
  * 
  */
 void grt_integ_static_grn(
-    GRT_MODEL1D *mod1d, MYINT nr, real_t *rs, real_t vmin_ref, real_t keps, real_t k0, real_t Length,
+    GRT_MODEL1D *mod1d, size_t nr, real_t *rs, real_t vmin_ref, real_t keps, real_t k0, real_t Length,
     real_t filonLength, real_t safilonTol, real_t filonCut, 
 
     // 返回值，代表Z、R、T分量

--- a/pygrt/C_extension/include/grt/static/static_layer.h
+++ b/pygrt/C_extension/include/grt/static/static_layer.h
@@ -80,7 +80,7 @@ void grt_static_wave2qwv_z_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R
  * @param[out]     M             R/T矩阵
  * 
  */
-void grt_static_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_static_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 /**
  * 计算界面的 SH 波静态反射透射系数RDL/RUL/TDL/TUL
@@ -91,7 +91,7 @@ void grt_static_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRI
  * @param[out]     M             R/T矩阵
  * 
  */
-void grt_static_RT_matrix_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_static_RT_matrix_SH(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);
 
 
 /**
@@ -102,4 +102,4 @@ void grt_static_RT_matrix_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX
  * @param[out]     M             R/T矩阵
  * 
  */
-void grt_static_delay_RT_matrix(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M);
+void grt_static_delay_RT_matrix(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M);

--- a/pygrt/C_extension/src/common/const.c
+++ b/pygrt/C_extension/src/common/const.c
@@ -10,10 +10,10 @@
 
 
 /** 分别对应爆炸源(0阶)，垂直力源(0阶)，水平力源(1阶)，剪切源(0,1,2阶) */ 
-const MYINT GRT_SRC_M_ORDERS[GRT_SRC_M_NUM] = {0, 0, 1, 0, 1, 2};
+const int GRT_SRC_M_ORDERS[GRT_SRC_M_NUM] = {0, 0, 1, 0, 1, 2};
 
 /** 不同震源类型使用的格林函数类型，0为Gij，1为格林函数导数Gij,k */
-const MYINT GRT_SRC_M_GTYPES[GRT_SRC_M_NUM] = {1, 0, 0, 1, 1, 1};
+const int GRT_SRC_M_GTYPES[GRT_SRC_M_NUM] = {1, 0, 0, 1, 1, 1};
 
 /** 不同震源，不同阶数的名称简写，用于命名 */
 const char *GRT_SRC_M_NAME_ABBR[GRT_SRC_M_NUM] = {"EX", "VF", "HF", "DD", "DS", "SS"};

--- a/pygrt/C_extension/src/common/dwm.c
+++ b/pygrt/C_extension/src/common/dwm.c
@@ -25,7 +25,7 @@
 
 real_t grt_discrete_integ(
     GRT_MODEL1D *mod1d, real_t dk, real_t kmax, real_t keps,
-    MYINT nr, real_t *rs,
+    size_t nr, real_t *rs,
     cplx_t sum_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool calc_upar,
     cplx_t sum_uiz_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
@@ -39,16 +39,14 @@ real_t grt_discrete_integ(
     cplx_t QWV_uiz[GRT_SRC_M_NUM][GRT_QWV_NUM];
     
     real_t k = 0.0;
-    MYINT ik = 0;
+    size_t ik = 0;
 
     // 所有震中距的k循环是否结束
     bool iendk = true;
 
     // 每个震中距的k循环是否结束
-    bool *iendkrs = (bool *)malloc(nr * sizeof(bool));
+    bool *iendkrs = (bool *)calloc(nr, sizeof(bool)); // 自动初始化为 false
     bool iendk0 = false;
-    for(MYINT ir=0; ir<nr; ++ir) iendkrs[ir] = false;
-    
 
     // 波数k循环 (5.9.2)
     while(true){
@@ -66,11 +64,11 @@ real_t grt_discrete_integ(
 
         // 震中距rs循环
         iendk = true;
-        for(MYINT ir=0; ir<nr; ++ir){
+        for(size_t ir=0; ir<nr; ++ir){
             if(iendkrs[ir]) continue; // 该震中距下的波数k积分已收敛
 
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-                for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
+                for(int v=0; v<GRT_INTEG_NUM; ++v){
                     SUM[i][v] = 0.0;
                 }
             }
@@ -79,10 +77,10 @@ real_t grt_discrete_integ(
             grt_int_Pk(k, rs[ir], QWV, false, SUM);
             
             iendk0 = true;
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-                MYINT modr = GRT_SRC_M_ORDERS[i];
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
+                int modr = GRT_SRC_M_ORDERS[i];
 
-                for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+                for(int v=0; v<GRT_INTEG_NUM; ++v){
                     sum_J[ir][i][v] += SUM[i][v];
                     
                     // 是否提前判断达到收敛
@@ -107,8 +105,8 @@ real_t grt_discrete_integ(
                 grt_int_Pk(k, rs[ir], QWV_uiz, false, SUM);
                 
                 // keps不参与计算位移空间导数的积分，背后逻辑认为u收敛，则uiz也收敛
-                for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-                    for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+                for(int i=0; i<GRT_SRC_M_NUM; ++i){
+                    for(int v=0; v<GRT_INTEG_NUM; ++v){
                         sum_uiz_J[ir][i][v] += SUM[i][v];
                     }
                 }
@@ -118,8 +116,8 @@ real_t grt_discrete_integ(
                 grt_int_Pk(k, rs[ir], QWV, true, SUM);
                 
                 // keps不参与计算位移空间导数的积分，背后逻辑认为u收敛，则uiz也收敛
-                for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-                    for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+                for(int i=0; i<GRT_SRC_M_NUM; ++i){
+                    for(int v=0; v<GRT_INTEG_NUM; ++v){
                         sum_uir_J[ir][i][v] += SUM[i][v];
                     }
                 }

--- a/pygrt/C_extension/src/common/integral.c
+++ b/pygrt/C_extension/src/common/integral.c
@@ -37,24 +37,24 @@ void grt_int_Pk(
     grt_bessel012(kr, &bjmk[0], &bjmk[1], &bjmk[2]); 
     if(calc_uir){
         real_t bjmk0[GRT_MORDER_MAX+1] = {0};
-        for(MYINT i=0; i<=GRT_MORDER_MAX; ++i)  bjmk0[i] = bjmk[i];
+        for(int i=0; i<=GRT_MORDER_MAX; ++i)  bjmk0[i] = bjmk[i];
 
         grt_besselp012(kr, &bjmk[0], &bjmk[1], &bjmk[2]); 
         kcoef = k*k;
 
-        for(MYINT i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] = kr_inv * (-kr_inv * bjmk0[i] + bjmk[i]);
+        for(int i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] = kr_inv * (-kr_inv * bjmk0[i] + bjmk[i]);
     } 
     else {
-        for(MYINT i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] = bjmk[i]*kr_inv;
+        for(int i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] = bjmk[i]*kr_inv;
     }
 
-    for(MYINT i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] *= kcoef;
-    for(MYINT i=0; i<=GRT_MORDER_MAX; ++i)  bjmk[i] *= kcoef;
+    for(int i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] *= kcoef;
+    for(int i=0; i<=GRT_MORDER_MAX; ++i)  bjmk[i] *= kcoef;
 
 
     // 公式(5.6.22), 将公式分解为F(k,w)Jm(kr)k的形式
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        MYINT modr = GRT_SRC_M_ORDERS[i];  // 对应m阶数
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        int modr = GRT_SRC_M_ORDERS[i];  // 对应m阶数
         if(modr == 0){
             SUM[i][0] = - QWV[i][0] * bjmk[1];   // - q0*J1*k
             SUM[i][2] =   QWV[i][1] * bjmk[0];   //   w0*J0*k
@@ -96,11 +96,11 @@ void grt_int_Pk_filon(
         bjmk[2] = cos(kr - FIVEQUARTERPI - phi0);
     }
 
-    for(MYINT i=0; i<=GRT_MORDER_MAX; ++i)  bjmk[i] *= kcoef;
+    for(int i=0; i<=GRT_MORDER_MAX; ++i)  bjmk[i] *= kcoef;
     
     // 公式(5.6.22), 将公式分解为F(k,w)Jm(kr)k的形式，忽略近场项
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        MYINT modr = GRT_SRC_M_ORDERS[i];  // 对应m阶数
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        int modr = GRT_SRC_M_ORDERS[i];  // 对应m阶数
         if(modr == 0){
             SUM[i][0] = - QWV[i][0] * bjmk[1];   // - q0*J1*k
             SUM[i][2] =   QWV[i][1] * bjmk[0];   //   w0*J0*k
@@ -120,7 +120,7 @@ void grt_int_Pk_filon(
  * 如果kodr0==1，则说明对r取偏导，需计算(a*k^3 + b*k^2 + c*k) * cos(kr - (2m+1)/4) 在[k1, k2]上的积分，
  */
 static cplx_t interg_quad_cos(
-    cplx_t a, cplx_t b, cplx_t c, MYINT modr, real_t r, real_t k1, real_t k2, MYINT kodr0)
+    cplx_t a, cplx_t b, cplx_t c, int modr, real_t r, real_t k1, real_t k2, int kodr0)
 {
     real_t s1, s2, c1, c2;
     real_t k1r, k2r, phi;
@@ -167,22 +167,22 @@ void grt_int_Pk_sa_filon(
 {
     // 使用bessel递推公式 Jm'(x) = m/x * Jm(x) - J_{m+1}(x)
     // 考虑大震中距，忽略第一项，再使用bessel渐近公式
-    MYINT modr0 = (calc_uir)? 1 : 0;
-    MYINT kodr0 = (calc_uir)? 1 : 0;
-    MYINT sgn = (calc_uir)? -1 : 1;
+    int modr0 = (calc_uir)? 1 : 0;
+    int kodr0 = (calc_uir)? 1 : 0;
+    int sgn = (calc_uir)? -1 : 1;
 
     // 对sqrt(k)*F(k,w)进行二次曲线拟合，再计算 (a*k^2 + b*k + c) * cos(kr - (2m+1)/4) 的积分
     // 拟合二次函数的参数
     cplx_t quad_a[GRT_SRC_M_NUM][GRT_QWV_NUM]={0};
     cplx_t quad_b[GRT_SRC_M_NUM][GRT_QWV_NUM]={0};
     cplx_t quad_c[GRT_SRC_M_NUM][GRT_QWV_NUM]={0};
-    for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-        MYINT modr = GRT_SRC_M_ORDERS[im];
-        for(MYINT c=0; c<GRT_QWV_NUM; ++c){
+    for(int im=0; im<GRT_SRC_M_NUM; ++im){
+        int modr = GRT_SRC_M_ORDERS[im];
+        for(int c=0; c<GRT_QWV_NUM; ++c){
             if(modr==0 && GRT_QWV_CODES[c] == 'v')  continue;
 
             cplx_t F3[3];
-            for(MYINT d=0; d<3; ++d)  F3[d] = QWV3[d][im][c] * sqrt(k3[d]) * sgn;
+            for(int d=0; d<3; ++d)  F3[d] = QWV3[d][im][c] * sqrt(k3[d]) * sgn;
 
             // 拟合参数
             grt_quad_term(k3, F3, &quad_a[im][c], &quad_b[im][c], &quad_c[im][c]);
@@ -191,8 +191,8 @@ void grt_int_Pk_sa_filon(
 
     real_t kmin = k3[0], kmax = k3[2];
     // 公式(5.6.22), 将公式分解为F(k,w)Jm(kr)k的形式
-    for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-        MYINT modr = GRT_SRC_M_ORDERS[im];  // 对应m阶数
+    for(int im=0; im<GRT_SRC_M_NUM; ++im){
+        int modr = GRT_SRC_M_ORDERS[im];  // 对应m阶数
         if(modr == 0){
             SUM[im][0] = - interg_quad_cos(quad_a[im][0],quad_b[im][0],quad_c[im][0],1+modr0,r,kmin,kmax,kodr0);   // - q0*J1*k
             SUM[im][2] =   interg_quad_cos(quad_a[im][1],quad_b[im][1],quad_c[im][1],0+modr0,r,kmin,kmax,kodr0);   //   w0*J0*k
@@ -214,8 +214,8 @@ void grt_merge_Pk(
     // 累积求和，Z、R、T分量 
     cplx_t tol[GRT_SRC_M_NUM][GRT_CHANNEL_NUM])
 {   
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        MYINT modr = GRT_SRC_M_ORDERS[i];
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        int modr = GRT_SRC_M_ORDERS[i];
         if(modr==0){
             tol[i][0] = sum_J[i][2];
             tol[i][1] = sum_J[i][0];

--- a/pygrt/C_extension/src/common/iostats.c
+++ b/pygrt/C_extension/src/common/iostats.c
@@ -22,9 +22,9 @@ void grt_write_stats(
 {
     fwrite(&k, sizeof(real_t), 1, f0);
 
-    for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-        MYINT modr = GRT_SRC_M_ORDERS[im];
-        for(MYINT c=0; c<GRT_QWV_NUM; ++c){
+    for(int im=0; im<GRT_SRC_M_NUM; ++im){
+        int modr = GRT_SRC_M_ORDERS[im];
+        for(int c=0; c<GRT_QWV_NUM; ++c){
             if(modr == 0 && GRT_QWV_CODES[c] == 'v')   continue;
 
             fwrite(&QWV[im][c], sizeof(cplx_t), 1, f0);
@@ -33,16 +33,16 @@ void grt_write_stats(
 }
 
 
-MYINT grt_extract_stats(FILE *bf0, FILE *af0){
+int grt_extract_stats(FILE *bf0, FILE *af0){
     // 打印标题
     if(bf0 == NULL){
         char K[20];
         snprintf(K, sizeof(K), GRT_STRING_FMT, "k");  K[0]=GRT_COMMENT_HEAD;
         fprintf(af0, "%s", K);
 
-        for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-            MYINT modr = GRT_SRC_M_ORDERS[im];
-            for(MYINT c=0; c<GRT_QWV_NUM; ++c){
+        for(int im=0; im<GRT_SRC_M_NUM; ++im){
+            int modr = GRT_SRC_M_ORDERS[im];
+            for(int c=0; c<GRT_QWV_NUM; ++c){
                 if(modr == 0 && GRT_QWV_CODES[c] == 'v')   continue;
 
                 snprintf(K, sizeof(K), "%s_%c", GRT_SRC_M_NAME_ABBR[im], GRT_QWV_CODES[c]);
@@ -59,9 +59,9 @@ MYINT grt_extract_stats(FILE *bf0, FILE *af0){
     if(1 != fread(&k, sizeof(real_t), 1, bf0))  return -1;
     fprintf(af0, GRT_REAL_FMT, k);
 
-    for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-        MYINT modr = GRT_SRC_M_ORDERS[im];
-        for(MYINT c=0; c<GRT_QWV_NUM; ++c){
+    for(int im=0; im<GRT_SRC_M_NUM; ++im){
+        int modr = GRT_SRC_M_ORDERS[im];
+        for(int c=0; c<GRT_QWV_NUM; ++c){
             if(modr == 0 && GRT_QWV_CODES[c] == 'v')   continue;
 
             if(1 != fread(&val, sizeof(cplx_t), 1, bf0))  return -1;
@@ -79,10 +79,10 @@ void grt_write_stats_ptam(
     cplx_t Fpt[GRT_SRC_M_NUM][GRT_INTEG_NUM][GRT_PTAM_PT_MAX]
 ){
 
-    for(MYINT i=0; i<GRT_PTAM_PT_MAX; ++i){
-        for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-            MYINT modr = GRT_SRC_M_ORDERS[im];
-            for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+    for(int i=0; i<GRT_PTAM_PT_MAX; ++i){
+        for(int im=0; im<GRT_SRC_M_NUM; ++im){
+            int modr = GRT_SRC_M_ORDERS[im];
+            for(int v=0; v<GRT_INTEG_NUM; ++v){
                 if(modr == 0 && v!=0 && v!=2)  continue;
                 
                 fwrite(&Kpt[im][v][i], sizeof(real_t),  1, f0);
@@ -94,15 +94,15 @@ void grt_write_stats_ptam(
 }
 
 
-MYINT grt_extract_stats_ptam(FILE *bf0, FILE *af0){
+int grt_extract_stats_ptam(FILE *bf0, FILE *af0){
     // 打印标题
     if(bf0 == NULL){
         char K[20], K2[20];
-        MYINT icol=0;
+        int icol=0;
 
-        for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-            MYINT modr = GRT_SRC_M_ORDERS[im];
-            for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+        for(int im=0; im<GRT_SRC_M_NUM; ++im){
+            int modr = GRT_SRC_M_ORDERS[im];
+            for(int v=0; v<GRT_INTEG_NUM; ++v){
                 if(modr == 0 && v!=0 && v!=2)  continue;
 
                 snprintf(K2, sizeof(K2), "sum_%s_%d_k", GRT_SRC_M_NAME_ABBR[im], v);
@@ -126,9 +126,9 @@ MYINT grt_extract_stats_ptam(FILE *bf0, FILE *af0){
     real_t k;
     cplx_t val;
 
-    for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-        MYINT modr = GRT_SRC_M_ORDERS[im];
-        for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+    for(int im=0; im<GRT_SRC_M_NUM; ++im){
+        int modr = GRT_SRC_M_ORDERS[im];
+        for(int v=0; v<GRT_INTEG_NUM; ++v){
             if(modr == 0 && v!=0 && v!=2)  continue;
 
             if(1 != fread(&k, sizeof(real_t), 1, bf0))  return -1;

--- a/pygrt/C_extension/src/common/myfftw.c
+++ b/pygrt/C_extension/src/common/myfftw.c
@@ -12,7 +12,7 @@
 #include "grt/common/checkerror.h"
 
 #define X(T, s, S) \
-static GRT_FFTW##S##_HOLDER *  grt_init_fftw##s##_holder(const MYINT nt, const real_t dt, const MYINT nf_valid, const real_t df)\
+static GRT_FFTW##S##_HOLDER *  grt_init_fftw##s##_holder(const size_t nt, const real_t dt, const size_t nf_valid, const real_t df)\
 {\
     GRT_FFTW##S##_HOLDER *fh = (GRT_FFTW##S##_HOLDER*)calloc(1, sizeof(GRT_FFTW##S##_HOLDER));\
     if (!fh) {\
@@ -41,7 +41,7 @@ void grt_reset_fftw##s##_holder_zero(GRT_FFTW##S##_HOLDER *fh)\
 }\
 \
 \
-GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_C2R_1D(const MYINT nt, const real_t dt, const MYINT nf_valid, const real_t df)\
+GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_C2R_1D(const size_t nt, const real_t dt, const size_t nf_valid, const real_t df)\
 {\
     GRT_FFTW##S##_HOLDER * fh = grt_init_fftw##s##_holder(nt, dt, nf_valid, df);\
     fh->plan = fftw##s##_plan_dft_c2r_1d(nt, fh->W_f, fh->w_t, FFTW_ESTIMATE);\
@@ -49,7 +49,7 @@ GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_C2R_1D(const MYINT nt, const 
 }\
 \
 \
-GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_R2C_1D(const MYINT nt, const real_t dt, const MYINT nf_valid, const real_t df)\
+GRT_FFTW##S##_HOLDER * grt_create_fftw##s##_holder_R2C_1D(const size_t nt, const real_t dt, const size_t nf_valid, const real_t df)\
 {\
     GRT_FFTW##S##_HOLDER * fh = grt_init_fftw##s##_holder(nt, dt, nf_valid, df);\
     fh->plan = fftw##s##_plan_dft_r2c_1d(nt, fh->w_t, fh->W_f, FFTW_ESTIMATE);\
@@ -70,17 +70,17 @@ void grt_destroy_fftw##s##_holder(GRT_FFTW##S##_HOLDER *fh)\
 \
 void grt_naive_inverse_transform_##T(GRT_FFTW##S##_HOLDER *fh)\
 {\
-    MYINT nt = fh->nt;\
-    MYINT nf = fh->nf;\
-    MYINT nf_valid = fh->nf_valid;\
+    size_t nt = fh->nt;\
+    size_t nf = fh->nf;\
+    size_t nf_valid = fh->nf_valid;\
     T f;\
-    for(MYINT i = 0; i < nt; i++) {\
+    for(size_t i = 0; i < nt; i++) {\
         T t = i*fh->dt;\
         fh->w_t[i] = 0.0;\
         /*单独处理零频*/\
         if(fh->f0 == 0.0)  fh->w_t[i] += creal(fh->W_f[0]); \
         /*对频率点进行求和（数值积分）*/\
-        for(MYINT k = 1; k < nf_valid-1; k++) {\
+        for(size_t k = 1; k < nf_valid-1; k++) {\
             f = k*fh->df + fh->f0;\
             fh->w_t[i] += 2.0*creal(fh->W_f[k] * exp(I * PI2 * f * t));\
         }\

--- a/pygrt/C_extension/src/common/progressbar.c
+++ b/pygrt/C_extension/src/common/progressbar.c
@@ -12,12 +12,12 @@
 #include "grt/common/progressbar.h"
 
 
-void grt_printprogressBar(const char *prefix, MYINT percentage) {
+void grt_printprogressBar(const char *prefix, int percentage) {
     printf("\r\033[K"); // 移动到行首并清空行
     if(prefix!=NULL) printf("%s", prefix);
     printf("[");
-    MYINT pos = _PROGRESSBAR_WIDTH_ * percentage / 100;
-    for (MYINT i = 0; i < _PROGRESSBAR_WIDTH_; ++i) {
+    int pos = _PROGRESSBAR_WIDTH_ * percentage / 100;
+    for (int i = 0; i < _PROGRESSBAR_WIDTH_; ++i) {
         if (i < pos) printf("=");
         else if (i == pos) printf(">");
         else printf(" ");

--- a/pygrt/C_extension/src/common/ptam.c
+++ b/pygrt/C_extension/src/common/ptam.c
@@ -42,9 +42,9 @@
  * @param[in,out]       iendk0    一个布尔指针，用于指示是否满足结束条件 
  */
 static void process_peak_or_trough(
-    MYINT ir, MYINT im, MYINT v, real_t k, real_t dk, 
+    size_t ir, int im, int v, real_t k, real_t dk, 
     cplx_t (*J3)[GRT_PTAM_WINDOW_SIZE][GRT_SRC_M_NUM][GRT_INTEG_NUM], real_t (*Kpt)[GRT_SRC_M_NUM][GRT_INTEG_NUM][GRT_PTAM_PT_MAX], 
-    cplx_t (*Fpt)[GRT_SRC_M_NUM][GRT_INTEG_NUM][GRT_PTAM_PT_MAX], MYINT (*Ipt)[GRT_SRC_M_NUM][GRT_INTEG_NUM], MYINT (*Gpt)[GRT_SRC_M_NUM][GRT_INTEG_NUM], bool *iendk0)
+    cplx_t (*Fpt)[GRT_SRC_M_NUM][GRT_INTEG_NUM][GRT_PTAM_PT_MAX], size_t (*Ipt)[GRT_SRC_M_NUM][GRT_INTEG_NUM], size_t (*Gpt)[GRT_SRC_M_NUM][GRT_INTEG_NUM], bool *iendk0)
 {
     cplx_t tmp0;
     if (Gpt[ir][im][v] >= GRT_PTAM_WINDOW_SIZE-1 && Ipt[ir][im][v] < GRT_PTAM_PT_MAX) {
@@ -81,19 +81,19 @@ static void process_peak_or_trough(
  * 
  */
 static void ptam_once(
-    const MYINT ir, const MYINT nr, const real_t precoef, real_t k, real_t dk, 
+    const size_t ir, const size_t nr, const real_t precoef, real_t k, real_t dk, 
     cplx_t SUM3[nr][GRT_PTAM_WINDOW_SIZE][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     cplx_t sum_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     real_t Kpt[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM][GRT_PTAM_PT_MAX],
     cplx_t Fpt[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM][GRT_PTAM_PT_MAX],
-    MYINT Ipt[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
-    MYINT Gpt[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
+    size_t Ipt[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
+    size_t Gpt[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool *iendk0)
 {
     *iendk0 = true;
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        MYINT modr = GRT_SRC_M_ORDERS[i];
-        for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        int modr = GRT_SRC_M_ORDERS[i];
+        for(int v=0; v<GRT_INTEG_NUM; ++v){
             if(modr == 0 && v!=0 && v!= 2)  continue;
 
             // 赋更新量
@@ -105,7 +105,7 @@ static void ptam_once(
             process_peak_or_trough(ir, i, v, k, dk, SUM3, Kpt, Fpt, Ipt, Gpt, iendk0);
 
             // 左移动点, 
-            for(MYINT jj=0; jj<GRT_PTAM_WINDOW_SIZE-1; ++jj){
+            for(int jj=0; jj<GRT_PTAM_WINDOW_SIZE-1; ++jj){
                 SUM3[ir][jj][i][v] = SUM3[ir][jj+1][i][v];
             }
 
@@ -118,7 +118,7 @@ static void ptam_once(
 
 void grt_PTA_method(
     GRT_MODEL1D *mod1d, real_t k0, real_t predk,
-    MYINT nr, real_t *rs,
+    size_t nr, real_t *rs,
     cplx_t sum_J0[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool calc_upar,
     cplx_t sum_uiz_J0[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
@@ -169,21 +169,21 @@ void grt_PTA_method(
 
     #define __ARR [GRT_SRC_M_NUM][GRT_INTEG_NUM]
         // 存储波峰波谷的总个数
-        __CALLOC_ARRAY(Ipt, MYINT, __ARR);
-        __CALLOC_ARRAY(Ipt_uiz, MYINT, __ARR);
-        __CALLOC_ARRAY(Ipt_uir, MYINT, __ARR);
+        __CALLOC_ARRAY(Ipt, size_t, __ARR);
+        __CALLOC_ARRAY(Ipt_uiz, size_t, __ARR);
+        __CALLOC_ARRAY(Ipt_uir, size_t, __ARR);
 
         // 记录点数，当峰谷找到后，清零
-        __CALLOC_ARRAY(Gpt, MYINT, __ARR);
-        __CALLOC_ARRAY(Gpt_uiz, MYINT, __ARR);
-        __CALLOC_ARRAY(Gpt_uir, MYINT, __ARR);
+        __CALLOC_ARRAY(Gpt, size_t, __ARR);
+        __CALLOC_ARRAY(Gpt_uiz, size_t, __ARR);
+        __CALLOC_ARRAY(Gpt_uir, size_t, __ARR);
     #undef __ARR
     #undef __CALLOC_ARRAY
 
 
-    for(MYINT ir=0; ir<nr; ++ir){
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-            for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+    for(size_t ir=0; ir<nr; ++ir){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i){
+            for(int v=0; v<GRT_INTEG_NUM; ++v){
                 sum_J[ir][i][v] = sum_J0[ir][i][v];
 
                 if(calc_upar){
@@ -200,7 +200,7 @@ void grt_PTA_method(
 
 
     // 对于PTAM，不同震中距使用不同dk
-    for(MYINT ir=0; ir<nr; ++ir){
+    for(size_t ir=0; ir<nr; ++ir){
         real_t dk = PI/((GRT_PTAM_WAITS_MAX-1)*rs[ir]); 
         real_t precoef = dk/predk; // 提前乘dk系数，以抵消格林函数主函数计算时最后乘dk
         // 根据波峰波谷的目标也给出一个kmax，+5以防万一 
@@ -251,13 +251,13 @@ void grt_PTA_method(
     }
 
     // 做缩减序列，赋值最终解
-    for(MYINT ir=0; ir<nr; ++ir){
+    for(size_t ir=0; ir<nr; ++ir){
         FILE *fstatsP = ptam_fstatsnr[ir][1];
         // 记录到文件
         if(fstatsP!=NULL)  grt_write_stats_ptam(fstatsP, Kpt[ir], Fpt[ir]);
 
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-            for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i){
+            for(int v=0; v<GRT_INTEG_NUM; ++v){
                 grt_cplx_shrink(Ipt[ir][i][v], Fpt[ir][i][v]);  
                 sum_J0[ir][i][v] = Fpt[ir][i][v][0];
 
@@ -290,10 +290,10 @@ void grt_PTA_method(
 
 
 
-MYINT grt_cplx_peak_or_trough(MYINT idx1, MYINT idx2, const cplx_t arr[GRT_PTAM_WINDOW_SIZE][GRT_SRC_M_NUM][GRT_INTEG_NUM], real_t k, real_t dk, real_t *pk, cplx_t *value){
+int grt_cplx_peak_or_trough(int idx1, int idx2, const cplx_t arr[GRT_PTAM_WINDOW_SIZE][GRT_SRC_M_NUM][GRT_INTEG_NUM], real_t k, real_t dk, real_t *pk, cplx_t *value){
     cplx_t f1, f2, f3;
     real_t rf1, rf2, rf3;
-    MYINT stat=0;
+    int stat=0;
 
     f1 = arr[0][idx1][idx2];
     f2 = arr[1][idx1][idx2];
@@ -341,9 +341,9 @@ MYINT grt_cplx_peak_or_trough(MYINT idx1, MYINT idx2, const cplx_t arr[GRT_PTAM_
 }
 
 
-void grt_cplx_shrink(MYINT n1, cplx_t *arr){
-    for(MYINT n=n1; n>1; --n){
-        for(MYINT i=0; i<n-1; ++i){
+void grt_cplx_shrink(size_t n1, cplx_t *arr){
+    for(size_t n=n1; n>1; --n){
+        for(size_t i=0; i<n-1; ++i){
             arr[i] = 0.5*(arr[i] + arr[i+1]);
         }
     }

--- a/pygrt/C_extension/src/common/safim.c
+++ b/pygrt/C_extension/src/common/safim.c
@@ -101,14 +101,14 @@ static KInterval stack_pop(KIntervalStack *stack) {
  *    + stats = 4,   [a+h, a+2h]
  * 
  */
-static cplx_t simpson(const KInterval *item_pt, MYINT im, MYINT iqwv, bool isuiz, SIMPSON_INTV stats) {
+static cplx_t simpson(const KInterval *item_pt, int im, int iqwv, bool isuiz, SIMPSON_INTV stats) {
     cplx_t Fint = 0.0;
     real_t klen = item_pt->k3[2] -  item_pt->k3[0];
     const cplx_t (*F3)[GRT_SRC_M_NUM][GRT_QWV_NUM] = (isuiz)? item_pt->F3_uiz : item_pt->F3;
     
     // 使用F(k)*sqrt(k)来衡量积分值，这可以平衡后续计算F(k)*Jm(kr)k积分时的系数
     real_t sk[3];
-    for(MYINT i=0; i<3; ++i){
+    for(int i=0; i<3; ++i){
         sk[i] = sqrt(item_pt->k3[i]);
     }
 
@@ -138,8 +138,8 @@ static cplx_t simpson(const KInterval *item_pt, MYINT im, MYINT iqwv, bool isuiz
 /** 比较QWV的最大绝对值 */
 static void get_maxabsQWV(const cplx_t F[GRT_SRC_M_NUM][GRT_QWV_NUM], real_t maxabsF[GRT_GTYPES_MAX]){
     real_t tmp;
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        for(MYINT c=0; c<GRT_QWV_NUM; ++c){
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int c=0; c<GRT_QWV_NUM; ++c){
             tmp = fabs(F[i][c]);
             if(tmp > maxabsF[GRT_SRC_M_GTYPES[i]]){
                 maxabsF[GRT_SRC_M_GTYPES[i]] = tmp;
@@ -168,9 +168,9 @@ static bool check_fit(
 
     real_t S_dif, S_ref;
     bool badtol = false;
-    for(MYINT im=0; im<GRT_SRC_M_NUM; ++im){
-        MYINT igtyp = GRT_SRC_M_GTYPES[im];
-        for(MYINT c=0; c<GRT_QWV_NUM; ++c){
+    for(int im=0; im<GRT_SRC_M_NUM; ++im){
+        int igtyp = GRT_SRC_M_GTYPES[im];
+        for(int c=0; c<GRT_QWV_NUM; ++c){
             if(GRT_SRC_M_ORDERS[im]==0 && GRT_QWV_CODES[c]=='v')  continue;
             // qw和v分开采样?
             // if(isqw && GRT_QWV_CODES[c]=='v')  continue;
@@ -187,7 +187,7 @@ static bool check_fit(
             bool islowamp = true;
             real_t ref_amp = REF_AMP_SCALE*maxabsQWV[igtyp];
             // 比较当前区间内5个核函数幅值，是否都低于参考值
-            for(MYINT d=0; d<3; ++d){
+            for(int d=0; d<3; ++d){
                 islowamp = islowamp && (fabs(F3L[d][im][c]) < ref_amp);
                 if(d>0){
                     islowamp = islowamp && (fabs(F3R[d][im][c]) < ref_amp);
@@ -238,7 +238,7 @@ static bool check_fit(
  */
 static void interv_integ(
     const KInterval *ptKitv,
-    MYINT nr, real_t *rs,
+    size_t nr, real_t *rs,
     cplx_t sum_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool calc_upar,
     cplx_t sum_uiz_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
@@ -247,18 +247,18 @@ static void interv_integ(
     cplx_t SUM[GRT_SRC_M_NUM][GRT_INTEG_NUM]={0};
 
     // 震中距rs循环
-    for(MYINT ir=0; ir<nr; ++ir){
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-            for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+    for(size_t ir=0; ir<nr; ++ir){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i){
+            for(int v=0; v<GRT_INTEG_NUM; ++v){
                 SUM[i][v] = 0.0;
             }
         }
 
         // 该分段内的积分
         grt_int_Pk_sa_filon(ptKitv->k3, rs[ir], ptKitv->F3, false, SUM);
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-            MYINT modr = GRT_SRC_M_ORDERS[i];
-            for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i){
+            int modr = GRT_SRC_M_ORDERS[i];
+            for(int v=0; v<GRT_INTEG_NUM; ++v){
                 if((modr==0 && v!=0 && v!=2))  continue;
                 sum_J[ir][i][v] += SUM[i][v];
             }
@@ -267,9 +267,9 @@ static void interv_integ(
         if(calc_upar){
             //----------------------------- ui_z --------------------------------------
             grt_int_Pk_sa_filon(ptKitv->k3, rs[ir], ptKitv->F3_uiz, false, SUM);
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-                MYINT modr = GRT_SRC_M_ORDERS[i];
-                for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
+                int modr = GRT_SRC_M_ORDERS[i];
+                for(int v=0; v<GRT_INTEG_NUM; ++v){
                     if((modr==0 && v!=0 && v!=2))  continue;
                     sum_uiz_J[ir][i][v] += SUM[i][v];
                 }
@@ -277,9 +277,9 @@ static void interv_integ(
 
             //----------------------------- ui_r --------------------------------------
             grt_int_Pk_sa_filon(ptKitv->k3, rs[ir], ptKitv->F3, true, SUM);
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-                MYINT modr = GRT_SRC_M_ORDERS[i];
-                for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
+                int modr = GRT_SRC_M_ORDERS[i];
+                for(int v=0; v<GRT_INTEG_NUM; ++v){
                     if((modr==0 && v!=0 && v!=2))  continue;
                     sum_uir_J[ir][i][v] += SUM[i][v];
                 }
@@ -294,7 +294,7 @@ static void interv_integ(
 
 real_t grt_sa_filon_integ(
     GRT_MODEL1D *mod1d, real_t k0, real_t dk0, real_t tol, real_t kmax, real_t kref, 
-    MYINT nr, real_t *rs,
+    size_t nr, real_t *rs,
     cplx_t sum_J0[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     bool calc_upar,
     cplx_t sum_uiz_J0[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
@@ -322,7 +322,7 @@ real_t grt_sa_filon_integ(
         .F3 = {{{0}}}, 
         .F3_uiz = {{{0}}} 
     };
-    for(MYINT i=0; i<3; ++i) {
+    for(int i=0; i<3; ++i) {
         grt_mod1d_xa_xb(mod1d, Kitv.k3[i]);
         kerfunc(mod1d, Kitv.F3[i], calc_upar, Kitv.F3_uiz[i]);
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
@@ -381,7 +381,7 @@ real_t grt_sa_filon_integ(
 
 
         // 增加新值，并比较QWV最大绝对值
-        for(MYINT i=0; i<3; ++i){
+        for(int i=0; i<3; ++i){
             get_maxabsQWV(Kitv_left.F3[i], maxabsQWV);
             if(calc_upar)  get_maxabsQWV(Kitv_left.F3_uiz[i], maxabsQWV_uiz);
             if(i>0){
@@ -406,10 +406,10 @@ real_t grt_sa_filon_integ(
             // 由于栈的特性，最终记录的k值采样是按顺序的
             // 记录后四个采样值
             if(fstats!=NULL){
-                for(MYINT i=1; i<3; ++i){
+                for(int i=1; i<3; ++i){
                     grt_write_stats(fstats, Kitv_left.k3[i], Kitv_left.F3[i]);
                 }
-                for(MYINT i=1; i<3; ++i){
+                for(int i=1; i<3; ++i){
                     grt_write_stats(fstats, Kitv_right.k3[i], Kitv_right.F3[i]);
                 }
             }
@@ -419,10 +419,10 @@ real_t grt_sa_filon_integ(
     } // END sampling
 
     // 乘上总系数 sqrt(2.0/(PI*r)) / dk0,  除dks0是在该函数外还会再乘dk0, 并将结果加到原数组中
-    for(MYINT ir=0; ir<nr; ++ir){
+    for(size_t ir=0; ir<nr; ++ir){
         real_t tmp = sqrt(2.0/(PI*rs[ir])) / dk0;
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-            for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i){
+            for(int v=0; v<GRT_INTEG_NUM; ++v){
                 sum_J0[ir][i][v] += sum_J[ir][i][v] * tmp;
                 if(calc_upar){
                     sum_uiz_J0[ir][i][v] += sum_uiz_J[ir][i][v] * tmp;

--- a/pygrt/C_extension/src/common/search.c
+++ b/pygrt/C_extension/src/common/search.c
@@ -14,13 +14,16 @@
 #include "grt/common/const.h"
 
 // 定义 X 宏，为多个类型定义查找函数
-#define __FOR_EACH_TYPE \
-    X(MYINT)  X(real_t)  X(float)  X(double)
+#define __FOR_EACH_REAL \
+    X(real_t)  X(float)  X(double)
+
+#define __FOR_EACH_INT \
+    X(size_t)
 
 
 #define X(T) \
-MYINT grt_findElement_##T(const T *array, MYINT size, T target) {\
-    for (MYINT i = 0; i < size; ++i) {\
+ssize_t grt_findElement_##T(const T *array, size_t size, T target) {\
+    for (size_t i = 0; i < size; ++i) {\
         if (array[i] == target) {\
             /** 找到目标元素，返回索引 */\
             return i;\
@@ -30,16 +33,17 @@ MYINT grt_findElement_##T(const T *array, MYINT size, T target) {\
     return -1; \
 }
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
+__FOR_EACH_INT
 #undef X
 
 
 
 #define X(T) \
-MYINT grt_findLessEqualClosest_##T(const T *array, MYINT size, T target) {\
-    MYINT ires=-1;\
+ssize_t grt_findLessEqualClosest_##T(const T *array, size_t size, T target) {\
+    ssize_t ires=-1;\
     T mindist=-1, dist=0;\
-    for (MYINT i = 0; i < size; ++i) {\
+    for (size_t i = 0; i < size; ++i) {\
         dist = target-array[i];\
         if(dist >= 0 && (mindist < 0 || dist < mindist)){\
             ires = i;\
@@ -49,16 +53,16 @@ MYINT grt_findLessEqualClosest_##T(const T *array, MYINT size, T target) {\
     return ires;\
 }
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
 #undef X
 
 
 
 #define X(T) \
-MYINT grt_findClosest_##T(const T *array, MYINT size, T target) {\
-    MYINT ires=0;\
+size_t grt_findClosest_##T(const T *array, size_t size, T target) {\
+    size_t ires=0;\
     T mindist=-1, dist=0;\
-    for (MYINT i = 0; i < size; ++i) {\
+    for (size_t i = 0; i < size; ++i) {\
         dist = fabs(target-array[i]);\
         if(mindist < 0 || dist < mindist){\
             ires = i;\
@@ -68,15 +72,15 @@ MYINT grt_findClosest_##T(const T *array, MYINT size, T target) {\
     return ires;\
 }
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
 #undef X
 
 
 #define X(T) \
-MYINT grt_findMin_##T(const T *array, MYINT size) {\
+size_t grt_findMin_##T(const T *array, size_t size) {\
     T rval = array[0];\
-    MYINT idx=0;\
-    for(MYINT ir=0; ir<size; ++ir){\
+    size_t idx=0;\
+    for(size_t ir=0; ir<size; ++ir){\
         if(array[ir] < rval){\
             rval = array[ir];\
             idx = ir;\
@@ -84,10 +88,10 @@ MYINT grt_findMin_##T(const T *array, MYINT size) {\
     }\
     return idx;\
 }\
-MYINT grt_findMax_##T(const T *array, MYINT size) {\
+size_t grt_findMax_##T(const T *array, size_t size) {\
     T rval = array[0];\
-    MYINT idx=0;\
-    for(MYINT ir=0; ir<size; ++ir){\
+    size_t idx=0;\
+    for(size_t ir=0; ir<size; ++ir){\
         if(array[ir] > rval){\
             rval = array[ir];\
             idx = ir;\
@@ -96,7 +100,8 @@ MYINT grt_findMax_##T(const T *array, MYINT size) {\
     return idx;\
 }
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
+__FOR_EACH_INT
 #undef X
 
 
@@ -113,23 +118,25 @@ int grt_compare_##T(const void *a, const void *b) {\
     }\
 }\
 
-__FOR_EACH_TYPE
+__FOR_EACH_REAL
+__FOR_EACH_INT
 #undef X
-#undef __FOR_EACH_TYPE
+#undef __FOR_EACH_REAL
+#undef __FOR_EACH_INT
 
 
-MYINT grt_insertOrdered(
-    void *arr, MYINT *size, MYINT capacity, const void *target, size_t elementSize, bool ascending,
+ssize_t grt_insertOrdered(
+    void *arr, size_t *size, size_t capacity, const void *target, size_t elementSize, bool ascending,
     int (*compare)(const void *, const void *))
 {    
-    MYINT sgn = (ascending)? 1 : -1;
+    int sgn = (ascending)? 1 : -1;
 
     // 数组满载情况下，只可能插入更小(升序)或更大(降序)的数值
     if(*size == capacity && sgn*compare(target, arr+(*size-1)*elementSize) >= 0) return -1;
 
     // 找到插入位置
-    MYINT pos=*size;
-    for(MYINT i=0; i<*size; ++i){
+    size_t pos=*size;
+    for(size_t i=0; i<*size; ++i){
         if(sgn*compare(target, arr+i*elementSize) < 0){
             pos = i;
             break;
@@ -137,7 +144,7 @@ MYINT grt_insertOrdered(
     }
 
     // 截断式插入，防止越界
-    MYINT lastpos = *size;
+    size_t lastpos = *size;
     if(lastpos >= capacity){
         lastpos = capacity-1;
     } else {

--- a/pygrt/C_extension/src/common/util.c
+++ b/pygrt/C_extension/src/common/util.c
@@ -21,7 +21,7 @@
 
 #include "grt/common/checkerror.h"
 
-char ** grt_string_split(const char *string, const char *delim, int *size)
+char ** grt_string_split(const char *string, const char *delim, size_t *size)
 {
     char *str_copy = strdup(string);  // 创建字符串副本，以免修改原始字符串
     char *token = strtok(str_copy, delim);
@@ -43,7 +43,7 @@ char ** grt_string_split(const char *string, const char *delim, int *size)
     return s_split;
 }
 
-char ** grt_string_from_file(FILE *fp, int *size){
+char ** grt_string_from_file(FILE *fp, size_t *size){
     char **s_split = NULL;
     *size = 0;
     s_split = (char**)realloc(s_split, sizeof(char*)*(*size+1));
@@ -232,7 +232,7 @@ static void write_one_to_sac(
     cfac = exp(I*PI2*pt_fh->df*delayT);
     ccoef = sgn;
     // 只赋值有效长度，其余均为0
-    for(int i=0; i<pt_fh->nf_valid; ++i){
+    for(size_t i=0; i<pt_fh->nf_valid; ++i){
         pt_fh->W_f[i] = grncplx[i] * ccoef;
         ccoef *= cfac;
     }
@@ -252,7 +252,7 @@ static void write_one_to_sac(
     double fac, coef;
     coef = pt_fh->df * exp(delayT*wI);
     fac = exp(wI*pt_fh->dt);
-    for(int i=0; i<pt_fh->nt; ++i){
+    for(size_t i=0; i<pt_fh->nt; ++i){
         float_arr[i] = pt_fh->w_t[i] * coef;
         coef *= fac;
     }
@@ -372,7 +372,7 @@ void grt_GF_freq2time_write_to_file(
     const char *command, const GRT_MODEL1D *mod1d, 
     const char *s_output_dir, const char *s_modelname, const char *s_depsrc, const char *s_deprcv,    
     const real_t wI, GRT_FFTW_HOLDER *pt_fh,
-    const MYINT nr, char *s_dists[nr], const real_t dists[nr], real_t travtPS[nr][2],
+    const size_t nr, char *s_dists[nr], const real_t dists[nr], real_t travtPS[nr][2],
     const real_t depsrc, const real_t deprcv,
     const real_t delayT0, const real_t delayV0, const bool calc_upar,
     const bool doEX, const bool doVF, const bool doHF, const bool doDC, 
@@ -406,7 +406,7 @@ void grt_GF_freq2time_write_to_file(
     GRT_SAFE_ASPRINTF(&s_output_dirprefx, "%s/%s_%s_%s", s_output_dir, s_modelname, s_depsrc, s_deprcv);
     
     // 做反傅里叶变换，保存SAC文件
-    for(int ir=0; ir<nr; ++ir){
+    for(size_t ir=0; ir<nr; ++ir){
         hd.dist = dists[ir];
 
         single_freq2time_write_to_file(

--- a/pygrt/C_extension/src/dynamic/grt_syn.c
+++ b/pygrt/C_extension/src/dynamic/grt_syn.c
@@ -67,12 +67,12 @@ typedef struct {
     /** 积分次数 */
     struct {
         bool active;
-        MYINT int_times;
+        int int_times;
     } I;
     /** 求导次数 */
     struct {
         bool active;
-        MYINT dif_times;
+        int dif_times;
     } J;
     /** 时间函数 */
     struct {
@@ -98,7 +98,7 @@ typedef struct {
     real_t srcRadi[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
 
     // 最终要计算的震源类型
-    MYINT computeType;
+    int computeType;
     char s_computeType[3];
 
 } GRT_MODULE_CTRL;

--- a/pygrt/C_extension/src/dynamic/layer.c
+++ b/pygrt/C_extension/src/dynamic/layer.c
@@ -65,7 +65,7 @@ void grt_topfree_RU(const GRT_MODEL1D *mod1d, RT_MATRIX *M)
 
 void grt_wave2qwv_REV_PSV(const GRT_MODEL1D *mod1d, cplx_t R[2][2], cplx_t R_EV[2][2])
 {
-    MYINT ircv = mod1d->ircv;
+    size_t ircv = mod1d->ircv;
     cplx_t xa = mod1d->xa[ircv];
     cplx_t xb = mod1d->xb[ircv];
     real_t k = mod1d->k;
@@ -99,7 +99,7 @@ void grt_wave2qwv_REV_PSV(const GRT_MODEL1D *mod1d, cplx_t R[2][2], cplx_t R_EV[
 
 void grt_wave2qwv_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL)
 {
-    MYINT ircv = mod1d->ircv;
+    size_t ircv = mod1d->ircv;
     cplx_t xb = mod1d->xb[ircv];
     real_t k = mod1d->k;
 
@@ -116,7 +116,7 @@ void grt_wave2qwv_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL)
 
 void grt_wave2qwv_z_REV_PSV(const GRT_MODEL1D *mod1d, const cplx_t R[2][2], cplx_t R_EV[2][2])
 {
-    MYINT ircv = mod1d->ircv;
+    size_t ircv = mod1d->ircv;
     cplx_t xa = mod1d->xa[ircv];
     cplx_t xb = mod1d->xb[ircv];
     real_t k = mod1d->k;
@@ -149,7 +149,7 @@ void grt_wave2qwv_z_REV_PSV(const GRT_MODEL1D *mod1d, const cplx_t R[2][2], cplx
 
 void grt_wave2qwv_z_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL)
 {
-    MYINT ircv = mod1d->ircv;
+    size_t ircv = mod1d->ircv;
     cplx_t xb = mod1d->xb[ircv];
     real_t k = mod1d->k;
     
@@ -171,7 +171,7 @@ void grt_wave2qwv_z_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL)
 }    
 
 
-void grt_RT_matrix_ll_PSV(const GRT_MODEL1D *mod1d, MYINT iy, RT_MATRIX *M)
+void grt_RT_matrix_ll_PSV(const GRT_MODEL1D *mod1d, size_t iy, RT_MATRIX *M)
 {
     MODEL_2LAYS_ATTRIB(cplx_t, xa);
     MODEL_2LAYS_ATTRIB(real_t, Rho);
@@ -206,7 +206,7 @@ void grt_RT_matrix_ll_SH(RT_MATRIX *M)
 
 
 
-void grt_RT_matrix_ls_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_RT_matrix_ls_PSV(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     MODEL_2LAYS_ATTRIB(cplx_t, xa);
     MODEL_2LAYS_ATTRIB(cplx_t, xb);
@@ -219,7 +219,7 @@ void grt_RT_matrix_ls_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M
 
     // 讨论液-固 or 固-液
     bool isfluidUp = (mu1 == 0.0);  // 上层是否为液体
-    MYINT sgn = 1;
+    int sgn = 1;
     if(isfluidUp && mu2 == 0.0){
         GRTRaiseError("Error: fluid-fluid interface is not allowed in function %s\n", __func__);
     }
@@ -275,7 +275,7 @@ void grt_RT_matrix_ls_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M
 }
 
 
-void grt_RT_matrix_ls_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_RT_matrix_ls_SH(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     // TEMPORARY!!!!!!
     // 之后不再使用mu或其它变量来判断是否为液体，直接定义一个新的数组
@@ -309,7 +309,7 @@ void grt_RT_matrix_ls_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
 
 
 
-void grt_RT_matrix_ss_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_RT_matrix_ss_PSV(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     MODEL_2LAYS_ATTRIB(cplx_t, xa);
     MODEL_2LAYS_ATTRIB(cplx_t, xb);
@@ -386,7 +386,7 @@ void grt_RT_matrix_ss_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M
 }
 
 
-void grt_RT_matrix_ss_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_RT_matrix_ss_SH(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     MODEL_2LAYS_ATTRIB(cplx_t, xb);
     MODEL_2LAYS_ATTRIB(cplx_t, mu);
@@ -404,7 +404,7 @@ void grt_RT_matrix_ss_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
 
 
 
-void grt_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     // TEMPORARY!!!!!!
     // 之后不再使用mu或其它变量来判断是否为液体，直接定义一个新的数组
@@ -423,7 +423,7 @@ void grt_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
 }
 
 
-void grt_RT_matrix_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_RT_matrix_SH(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     // TEMPORARY!!!!!!
     // 之后不再使用mu或其它变量来判断是否为液体，直接定义一个新的数组
@@ -442,7 +442,7 @@ void grt_RT_matrix_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
 }
 
 
-void grt_delay_RT_matrix(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_delay_RT_matrix(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     real_t thk = mod1d->Thk[iy-1];
     cplx_t xa1 = mod1d->xa[iy-1];
@@ -475,7 +475,7 @@ void grt_delay_RT_matrix(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
 
 void grt_get_layer_D(
     cplx_t xa, cplx_t xb, cplx_t kbkb, cplx_t mu,
-    cplx_t omega, real_t rho, real_t k, cplx_t D[4][4], bool inverse, MYINT liquid_invtype)
+    cplx_t omega, real_t rho, real_t k, cplx_t D[4][4], bool inverse, int liquid_invtype)
 {
     // 第iy层物理量
     cplx_t Omg;
@@ -491,8 +491,8 @@ void grt_get_layer_D(
             D[1][0] = 2*mu*Omg*k*xa;      D[1][1] = -2*k*mu*k*xa*k*xb;   D[1][2] = -k*k*xa;              D[1][3] = k*xa*k*xb;   
             D[2][0] = -2*k*mu*k*xa*k*xb;  D[2][1] = -2*mu*Omg*k*xb;      D[2][2] = k*xa*k*xb;            D[2][3] = k*k*xb;   
             D[3][0] = -2*mu*Omg*k*xa;     D[3][1] = -2*k*mu*k*xa*k*xb;   D[3][2] = k*k*xa;               D[3][3] = k*xa*k*xb;
-            for(MYINT i=0; i<4; ++i){
-                for(MYINT j=0; j<4; ++j){
+            for(int i=0; i<4; ++i){
+                for(int j=0; j<4; ++j){
                     D[i][j] /= - 2*mu*kbkb*k*xa*k*xb;
                 }
             }
@@ -510,8 +510,8 @@ void grt_get_layer_D(
                 D[1][0] = 0.0;                D[1][1] = 0.0;                 D[1][2] = 0.0;                  D[1][3] = 0.0;   
                 D[2][0] = xa;                 D[2][1] = - (1.0 + Omg*Omg);   D[2][2] = - xa * Omg;           D[2][3] = 0.0;   
                 D[3][0] = 0.0;                D[3][1] = 0.0;                 D[3][2] = 0.0;                  D[3][3] = 0.0;
-                for(MYINT i=0; i<4; ++i){
-                    for(MYINT j=0; j<4; ++j){
+                for(int i=0; i<4; ++i){
+                    for(int j=0; j<4; ++j){
                         D[i][j] /= 2*k*xa*(1.0 + Omg*Omg);
                     }
                 }
@@ -646,8 +646,8 @@ void grt_get_layer_T(
     } else{
         T[0][0] = mu*k*xb;      T[0][1] = 1;
         T[1][0] = mu*k*xb;      T[1][1] = - 1;
-        for(MYINT i=0; i<2; ++i){
-            for(MYINT j=0; j<2; ++j){
+        for(int i=0; i<2; ++i){
+            for(int j=0; j<2; ++j){
                 T[i][j] *= 1/(2*mu*k*k*xb);
             }
         }
@@ -698,7 +698,7 @@ void grt_RT_matrix_from_4x4(
     cplx_t omega, real_t thk,
     real_t k, 
     cplx_t RD[2][2], cplx_t *RDL, cplx_t RU[2][2], cplx_t *RUL, 
-    cplx_t TD[2][2], cplx_t *TDL, cplx_t TU[2][2], cplx_t *TUL, MYINT *stats)
+    cplx_t TD[2][2], cplx_t *TDL, cplx_t TU[2][2], cplx_t *TUL, int *stats)
 {
     cplx_t D1_inv[4][4], D2[4][4], Q[4][4];
 

--- a/pygrt/C_extension/src/dynamic/propagate.c
+++ b/pygrt/C_extension/src/dynamic/propagate.c
@@ -32,17 +32,17 @@ void grt_kernel(
     bool calc_uiz, cplx_t QWV_uiz[GRT_SRC_M_NUM][GRT_QWV_NUM])
 {
     // 初始化qwv为0
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        for(MYINT j=0; j<GRT_QWV_NUM; ++j){
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int j=0; j<GRT_QWV_NUM; ++j){
             QWV[i][j] = 0.0;
             if(calc_uiz)  QWV_uiz[i][j] = 0.0;
         }
     }
 
     bool ircvup = mod1d->ircvup;
-    MYINT isrc = mod1d->isrc; // 震源所在虚拟层位, isrc>=1
-    MYINT ircv = mod1d->ircv; // 接收点所在虚拟层位, ircv>=1, ircv != isrc
-    MYINT imin, imax; // 相对浅层深层层位
+    size_t isrc = mod1d->isrc; // 震源所在虚拟层位, isrc>=1
+    size_t ircv = mod1d->ircv; // 接收点所在虚拟层位, ircv>=1, ircv != isrc
+    size_t imin, imax; // 相对浅层深层层位
     imin = GRT_MIN(mod1d->isrc, mod1d->ircv);
     imax = GRT_MAX(mod1d->isrc, mod1d->ircv);
 
@@ -68,7 +68,7 @@ void grt_kernel(
     cplx_t uiz_R_EV[2][2], uiz_R_EVL;
 
     // 从顶到底进行矩阵递推, 公式(5.5.3)
-    for(MYINT iy=1; iy<mod1d->n; ++iy){ // 因为n>=3, 故一定会进入该循环
+    for(size_t iy=1; iy<mod1d->n; ++iy){ // 因为n>=3, 故一定会进入该循环
 
         // 定义物理层内的反射透射系数矩阵
         grt_init_RT_matrix(M);
@@ -158,7 +158,7 @@ void grt_kernel(
         tmpRL = M_FB->invTL  / (1.0 - M_BL->RDL * M_FB->RUL);
         tmpRL2 = R_EVL * tmpRL;
 
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i){
             grt_construct_qwv(ircvup, tmp2x2, tmpRL2, M_BL->RD, M_BL->RDL, src_coef_PSV[i], src_coef_SH[i], QWV[i]);
         }
 
@@ -169,7 +169,7 @@ void grt_kernel(
             grt_cmat2x2_mul(uiz_R_EV, tmp2x2_uiz, tmp2x2_uiz);
             tmpRL2 = uiz_R_EVL * tmpRL;
 
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
                 grt_construct_qwv(ircvup, tmp2x2_uiz, tmpRL2, M_BL->RD, M_BL->RDL, src_coef_PSV[i], src_coef_SH[i], QWV_uiz[i]);
             }    
         }
@@ -197,7 +197,7 @@ void grt_kernel(
         tmpRL = M_AL->invTL / (1.0 - M_FA->RUL * M_AL->RDL);
         tmpRL2 = R_EVL * tmpRL;
 
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i){
             grt_construct_qwv(ircvup, tmp2x2, tmpRL2, M_FA->RU, M_FA->RUL, src_coef_PSV[i], src_coef_SH[i], QWV[i]);
         }
 
@@ -208,7 +208,7 @@ void grt_kernel(
             grt_cmat2x2_mul(uiz_R_EV, tmp2x2_uiz, tmp2x2_uiz);
             tmpRL2 = uiz_R_EVL * tmpRL;
             
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
                 grt_construct_qwv(ircvup, tmp2x2_uiz, tmpRL2, M_FA->RU, M_FA->RUL, src_coef_PSV[i], src_coef_SH[i], QWV_uiz[i]);
             }
         }
@@ -223,7 +223,7 @@ void grt_kernel(
     // 当震源和场点均位于地表时，可理论验证DS分量恒为0，这里直接赋0以避免后续的精度干扰
     if(mod1d->depsrc == 0.0 && mod1d->deprcv == 0.0)
     {
-        for(MYINT c=0; c<GRT_QWV_NUM; ++c){
+        for(int c=0; c<GRT_QWV_NUM; ++c){
             QWV[GRT_SRC_M_DS_INDEX][c] = 0.0;
             if(calc_uiz)  QWV_uiz[GRT_SRC_M_DS_INDEX][c] = 0.0;
         }

--- a/pygrt/C_extension/src/dynamic/source.c
+++ b/pygrt/C_extension/src/dynamic/source.c
@@ -21,15 +21,15 @@
 void grt_source_coef_PSV(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM-1][2])
 {
     // 先全部赋0 
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        for(MYINT j=0; j<GRT_QWV_NUM-1; ++j){
-            for(MYINT p=0; p<2; ++p){
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int j=0; j<GRT_QWV_NUM-1; ++j){
+            for(int p=0; p<2; ++p){
                 coef[i][j][p] = 0.0;
             }
         }
     }
 
-    MYINT isrc = mod1d->isrc;
+    size_t isrc = mod1d->isrc;
     cplx_t xa = mod1d->xa[isrc];
     cplx_t caca = mod1d->caca[isrc];
     cplx_t xb = mod1d->xb[isrc];
@@ -70,13 +70,13 @@ void grt_source_coef_PSV(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GR
 void grt_source_coef_SH(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][2])
 {
     // 先全部赋0 
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        for(MYINT p=0; p<2; ++p){
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int p=0; p<2; ++p){
             coef[i][p] = 0.0;
         }
     }
 
-    MYINT isrc = mod1d->isrc;
+    size_t isrc = mod1d->isrc;
     cplx_t xb = mod1d->xb[isrc];
     cplx_t cbcb = mod1d->cbcb[isrc];
     real_t k = mod1d->k;

--- a/pygrt/C_extension/src/grt.c
+++ b/pygrt/C_extension/src/grt.c
@@ -56,7 +56,7 @@ printf("\n"
 "\n\n");
 printf("GRT supports the following modules:\n"
 "----------------------------------------------------------------\n");
-for (MYINT n = 0; GRT_Module_Names[n] != NULL; ++n) {
+for (size_t n = 0; GRT_Module_Names[n] != NULL; ++n) {
     const char *name = GRT_Module_Names[n];
     printf("    %-s\n", name);
 }

--- a/pygrt/C_extension/src/static/grt_static_rotation.c
+++ b/pygrt/C_extension/src/static/grt_static_rotation.c
@@ -85,8 +85,8 @@ int static_rotation_main(int argc, char **argv){
 
     // 读入数据是否旋转到ZNE
     {
-        MYINT rot2ZNE_int;
-        NC_CHECK(GRT_NC_FUNC_MYINT(nc_get_att) (in_ncid, NC_GLOBAL, "rot2ZNE", &rot2ZNE_int));
+        int rot2ZNE_int;
+        NC_CHECK(nc_get_att_int(in_ncid, NC_GLOBAL, "rot2ZNE", &rot2ZNE_int));
         rot2ZNE = !(rot2ZNE_int == 0);
     }
 
@@ -94,8 +94,8 @@ int static_rotation_main(int argc, char **argv){
     const char *chs = (rot2ZNE)? GRT_ZNE_CODES : GRT_ZRT_CODES;
 
     // 读入的数据是否有位移偏导
-    MYINT calc_upar;
-    NC_CHECK(GRT_NC_FUNC_MYINT(nc_get_att) (in_ncid, NC_GLOBAL, "calc_upar", &calc_upar));
+    int calc_upar;
+    NC_CHECK(nc_get_att_int(in_ncid, NC_GLOBAL, "calc_upar", &calc_upar));
     if(calc_upar == 0){
         GRTRaiseError("[%s] Input grid didn't have displacement derivatives.", command);
     }

--- a/pygrt/C_extension/src/static/grt_static_strain.c
+++ b/pygrt/C_extension/src/static/grt_static_strain.c
@@ -82,8 +82,8 @@ int static_strain_main(int argc, char **argv){
 
     // 读入数据是否旋转到ZNE
     {
-        MYINT rot2ZNE_int;
-        NC_CHECK(GRT_NC_FUNC_MYINT(nc_get_att) (in_ncid, NC_GLOBAL, "rot2ZNE", &rot2ZNE_int));
+        int rot2ZNE_int;
+        NC_CHECK(nc_get_att_int(in_ncid, NC_GLOBAL, "rot2ZNE", &rot2ZNE_int));
         rot2ZNE = !(rot2ZNE_int == 0);
     }
 
@@ -91,8 +91,8 @@ int static_strain_main(int argc, char **argv){
     const char *chs = (rot2ZNE)? GRT_ZNE_CODES : GRT_ZRT_CODES;
 
     // 读入的数据是否有位移偏导
-    MYINT calc_upar;
-    NC_CHECK(GRT_NC_FUNC_MYINT(nc_get_att) (in_ncid, NC_GLOBAL, "calc_upar", &calc_upar));
+    int calc_upar;
+    NC_CHECK(nc_get_att_int(in_ncid, NC_GLOBAL, "calc_upar", &calc_upar));
     if(calc_upar == 0){
         GRTRaiseError("[%s] Input grid didn't have displacement derivatives.", command);
     }

--- a/pygrt/C_extension/src/static/grt_static_stress.c
+++ b/pygrt/C_extension/src/static/grt_static_stress.c
@@ -83,8 +83,8 @@ int static_stress_main(int argc, char **argv){
 
     // 读入数据是否旋转到ZNE
     {
-        MYINT rot2ZNE_int;
-        NC_CHECK(GRT_NC_FUNC_MYINT(nc_get_att) (in_ncid, NC_GLOBAL, "rot2ZNE", &rot2ZNE_int));
+        int rot2ZNE_int;
+        NC_CHECK(nc_get_att_int(in_ncid, NC_GLOBAL, "rot2ZNE", &rot2ZNE_int));
         rot2ZNE = !(rot2ZNE_int == 0);
     }
 
@@ -92,8 +92,8 @@ int static_stress_main(int argc, char **argv){
     const char *chs = (rot2ZNE)? GRT_ZNE_CODES : GRT_ZRT_CODES;
 
     // 读入的数据是否有位移偏导
-    MYINT calc_upar;
-    NC_CHECK(GRT_NC_FUNC_MYINT(nc_get_att) (in_ncid, NC_GLOBAL, "calc_upar", &calc_upar));
+    int calc_upar;
+    NC_CHECK(nc_get_att_int(in_ncid, NC_GLOBAL, "calc_upar", &calc_upar));
     if(calc_upar == 0){
         GRTRaiseError("[%s] Input grid didn't have displacement derivatives.", command);
     }

--- a/pygrt/C_extension/src/static/grt_static_syn.c
+++ b/pygrt/C_extension/src/static/grt_static_syn.c
@@ -64,7 +64,7 @@ typedef struct {
     real_t srcRadi[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
 
     // 最终要计算的震源类型
-    MYINT computeType;
+    int computeType;
     char s_computeType[3];
 
 } GRT_MODULE_CTRL;
@@ -334,8 +334,8 @@ int static_syn_main(int argc, char **argv){
     if(Ctrl->S.mult_src_mu) Ctrl->S.M0 *= src_mu;
 
     // 读入的数据是否有位移偏导
-    MYINT calc_upar;
-    NC_CHECK(GRT_NC_FUNC_MYINT(nc_get_att) (in_ncid, NC_GLOBAL, "calc_upar", &calc_upar));
+    int calc_upar;
+    NC_CHECK(nc_get_att_int(in_ncid, NC_GLOBAL, "calc_upar", &calc_upar));
     if(Ctrl->e.active && calc_upar == 0){
         GRTRaiseError("[%s] Input grid didn't have displacement derivatives, you can't set -e.", command);
     }
@@ -344,7 +344,7 @@ int static_syn_main(int argc, char **argv){
     NC_CHECK(NC_FUNC_REAL(nc_put_att) (out_ncid, NC_GLOBAL, "src_va", NC_REAL, 1, &src_va));
     NC_CHECK(NC_FUNC_REAL(nc_put_att) (out_ncid, NC_GLOBAL, "src_vb", NC_REAL, 1, &src_vb));
     NC_CHECK(NC_FUNC_REAL(nc_put_att) (out_ncid, NC_GLOBAL, "src_rho", NC_REAL, 1, &src_rho));
-    NC_CHECK(GRT_NC_FUNC_MYINT(nc_put_att) (out_ncid, NC_GLOBAL, "calc_upar", GRT_NC_MYINT, 1, &calc_upar));
+    NC_CHECK(nc_put_att_int(out_ncid, NC_GLOBAL, "calc_upar", NC_INT, 1, &calc_upar));
     {
         real_t rcv_va=0.0, rcv_vb=0.0, rcv_rho=0.0;
         NC_CHECK(NC_FUNC_REAL(nc_get_att) (in_ncid, NC_GLOBAL, "rcv_va", &rcv_va));
@@ -357,8 +357,8 @@ int static_syn_main(int argc, char **argv){
 
     // 是否旋转到ZNE记录到全局属性
     {
-        MYINT rot2ZNE_int = rot2ZNE;
-        NC_CHECK(GRT_NC_FUNC_MYINT(nc_put_att) (out_ncid, NC_GLOBAL, "rot2ZNE", GRT_NC_MYINT, 1, &rot2ZNE_int));
+        int rot2ZNE_int = rot2ZNE;
+        NC_CHECK(nc_put_att_int(out_ncid, NC_GLOBAL, "rot2ZNE", NC_INT, 1, &rot2ZNE_int));
     }
 
     // 震源类型写入全局属性

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -41,17 +41,17 @@
  * @param[out]   grn            三分量结果，浮点数数组
  */
 static void recordin_GRN(
-    MYINT nr, cplx_t coef, cplx_t sum_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
+    size_t nr, cplx_t coef, cplx_t sum_J[nr][GRT_SRC_M_NUM][GRT_INTEG_NUM],
     real_t grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM]
 ){
     // 局部变量，将某个频点的格林函数谱临时存放
     cplx_t (*tmp_grn)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (cplx_t(*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM])calloc(nr, sizeof(*tmp_grn));
 
-    for(MYINT ir=0; ir<nr; ++ir){
+    for(size_t ir=0; ir<nr; ++ir){
         grt_merge_Pk(sum_J[ir], tmp_grn[ir]);
 
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i) {
-            for(MYINT c=0; c<GRT_CHANNEL_NUM; ++c){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i) {
+            for(int c=0; c<GRT_CHANNEL_NUM; ++c){
                 grn[ir][i][c] = creal(coef * tmp_grn[ir][i][c]);
             }
 
@@ -64,7 +64,7 @@ static void recordin_GRN(
 
 
 void grt_integ_static_grn(
-    GRT_MODEL1D *mod1d, MYINT nr, real_t *rs, real_t vmin_ref, real_t keps, real_t k0, real_t Length,
+    GRT_MODEL1D *mod1d, size_t nr, real_t *rs, real_t vmin_ref, real_t keps, real_t k0, real_t Length,
     real_t filonLength, real_t safilonTol, real_t filonCut, 
 
     // 返回值，代表Z、R、T分量
@@ -105,9 +105,9 @@ void grt_integ_static_grn(
     // 在文件名后加后缀，区分不同震中距
     char **ptam_fstatsdir = (char**)calloc(nr, sizeof(char*));
     if(needfstats && vmin_ref < 0.0){
-        for(MYINT ir=0; ir<nr; ++ir){
+        for(size_t ir=0; ir<nr; ++ir){
             // 新建文件夹目录 
-            GRT_SAFE_ASPRINTF(&ptam_fstatsdir[ir], "%s/PTAM_%04d_%.5e", statsstr, ir, rs[ir]);
+            GRT_SAFE_ASPRINTF(&ptam_fstatsdir[ir], "%s/PTAM_%04zu_%.5e", statsstr, ir, rs[ir]);
             if(mkdir(ptam_fstatsdir[ir], 0777) != 0){
                 if(errno != EEXIST){
                     printf("Unable to create folder %s. Error code: %d\n", ptam_fstatsdir[ir], errno);
@@ -127,9 +127,9 @@ void grt_integ_static_grn(
             GRT_SAFE_ASPRINTF(&fname, "%s/K", statsstr);
             fstats = fopen(fname, "wb");
         }
-        for(MYINT ir=0; ir<nr; ++ir){
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-                for(MYINT v=0; v<GRT_INTEG_NUM; ++v){
+        for(size_t ir=0; ir<nr; ++ir){
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
+                for(int v=0; v<GRT_INTEG_NUM; ++v){
                     sum_J[ir][i][v] = 0.0;
                     if(calc_upar){
                         sum_uiz_J[ir][i][v] = 0.0;
@@ -204,7 +204,7 @@ void grt_integ_static_grn(
     GRT_SAFE_FREE_PTR_ARRAY(ptam_fstatsdir, nr);
 
     if(fstats!=NULL) fclose(fstats);
-    for(MYINT ir=0; ir<nr; ++ir){
+    for(size_t ir=0; ir<nr; ++ir){
         if(ptam_fstatsnr[ir][0]!=NULL){
             fclose(ptam_fstatsnr[ir][0]);
         }

--- a/pygrt/C_extension/src/static/static_layer.c
+++ b/pygrt/C_extension/src/static/static_layer.c
@@ -60,7 +60,7 @@ void grt_static_wave2qwv_z_REV_PSV(
     const cplx_t R[2][2], cplx_t R_EV[2][2])
 {
     real_t k = mod1d->k;
-    MYINT ircv = mod1d->ircv;
+    size_t ircv = mod1d->ircv;
     cplx_t delta1 = mod1d->delta[ircv];
 
     // 新推导公式
@@ -88,7 +88,7 @@ void grt_static_wave2qwv_z_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R
 }
 
 
-void grt_static_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_static_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     MODEL_2LAYS_ATTRIB(cplx_t, mu);
     MODEL_2LAYS_ATTRIB(cplx_t, delta);
@@ -130,7 +130,7 @@ void grt_static_RT_matrix_PSV(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRI
 }
 
 
-void grt_static_RT_matrix_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_static_RT_matrix_SH(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     MODEL_2LAYS_ATTRIB(cplx_t, mu);
     
@@ -148,7 +148,7 @@ void grt_static_RT_matrix_SH(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX
 }
 
 
-void grt_static_delay_RT_matrix(const GRT_MODEL1D *mod1d, const MYINT iy, RT_MATRIX *M)
+void grt_static_delay_RT_matrix(const GRT_MODEL1D *mod1d, const size_t iy, RT_MATRIX *M)
 {
     real_t thk = mod1d->Thk[iy-1];
     real_t k = mod1d->k;

--- a/pygrt/C_extension/src/static/static_propagate.c
+++ b/pygrt/C_extension/src/static/static_propagate.c
@@ -30,8 +30,8 @@ void grt_static_kernel(
     bool calc_uiz, cplx_t QWV_uiz[GRT_SRC_M_NUM][GRT_QWV_NUM])
 {   
     // 初始化qwv为0
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        for(MYINT j=0; j<GRT_QWV_NUM; ++j){
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int j=0; j<GRT_QWV_NUM; ++j){
             QWV[i][j] = 0.0;
             if(calc_uiz)  QWV_uiz[i][j] = 0.0;
         }
@@ -39,9 +39,9 @@ void grt_static_kernel(
 
 
     bool ircvup = mod1d->ircvup;
-    MYINT isrc = mod1d->isrc; // 震源所在虚拟层位, isrc>=1
-    MYINT ircv = mod1d->ircv; // 接收点所在虚拟层位, ircv>=1, ircv != isrc
-    MYINT imin, imax; // 相对浅层深层层位
+    size_t isrc = mod1d->isrc; // 震源所在虚拟层位, isrc>=1
+    size_t ircv = mod1d->ircv; // 接收点所在虚拟层位, ircv>=1, ircv != isrc
+    size_t imin, imax; // 相对浅层深层层位
     imin = GRT_MIN(isrc, ircv);
     imax = GRT_MAX(isrc, ircv);
 
@@ -67,7 +67,7 @@ void grt_static_kernel(
     cplx_t uiz_R_EV[2][2], uiz_R_EVL;
 
     // 从顶到底进行矩阵递推, 公式(5.5.3)
-    for(MYINT iy=1; iy<mod1d->n; ++iy){ // 因为n>=3, 故一定会进入该循环
+    for(size_t iy=1; iy<mod1d->n; ++iy){ // 因为n>=3, 故一定会进入该循环
 
         // 定义物理层内的反射透射系数矩阵
         grt_init_RT_matrix(M);
@@ -143,7 +143,7 @@ void grt_static_kernel(
         grt_cmat2x2_mul(R_EV, tmp2x2, tmp2x2);
         tmpRL = R_EVL * M_FB->invTL  / (1.0 - M_BL->RDL * M_FB->RUL);
 
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
+        for(size_t i=0; i<GRT_SRC_M_NUM; ++i){
             grt_construct_qwv(ircvup, tmp2x2, tmpRL, M_BL->RD, M_BL->RDL, src_coef_PSV[i], src_coef_SH[i], QWV[i]);
         }
         
@@ -154,7 +154,7 @@ void grt_static_kernel(
             grt_cmat2x2_mul(uiz_R_EV, tmp2x2_uiz, tmp2x2_uiz);
             tmpRL_uiz = tmpRL / R_EVL * uiz_R_EVL;
             
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
                 grt_construct_qwv(ircvup, tmp2x2_uiz, tmpRL_uiz, M_BL->RD, M_BL->RDL, src_coef_PSV[i], src_coef_SH[i], QWV_uiz[i]);
             }    
         }
@@ -179,7 +179,7 @@ void grt_static_kernel(
         grt_cmat2x2_mul(R_EV, tmp2x2, tmp2x2);
         tmpRL = R_EVL * M_AL->invTL / (1.0 - M_FA->RUL * M_AL->RDL);
         
-        for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int i=0; i<GRT_SRC_M_NUM; ++i){
             grt_construct_qwv(ircvup, tmp2x2, tmpRL, M_FA->RU, M_FA->RUL, src_coef_PSV[i], src_coef_SH[i], QWV[i]);
         }
 
@@ -189,7 +189,7 @@ void grt_static_kernel(
             grt_cmat2x2_mul(uiz_R_EV, tmp2x2_uiz, tmp2x2_uiz);
             tmpRL_uiz = tmpRL / R_EVL * uiz_R_EVL;
             
-            for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
+            for(int i=0; i<GRT_SRC_M_NUM; ++i){
                 grt_construct_qwv(ircvup, tmp2x2_uiz, tmpRL_uiz, M_FA->RU, M_FA->RUL, src_coef_PSV[i], src_coef_SH[i], QWV_uiz[i]);
             }
         }

--- a/pygrt/C_extension/src/static/static_source.c
+++ b/pygrt/C_extension/src/static/static_source.c
@@ -19,15 +19,15 @@
 void grt_static_source_coef_PSV(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM-1][2])
 {
     // 先全部赋0 
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        for(MYINT j=0; j<GRT_QWV_NUM-1; ++j){
-            for(MYINT p=0; p<2; ++p){
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int j=0; j<GRT_QWV_NUM-1; ++j){
+            for(int p=0; p<2; ++p){
                 coef[i][j][p] = 0.0;
             }
         }
     }
 
-    MYINT isrc = mod1d->isrc;
+    size_t isrc = mod1d->isrc;
     cplx_t delta = mod1d->delta[isrc];
     real_t k = mod1d->k;
 
@@ -63,8 +63,8 @@ void grt_static_source_coef_SH(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_N
     real_t k = mod1d->k;
     
     // 先全部赋0 
-    for(MYINT i=0; i<GRT_SRC_M_NUM; ++i){
-        for(MYINT p=0; p<2; ++p){
+    for(int i=0; i<GRT_SRC_M_NUM; ++i){
+        for(int p=0; p<2; ++p){
             coef[i][p] = 0.0;
         }
     }

--- a/pygrt/C_extension/src/travt/grt_travt.c
+++ b/pygrt/C_extension/src/travt/grt_travt.c
@@ -36,7 +36,7 @@ typedef struct {
         bool active;
         char **s_rs;
         real_t *rs;
-        MYINT nr;
+        size_t nr;
     } R;
 } GRT_MODULE_CTRL;
 
@@ -504,7 +504,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                 }
                 // 转为浮点数
                 Ctrl->R.rs = (real_t*)realloc(Ctrl->R.rs, sizeof(real_t)*(Ctrl->R.nr));
-                for(MYINT i=0; i<Ctrl->R.nr; ++i){
+                for(size_t i=0; i<Ctrl->R.nr; ++i){
                     Ctrl->R.rs[i] = atof(Ctrl->R.s_rs[i]);
                     if(Ctrl->R.rs[i] < 0.0){
                         GRTBadOptionError(command, R, "Can't set negative epicentral distance(%f).", Ctrl->R.rs[i]);
@@ -541,7 +541,7 @@ int travt_main(int argc, char **argv){
     printf("------------------------------------------------\n");
     printf(" Distance(km)     Tp(secs)         Ts(secs)     \n");
     double travtP=-1, travtS=-1;
-    for(int i=0; i<Ctrl->R.nr; ++i){
+    for(size_t i=0; i<Ctrl->R.nr; ++i){
         travtP = grt_compute_travt1d(
         mod1d->Thk, mod1d->Va, mod1d->n, mod1d->isrc, mod1d->ircv, Ctrl->R.rs[i]);
         travtS = grt_compute_travt1d(

--- a/pygrt/c_interfaces.py
+++ b/pygrt/c_interfaces.py
@@ -10,7 +10,7 @@
 
 import os
 from ctypes import \
-    c_double, c_float, c_int, c_bool, c_char_p, c_void_p,\
+    c_double, c_float, c_int, c_size_t, c_bool, c_char_p, c_void_p,\
     POINTER, cdll
 
 from .c_structures import * 
@@ -30,8 +30,8 @@ libgrt = cdll.LoadLibrary(
 C_grt_integ_grn_spec = libgrt.grt_integ_grn_spec
 """C库中计算格林函数的主函数 integ_grn_spec, 详见C API同名函数"""
 C_grt_integ_grn_spec.argtypes = [
-    POINTER(c_GRT_MODEL1D), c_int, c_int, PREAL,       
-    c_int, PREAL, REAL,
+    POINTER(c_GRT_MODEL1D), c_size_t, c_size_t, PREAL,       
+    c_size_t, PREAL, REAL,
     REAL, REAL, REAL, REAL, REAL, REAL, REAL, REAL,
     c_bool,
 
@@ -44,8 +44,8 @@ C_grt_integ_grn_spec.argtypes = [
     POINTER((PCPLX*CHANNEL_NUM)*SRC_M_NUM),
 
     c_char_p,
-    c_int, 
-    POINTER(c_int)
+    c_size_t, 
+    POINTER(c_size_t)
 ]
 
 
@@ -53,7 +53,7 @@ C_grt_integ_static_grn = libgrt.grt_integ_static_grn
 """计算静态格林函数"""
 C_grt_integ_static_grn.restype = None
 C_grt_integ_static_grn.argtypes = [
-    POINTER(c_GRT_MODEL1D), c_int, PREAL, REAL, REAL, REAL, REAL, 
+    POINTER(c_GRT_MODEL1D), c_size_t, PREAL, REAL, REAL, REAL, REAL, 
     REAL, REAL, REAL, 
     POINTER((REAL*CHANNEL_NUM)*SRC_M_NUM),
     c_bool,

--- a/pygrt/c_structures.py
+++ b/pygrt/c_structures.py
@@ -95,11 +95,11 @@ class c_GRT_MODEL1D(Structure):
 
     """
     _fields_ = [
-        ('n', c_int), 
+        ('n', c_size_t), 
         ("depsrc", REAL),
         ("deprcv", REAL),
-        ('isrc', c_int),
-        ('ircv', c_int),
+        ('isrc', c_size_t),
+        ('ircv', c_size_t),
         ('ircvup', c_bool),
         ('io_depth', c_bool),
 

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -327,7 +327,7 @@ class PyModel1D:
             statsidxs = np.array([-1])
 
         statsidxs = np.array(statsidxs)
-        c_statsidxs = npct.as_ctypes(np.array(statsidxs).astype('i'))
+        c_statsidxs = npct.as_ctypes(np.array(statsidxs).astype(np.uint64))   # size_t
         nstatsidxs = len(statsidxs)
 
 


### PR DESCRIPTION
For integers that represent quantities or indices, use `size_t`, otherwise `int` or `ssize_t`.