### PR TITLE
REFAC: move Generalized R/T matrix to struct `GRT_MODEL1D`

### DIFF
--- a/pygrt/C_extension/include/grt/common/RT_matrix.h
+++ b/pygrt/C_extension/include/grt/common/RT_matrix.h
@@ -13,8 +13,7 @@
 
 #include "grt/common/const.h"
 
-
-/** 应该把 PSV 和 SH 的小矩阵统一放在一个结构体中管理 */
+/* 使用结构体管理上行和下行的 R/T 矩阵 */
 typedef struct {
     cplx_t RD[2][2];     ///< P-SV 下传反射系数矩阵
     cplx_t RU[2][2];     ///< P-SV 上传反射系数矩阵

--- a/pygrt/C_extension/include/grt/common/kernel.h
+++ b/pygrt/C_extension/include/grt/common/kernel.h
@@ -17,7 +17,7 @@
  * 计算核函数的函数指针，动态与静态的接口一致
  */
 typedef void (*GRT_KernelFunc) (
-    const GRT_MODEL1D *mod1d, cplx_t QWV[GRT_SRC_M_NUM][GRT_QWV_NUM],
+    GRT_MODEL1D *mod1d, const real_t k, cplx_t QWV[GRT_SRC_M_NUM][GRT_QWV_NUM],
     bool calc_uiz, cplx_t QWV_uiz[GRT_SRC_M_NUM][GRT_QWV_NUM]);
 
 

--- a/pygrt/C_extension/include/grt/common/model.h
+++ b/pygrt/C_extension/include/grt/common/model.h
@@ -11,6 +11,7 @@
 #include <complex.h>
 #include <stdbool.h>
 #include "grt/common/const.h"
+#include "grt/common/RT_matrix.h"
 
 
 /** 1D 模型结构体，包括多个水平层，以及复数形式的弹性参数 */
@@ -49,6 +50,25 @@ typedef struct {
 
     /* 状态变量，非 0 为异常值 */
     int stats;
+
+    /* 根据震源和台站划分的广义 R/T 系数 */
+    RT_MATRIX M_AL;
+    RT_MATRIX M_BL;
+    RT_MATRIX M_RS;
+    RT_MATRIX M_FA;
+    RT_MATRIX M_FB;
+
+    /* 自由表面的反射系数矩阵，仅 RU, RUL 有用 */
+    RT_MATRIX M_top;
+
+    /* 接收点处的接收矩阵 (转为位移u和位移导数uiz的(B_m, C_m, P_m)系分量) */
+    cplx_t R_EV[2][2];
+    cplx_t R_EVL;
+    cplx_t uiz_R_EV[2][2];
+    cplx_t uiz_R_EVL;
+
+    /* 震源处的震源系数 */
+    cplx_t src_coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2];  ///< 震源系数 \f$ P_m, SV_m, SH_m \f$
 
 } GRT_MODEL1D;
 

--- a/pygrt/C_extension/include/grt/dynamic/layer.h
+++ b/pygrt/C_extension/include/grt/dynamic/layer.h
@@ -20,56 +20,48 @@
 /**
  * 计算自由表面的反射系数，公式(5.3.10-14) 
  * 
- * @param[in]     mod1d          模型结构体指针
- * @param[out]    M              R/T矩阵，仅填充RU
+ * 
+ * @param[in,out]     mod1d          模型结构体指针，结果保存在 Mtop
  * 
  */
-void grt_topfree_RU(const GRT_MODEL1D *mod1d, RT_MATRIX *M);
+void grt_topfree_RU(GRT_MODEL1D *mod1d);
 
 
 /**
  * 计算接收点位置的 P-SV 波接收矩阵，将波场转为位移，公式(5.2.19) + (5.7.7,25)
  * 
- * @param[in]     mod1d           模型结构体指针
- * @param[in]     R               P-SV波场
- * @param[out]    R_EV            P-SV接收函数矩阵
+ * @param[in,out]     mod1d           模型结构体指针，结果保存在 R_EV
  * 
  */
-void grt_wave2qwv_REV_PSV(const GRT_MODEL1D *mod1d, cplx_t R[2][2], cplx_t R_EV[2][2]);
+void grt_wave2qwv_REV_PSV(GRT_MODEL1D *mod1d);
 
 /**
  * 计算接收点位置的 SH 波接收矩阵，将波场转为位移，公式(5.2.19) + (5.7.7,25)
  * 
- * @param[in]     mod1d           模型结构体指针
- * @param[in]     RL              SH波场
- * @param[out]    R_EVL           SH接收函数值
+ * @param[in,out]     mod1d           模型结构体指针，结果保存在 R_EVL
  * 
  */
-void grt_wave2qwv_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL);
+void grt_wave2qwv_REV_SH(GRT_MODEL1D *mod1d);
 
 
 /**
  * 计算接收点位置的ui_z的 P-SV 波接收矩阵，即将波场转为ui_z。
  * 公式本质是推导ui_z关于q_m, w_m, v_m的连接矩阵（就是应力推导过程的一部分）
  * 
- * @param[in]     mod1d           模型结构体指针
- * @param[in]     R               P-SV波场
- * @param[out]    R_EV            P-SV接收函数矩阵
+ * @param[in,out]     mod1d           模型结构体指针，结果保存在 uiz_R_EV
  * 
  */
-void grt_wave2qwv_z_REV_PSV(const GRT_MODEL1D *mod1d, const cplx_t R[2][2], cplx_t R_EV[2][2]);
+void grt_wave2qwv_z_REV_PSV(GRT_MODEL1D *mod1d);
 
 
 /**
  * 计算接收点位置的ui_z的 SH 波接收矩阵，即将波场转为ui_z。
  * 公式本质是推导ui_z关于q_m, w_m, v_m的连接矩阵（就是应力推导过程的一部分）
  * 
- * @param[in]     mod1d           模型结构体指针
- * @param[in]     RL              SH波场
- * @param[out]    R_EVL           SH接收函数值
+ * @param[in,out]     mod1d           模型结构体指针，结果保存在 uiz_R_EVL
  * 
  */
-void grt_wave2qwv_z_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL);
+void grt_wave2qwv_z_REV_SH(GRT_MODEL1D *mod1d);
 
 
 /**

--- a/pygrt/C_extension/include/grt/dynamic/source.h
+++ b/pygrt/C_extension/include/grt/dynamic/source.h
@@ -20,14 +20,13 @@
  * 数组形状代表在[i][j][p]时表示i类震源的
  * P(j=0),SV(j=1)的震源系数(分别对应q,w)，且分为下行波(p=0)和上行波(p=1). 
  * 
- * @param[in]     mod1d        模型结构体指针
- * @param[out]    coef         震源系数 \f$ P_m, SV_m, SH_m \f$
+ * @param[in,out]     mod1d        模型结构体指针，结果保存在 src_coef
  * 
  */
-void grt_source_coef(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2]);
+void grt_source_coef(GRT_MODEL1D *mod1d);
 
 /* P-SV 波的震源系数  */
-void grt_source_coef_PSV(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2]);
+void grt_source_coef_PSV(GRT_MODEL1D *mod1d);
 
 /* SH 波的震源系数  */
-void grt_source_coef_SH(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2]);
+void grt_source_coef_SH(GRT_MODEL1D *mod1d);

--- a/pygrt/C_extension/include/grt/static/static_layer.h
+++ b/pygrt/C_extension/include/grt/static/static_layer.h
@@ -22,54 +22,45 @@
 /**
  * 计算自由表面的静态反射系数，公式(6.3.12)
  * 
- * @param[in]     mod1d             模型结构体指针
- * @param[out]    R_tilt            R/T矩阵，仅填充RU
+ * @param[in,out]     mod1d             模型结构体指针，结果保存在 Mtop
  * 
  */
-void grt_static_topfree_RU(const GRT_MODEL1D *mod1d, RT_MATRIX *M);
+void grt_static_topfree_RU(GRT_MODEL1D *mod1d);
 
 
 /**
  * 计算接收点位置的 P-SV 静态接收矩阵，将波场转为位移，公式(6.3.35)
  * 
- * @param[in]      mod1d           模型结构体指针
- * @param[in]      R               P-SV波场
- * @param[out]     R_EV            P-SV接收函数矩阵
+ * @param[in,out]      mod1d           模型结构体指针，结果保存在 R_EV
  * 
  */
-void grt_static_wave2qwv_REV_PSV(const GRT_MODEL1D *mod1d, const cplx_t R[2][2], cplx_t R_EV[2][2]);
+void grt_static_wave2qwv_REV_PSV(GRT_MODEL1D *mod1d);
 
 /**
  * 计算接收点位置的 SH 静态接收矩阵，将波场转为位移，公式(6.3.37)
  * 
- * @param[in]      mod1d           模型结构体指针
- * @param[in]      RL              SH波场
- * @param[out]     R_EVL           SH接收函数值
+ * @param[in,out]      mod1d           模型结构体指针，结果保存在 R_EVL
  * 
  */
-void grt_static_wave2qwv_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL);
+void grt_static_wave2qwv_REV_SH(GRT_MODEL1D *mod1d);
 
 /**
  * 计算接收点位置的ui_z的 P-SV 静态接收矩阵，即将波场转为ui_z。
  * 公式本质是推导ui_z关于q_m, w_m, v_m的连接矩阵（就是应力推导过程的一部分）
  * 
- * @param[in]      mod1d           模型结构体指针
- * @param[in]      R               P-SV波场
- * @param[out]     R_EV            P-SV接收函数矩阵
+ * @param[in,out]      mod1d           模型结构体指针，结果保存在 uiz_R_EV
  * 
  */
-void grt_static_wave2qwv_z_REV_PSV(const GRT_MODEL1D *mod1d, const cplx_t R[2][2], cplx_t R_EV[2][2]);
+void grt_static_wave2qwv_z_REV_PSV(GRT_MODEL1D *mod1d);
 
 /**
  * 计算接收点位置的ui_z的 SH 静态接收矩阵，即将波场转为ui_z。
  * 公式本质是推导ui_z关于q_m, w_m, v_m的连接矩阵（就是应力推导过程的一部分）
  * 
- * @param[in]      mod1d           模型结构体指针
- * @param[in]      RL              SH波场
- * @param[out]     R_EVL           SH接收函数值
+ * @param[in,out]      mod1d           模型结构体指针，结果保存在 uiz_R_EVL
  * 
  */
-void grt_static_wave2qwv_z_REV_SH(const GRT_MODEL1D *mod1d, cplx_t RL, cplx_t *R_EVL);
+void grt_static_wave2qwv_z_REV_SH(GRT_MODEL1D *mod1d);
 
 
 /**

--- a/pygrt/C_extension/include/grt/static/static_source.h
+++ b/pygrt/C_extension/include/grt/static/static_source.h
@@ -19,14 +19,13 @@
  * 数组形状代表在[i][j][p]时表示i类震源的
  * P(j=0),SV(j=1)的震源系数(分别对应q,w)，且分为下行波(p=0)和上行波(p=1). 
  * 
- * @param[in]     mod1d    模型结构体指针
- * @param[out]    coef     震源系数 \f$ P_m, SV_m, SH_m \f$
+ * @param[in,out]     mod1d    模型结构体指针，结果保存在 src_coef
  */
-void grt_static_source_coef(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2]);
+void grt_static_source_coef(GRT_MODEL1D *mod1d);
 
 
 /* P-SV 波的静态震源系数 */
-void grt_static_source_coef_PSV(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2]);
+void grt_static_source_coef_PSV(GRT_MODEL1D *mod1d);
 
 /* SH 波的静态震源系数 */
-void grt_static_source_coef_SH(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2]);
+void grt_static_source_coef_SH(GRT_MODEL1D *mod1d);

--- a/pygrt/C_extension/src/common/dwm.c
+++ b/pygrt/C_extension/src/common/dwm.c
@@ -55,8 +55,7 @@ real_t grt_discrete_integ(
         k += dk; 
 
         // 计算核函数 F(k, w)
-        grt_mod1d_xa_xb(mod1d, k);
-        kerfunc(mod1d, QWV, calc_upar, QWV_uiz); 
+        kerfunc(mod1d, k, QWV, calc_upar, QWV_uiz); 
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
         
         // 记录积分核函数

--- a/pygrt/C_extension/src/common/fim.c
+++ b/pygrt/C_extension/src/common/fim.c
@@ -60,8 +60,7 @@ real_t grt_linear_filon_integ(
         k += dk; 
 
         // 计算核函数 F(k, w)
-        grt_mod1d_xa_xb(mod1d, k);
-        kerfunc(mod1d, QWV, calc_upar, QWV_uiz); 
+        kerfunc(mod1d, k, QWV, calc_upar, QWV_uiz); 
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
 
         // 记录积分结果
@@ -175,8 +174,7 @@ real_t grt_linear_filon_integ(
         }
 
         // 计算核函数 F(k, w)
-        grt_mod1d_xa_xb(mod1d, k0N);
-        kerfunc(mod1d, QWV, calc_upar, QWV_uiz);
+        kerfunc(mod1d, k0N, QWV, calc_upar, QWV_uiz);
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN; 
 
         for(size_t ir=0; ir<nr; ++ir){

--- a/pygrt/C_extension/src/common/model.c
+++ b/pygrt/C_extension/src/common/model.c
@@ -131,23 +131,17 @@ GRT_MODEL1D * grt_init_mod1d(size_t n){
 
 
 GRT_MODEL1D * grt_copy_mod1d(const GRT_MODEL1D *mod1d1){
-    GRT_MODEL1D *mod1d2 = grt_init_mod1d(mod1d1->n);
+    GRT_MODEL1D *mod1d2 = (GRT_MODEL1D *)calloc(1, sizeof(GRT_MODEL1D));
+
+    // 先直接赋值，实现浅拷贝
+    *mod1d2 = *mod1d1;
+
+    // 对指针部分再重新申请内存并赋值，实现深拷贝
     size_t n = mod1d1->n;
-    mod1d2->n = mod1d1->n;
-    mod1d2->depsrc = mod1d1->depsrc;
-    mod1d2->deprcv = mod1d1->deprcv;
-    mod1d2->isrc = mod1d1->isrc;
-    mod1d2->ircv = mod1d1->ircv;
-    mod1d2->ircvup = mod1d1->ircvup;
-    mod1d2->io_depth = mod1d1->io_depth;
+    #define X(P, T)  \
+        mod1d2->P = (T*)calloc(n, sizeof(T));\
+        memcpy(mod1d2->P, mod1d1->P, sizeof(T)*n);\
 
-    mod1d2->omega = mod1d1->omega;
-    mod1d2->k = mod1d1->k;
-    mod1d2->c_phase = mod1d1->c_phase;
-
-    mod1d2->stats = mod1d1->stats;
-
-    #define X(P, T)  memcpy(mod1d2->P, mod1d1->P, sizeof(T)*n);
         GRT_FOR_EACH_MODEL_QUANTITY_ARRAY
     #undef X
 

--- a/pygrt/C_extension/src/common/ptam.c
+++ b/pygrt/C_extension/src/common/ptam.c
@@ -217,8 +217,7 @@ void grt_PTA_method(
             k += dk;
 
             // 计算核函数 F(k, w)
-            grt_mod1d_xa_xb(mod1d, k);
-            kerfunc(mod1d, QWV, calc_upar, QWV_uiz); 
+            kerfunc(mod1d, k, QWV, calc_upar, QWV_uiz); 
             if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
 
             // 记录核函数

--- a/pygrt/C_extension/src/common/safim.c
+++ b/pygrt/C_extension/src/common/safim.c
@@ -323,8 +323,7 @@ real_t grt_sa_filon_integ(
         .F3_uiz = {{{0}}} 
     };
     for(int i=0; i<3; ++i) {
-        grt_mod1d_xa_xb(mod1d, Kitv.k3[i]);
-        kerfunc(mod1d, Kitv.F3[i], calc_upar, Kitv.F3_uiz[i]);
+        kerfunc(mod1d, Kitv.k3[i], Kitv.F3[i], calc_upar, Kitv.F3_uiz[i]);
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
     }
     stack_push(&stack, Kitv);
@@ -371,12 +370,11 @@ real_t grt_sa_filon_integ(
             memcpy(Kitv_right.F3_uiz[0], Kitv.F3_uiz[1], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
             memcpy(Kitv_right.F3_uiz[2], Kitv.F3_uiz[2], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
         }
-        grt_mod1d_xa_xb(mod1d, Kitv_left.k3[1]);
-        kerfunc(mod1d, Kitv_left.F3[1], calc_upar, Kitv_left.F3_uiz[1]);
+        
+        kerfunc(mod1d, Kitv_left.k3[1], Kitv_left.F3[1], calc_upar, Kitv_left.F3_uiz[1]);
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
 
-        grt_mod1d_xa_xb(mod1d, Kitv_right.k3[1]);
-        kerfunc(mod1d, Kitv_right.F3[1], calc_upar, Kitv_right.F3_uiz[1]);
+        kerfunc(mod1d, Kitv_right.k3[1], Kitv_right.F3[1], calc_upar, Kitv_right.F3_uiz[1]);
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
 
 

--- a/pygrt/C_extension/src/dynamic/source.c
+++ b/pygrt/C_extension/src/dynamic/source.c
@@ -63,17 +63,17 @@ inline void _source_SH(const cplx_t xb, const cplx_t cbcb, const real_t k, cplx_
 }
 
 
-void grt_source_coef(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2])
+void grt_source_coef(GRT_MODEL1D *mod1d)
 {
     // 先全部赋0 
-    memset(coef, 0, sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM*2);
+    memset(mod1d->src_coef, 0, sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM*2);
 
-    grt_source_coef_PSV(mod1d, coef);
-    grt_source_coef_SH(mod1d, coef);
+    grt_source_coef_PSV(mod1d);
+    grt_source_coef_SH(mod1d);
 }
 
 
-void grt_source_coef_PSV(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2])
+void grt_source_coef_PSV(GRT_MODEL1D *mod1d)
 {
     size_t isrc = mod1d->isrc;
     cplx_t xa = mod1d->xa[isrc];
@@ -82,18 +82,18 @@ void grt_source_coef_PSV(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GR
     cplx_t cbcb = mod1d->cbcb[isrc];
     real_t k = mod1d->k;
 
-    _source_PSV(xa, caca, xb, cbcb, k, coef);
+    _source_PSV(xa, caca, xb, cbcb, k, mod1d->src_coef);
 }
 
 
-void grt_source_coef_SH(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2])
+void grt_source_coef_SH(GRT_MODEL1D *mod1d)
 {
     size_t isrc = mod1d->isrc;
     cplx_t xb = mod1d->xb[isrc];
     cplx_t cbcb = mod1d->cbcb[isrc];
     real_t k = mod1d->k;
 
-    _source_SH(xb, cbcb, k, coef);
+    _source_SH(xb, cbcb, k, mod1d->src_coef);
 }
 
 

--- a/pygrt/C_extension/src/static/static_source.c
+++ b/pygrt/C_extension/src/static/static_source.c
@@ -61,31 +61,31 @@ inline void _source_SH(const real_t k, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2
 }
 
 
-void grt_static_source_coef(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2])
+void grt_static_source_coef(GRT_MODEL1D *mod1d)
 {
     // 先全部赋0 
-    memset(coef, 0, sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM*2);
+    memset(mod1d->src_coef, 0, sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM*2);
     
-    grt_static_source_coef_PSV(mod1d, coef);
-    grt_static_source_coef_SH(mod1d, coef);
+    grt_static_source_coef_PSV(mod1d);
+    grt_static_source_coef_SH(mod1d);
 }
 
 
-void grt_static_source_coef_PSV(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2])
+void grt_static_source_coef_PSV(GRT_MODEL1D *mod1d)
 {
     size_t isrc = mod1d->isrc;
     cplx_t delta = mod1d->delta[isrc];
     real_t k = mod1d->k;
 
-    _source_PSV(delta, k, coef);
+    _source_PSV(delta, k, mod1d->src_coef);
 }
 
 
-void grt_static_source_coef_SH(const GRT_MODEL1D *mod1d, cplx_t coef[GRT_SRC_M_NUM][GRT_QWV_NUM][2])
+void grt_static_source_coef_SH(GRT_MODEL1D *mod1d)
 {
     real_t k = mod1d->k;
     
-    _source_SH(k, coef);
+    _source_SH(k, mod1d->src_coef);
 }
 
 

--- a/pygrt/c_structures.py
+++ b/pygrt/c_structures.py
@@ -55,45 +55,31 @@ CPLX = REAL*2
 PREAL = POINTER(REAL)
 PCPLX = POINTER(CPLX)
 
+class c_RT_MATRIX(Structure):
+    """
+    和C结构体 RT_MATRIX 匹配
+    """
+
+    _fields_ = [
+        ('RD', CPLX * 4),
+        ('RU', CPLX * 4),
+        ('TD', CPLX * 4),
+        ('TU', CPLX * 4),
+        ('RDL', CPLX),
+        ('RUL', CPLX),
+        ('TDL', CPLX),
+        ('TUL', CPLX),
+        ('invT', CPLX * 4),
+        ('invTL', CPLX),
+        ('stats', c_int)
+    ]
+
+
 class c_GRT_MODEL1D(Structure):
     """
     和C结构体 GRT_MODEL1D 作匹配
-
-    :field n:        层数
-    :filed depsrc:   震源深度 km
-    :filed deprcv:   接收点深度 km
-    :field isrc:     震源所在层位
-    :field ircv:     台站所在层位
-    :field ircvup:   台站层位是否高于震源 
-    :field io_depth: 模型读入的第一列是否为每层顶界面深度
-
-    :field omega:    圆频率
-    :field omega:    波数
-    :field c_phase:  相速度
-
-    :field thk:      数组, 每层层厚(km)
-    :field dep:      数组, 每层顶界面深度(km)
-    :field Va:       数组, 每层P波速度(km/s)
-    :field Vb:       数组, 每层S波速度(km/s)
-    :field Rho:      数组, 每层密度(g/cm^3)
-    :field Qa:       数组, 每层P波品质因子Q_P
-    :field Qb:       数组, 每层S波品质因子Q_S
-    :field Qainv:
-    :field Qbinv:
-
-    :field mu:
-    :field lambda:
-    :field delta:
-    :field atna:
-    :field atnb:
-    :field xa:
-    :field xb:
-    :field caca:
-    :field cbcb:
-
-    :field stats:
-
     """
+    
     _fields_ = [
         ('n', c_size_t), 
         ("depsrc", REAL),
@@ -128,4 +114,19 @@ class c_GRT_MODEL1D(Structure):
         ('cbcb', PCPLX),
 
         ('stats', c_int),
+
+        ('M_AL', c_RT_MATRIX),
+        ('M_BL', c_RT_MATRIX),
+        ('M_RS', c_RT_MATRIX),
+        ('M_FA', c_RT_MATRIX),
+        ('M_FB', c_RT_MATRIX),
+
+        ('M_top', c_RT_MATRIX),
+
+        ('R_EV', CPLX * 4),
+        ('R_EVL', CPLX),
+        ('uiz_R_EV', CPLX * 4),
+        ('uiz_R_EVL', CPLX),
+
+        ('src_coef', CPLX * SRC_M_NUM * QWV_NUM * 2)
     ]


### PR DESCRIPTION
Simplify function arguments in `(static_)layer.c/h` and `kernel_template.h`.

Recently I made some code simplification and refactoring in several PRs, mostly move the variables into the C struct. I think there should be a balance (I don't know, still learning....), and **extremely simplification will only increase the subsequent maintenance costs, extension capabilities, and readability**. It is good if the overall structure of the code remains in a good framework.