### PR TITLE
REFAC: remove obsolete macros in kernel definition

### DIFF
--- a/docs/doxyfile_h
+++ b/docs/doxyfile_h
@@ -31,8 +31,7 @@ USE_MATHJAX = YES
 
 MARKDOWN_SUPPORT = YES
 
-# 展开特定宏，使得介绍核函数的头文件（kernel_template.h）会被构建
 # 定义 GCC_ALWAYS_INLINE 宏，使在构建 matrix.h 时不警告
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
-PREDEFINED            = __DYNAMIC_KERNEL__ __STATIC_KERNEL__ GCC_ALWAYS_INLINE
+PREDEFINED             = GCC_ALWAYS_INLINE

--- a/pygrt/C_extension/src/common/kernel_template.c_
+++ b/pygrt/C_extension/src/common/kernel_template.c_
@@ -62,7 +62,6 @@ void __GRT_MATRIX_FUNC__(GRT_MODEL1D *mod1d, const real_t k)
         grt_mod1d_xa_xb(mod1d, k);
     #endif
 
-    bool ircvup = mod1d->ircvup;
     size_t isrc = mod1d->isrc; // 震源所在虚拟层位, isrc>=1
     size_t ircv = mod1d->ircv; // 接收点所在虚拟层位, ircv>=1, ircv != isrc
     size_t imin, imax; // 相对浅层深层层位
@@ -71,10 +70,8 @@ void __GRT_MATRIX_FUNC__(GRT_MODEL1D *mod1d, const real_t k)
 
     // 广义层的反射透射系数
     RT_MATRIX *M_BL = &mod1d->M_BL;
-    RT_MATRIX *M_AL = &mod1d->M_AL;
     RT_MATRIX *M_RS = &mod1d->M_RS;
     RT_MATRIX *M_FA = &mod1d->M_FA;
-    RT_MATRIX *M_FB = &mod1d->M_FB;
     // 自由表面
     RT_MATRIX *M_top = &mod1d->M_top;
 

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -19,10 +19,7 @@
 #include <string.h>
 #include <sys/time.h>
 
-#define __DYNAMIC_KERNEL__
 #include "grt/common/kernel.h"
-#undef __DYNAMIC_KERNEL__
-
 #include "grt/dynamic/grn.h"
 #include "grt/common/ptam.h"
 #include "grt/common/fim.h"

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -19,10 +19,7 @@
 #include <sys/stat.h>
 #include <errno.h>
 
-#define __STATIC_KERNEL__
 #include "grt/common/kernel.h"
-#undef __STATIC_KERNEL__
-
 #include "grt/static/static_grn.h"
 #include "grt/common/dwm.h"
 #include "grt/common/ptam.h"


### PR DESCRIPTION
redundant `__DYNAMIC_KERNEL__` and `__STATIC__KERNEL__`