### PR TITLE
FIX: skip the complex frequency points with lower amplitudes

### DIFF
--- a/pygrt/C_extension/include/grt/common/checkerror.h
+++ b/pygrt/C_extension/include/grt/common/checkerror.h
@@ -20,12 +20,14 @@
 // GRT自定义报错信息
 #define GRTRaiseError(ErrorMessage, ...) ({\
     fprintf(stderr, BOLD_RED ErrorMessage "\n" DEFAULT_RESTORE, ##__VA_ARGS__);\
+    fflush(stderr);\
     exit(EXIT_FAILURE);\
 })
 
 // GRT自定义警告信息，不结束程序
 #define GRTRaiseWarning(WarnMessage, ...) ({\
     fprintf(stderr, BOLD_YELLOW WarnMessage "\n" DEFAULT_RESTORE, ##__VA_ARGS__);\
+    fflush(stderr);\
 })
 
 // GRT报错：选项设置不符要求

--- a/pygrt/C_extension/include/grt/dynamic/grn.h
+++ b/pygrt/C_extension/include/grt/dynamic/grn.h
@@ -27,6 +27,7 @@
  * @param[in]      nr               震中距数量
  * @param[in]      rs               震中距数组 
  * @param[in]      wI               虚频率, \f$ \tilde{\omega} =\omega - i \omega_I  \f$ 
+ * @param[in]      keepAllFreq      计算所有频点，不论频率多低
  * @param[in]      vmin_ref         参考最小速度，用于定义波数积分的上限
  * @param[in]      keps             波数积分的收敛条件，要求在某震中距下所有格林函数都收敛，为负数代表不提前判断收敛，按照波数积分上限进行积分 
  * @param[in]      ampk             影响波数k积分上限的系数，见下方
@@ -50,7 +51,7 @@
  */ 
 void grt_integ_grn_spec(
     GRT_MODEL1D *mod1d, size_t nf1, size_t nf2, real_t *freqs,  
-    size_t nr, real_t *rs, real_t wI, 
+    size_t nr, real_t *rs, real_t wI, bool keepAllFreq,
     real_t vmin_ref, real_t keps, real_t ampk, real_t k0, real_t Length, real_t filonLength, real_t safilonTol, real_t filonCut,             
     bool print_progressbar, 
 

--- a/pygrt/c_interfaces.py
+++ b/pygrt/c_interfaces.py
@@ -31,7 +31,7 @@ C_grt_integ_grn_spec = libgrt.grt_integ_grn_spec
 """C库中计算格林函数的主函数 integ_grn_spec, 详见C API同名函数"""
 C_grt_integ_grn_spec.argtypes = [
     POINTER(c_GRT_MODEL1D), c_size_t, c_size_t, PREAL,       
-    c_size_t, PREAL, REAL,
+    c_size_t, PREAL, REAL, c_bool,
     REAL, REAL, REAL, REAL, REAL, REAL, REAL, REAL,
     c_bool,
 

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -147,6 +147,7 @@ class PyModel1D:
         upsampling_n:int = 1,
         freqband:Union[np.ndarray,List[float]]=[-1,-1],
         zeta:float=0.8, 
+        keepAllFreq:bool=False,
         vmin_ref:float=0.0,
         keps:float=-1.0,  
         ampk:float=1.15,
@@ -176,6 +177,7 @@ class PyModel1D:
             :param    zeta:          定义虚频率的系数 :math:`\zeta` ， 虚频率 :math:`\tilde{\omega} = \omega - j*w_I, w_I = \zeta*\pi/T, T=nt*dt` , T为时窗长度。
                                      使用离散波数积分时为了避开附加源以及奇点的影响， :ref:`(Bouchon, 1981) <bouchon_1981>`  在频率上添加微小虚部，
                                      更多测试见 :ref:`(张海明, 2021) <zhang_book_2021>`
+            :param    keepAllFreq    计算所有频点，不论频率多低
             :param    vmin_ref:      最小参考速度，默认vmin=max(minimum velocity, 0.1)，用于定义波数积分上限，小于0则在达到积分上限后使用峰谷平均法
                                     （默认当震源和场点深度差<=1km时自动使用峰谷平均法）
             :param    keps:          波数k积分收敛条件，见 :ref:`(Yao and Harkrider, 1983) <yao&harkrider_1983>`  :ref:`(初稿) <yao_init_manuscripts>`，
@@ -382,7 +384,7 @@ class PyModel1D:
         #     剪切源 DD[ZR],DS[ZRT],SS[ZRT]          1e-20 cm/(dyne*cm)
         #=================================================================================
         C_grt_integ_grn_spec(
-            self.c_mod1d, nf1, nf2, c_freqs, nrs, c_rs, wI, 
+            self.c_mod1d, nf1, nf2, c_freqs, nrs, c_rs, wI, keepAllFreq,
             vmin_ref, keps, ampk, k0, Length, filonLength, safilonTol, filonCut, print_runtime,
             c_grnArr, calc_upar, c_grnArr_uiz, c_grnArr_uir,
             c_statsfile, nstatsidxs, c_statsidxs

--- a/pygrt/utils.py
+++ b/pygrt/utils.py
@@ -1169,6 +1169,7 @@ def read_statsfile(statsfile:str):
     if len(Lst) != 1:
         raise OSError(f"{statsfile} should only match one file, but {len(Lst)} matched.")
     statsfile = Lst[0]
+    print(f"raed in {statsfile}.")
 
     # 确定自定义数据类型  EX_q, EX_w, VF_q, ...
     dtype = [('k', NPCT_REAL_TYPE)]

--- a/test/_correct_full_wave/correctness.sh
+++ b/test/_correct_full_wave/correctness.sh
@@ -12,7 +12,7 @@ grt greenfn -M../milrow  -D2/3 -N600/0.02 -R10 -e -OGRN
 grt greenfn -M../killari -D3/0 -N300/0.01 -R3  -e -OGRN 
 grt greenfn -M../thin1   -D0/0 -N700/0.02 -R1  -e -OGRN
 # liquid model
-grt greenfn -M../seafloor -D5/1.1 -N500/0.4 -R100 -e -OGRN
+grt greenfn -M../seafloor -D5/1.1 -N500/0.4+a -R100 -e -OGRN
 
 python ../compare_sac.py  "GRN/milrow_2_3_10/*"  "_Ref/milrow_2_3_10/*"
 python ../compare_sac.py  "GRN/killari_3_0_3/*"  "_Ref/killari_3_0_3/*"

--- a/test/greenfn/test_greenfn.py
+++ b/test/greenfn/test_greenfn.py
@@ -24,6 +24,7 @@ stgrn = pymod.compute_grn(dist, nt, dt, Length=20)[0]
 stgrn = pymod.compute_grn(dist, nt, dt, k0=4, ampk=1.2, keps=1e-3, vmin_ref=1.5)[0]
 
 stgrn = pymod.compute_grn(2000, 1400, 1.0, Length=20, safilonTol=1e-3)[0]
+stgrn = pymod.compute_grn(2000, 1400, 1.0, Length=20, safilonTol=1e-3, keepAllFreq=True)[0]
 
 stgrn = pymod.compute_grn(dist, nt, dt, Length=20, statsfile="GRN_grtstats")[0]
 stgrn = pymod.compute_grn(dist, nt, dt, Length=20, statsfile="GRN_grtstats", statsidxs=[1,10,20])[0]

--- a/test/greenfn/test_greenfn.sh
+++ b/test/greenfn/test_greenfn.sh
@@ -13,6 +13,7 @@ grt greenfn -M../milrow -D2/3 -N600/0.02 -L20 -R10 -OGRN
 grt greenfn -M../milrow -D2/3 -N600/0.02 -K+k4+s1.2+e1e-3+v1.5 -R10 -OGRN
 
 grt greenfn -M../milrow -D2/0 -N1400/1 -La20/1e-3/0 -E-2/9 -R2000 -OGRN
+grt greenfn -M../milrow -D2/0 -N1400/1+a -La20/1e-3/0 -E-2/9 -R2000 -OGRN
 
 grt greenfn -M../milrow -D2/3 -N600/0.02 -L20 -R10 -S -OGRN
 grt greenfn -M../milrow -D2/3 -N600/0.02 -L20 -R10 -S1,10,20 -OGRN


### PR DESCRIPTION
This is a problem that widely exists in the codes that use the DWM proposed by Bouchon (1981).

For PyGRT, I merely added a criterion to skip the low-freq points (see below). Because adding the imaginary frequency is also an approximate calculation. Since these points are already inaccurate anyway, it's better to simply discard them.

https://github.com/Dengda98/PyGRT/blob/768c86a43a36c99489c2df775c92ed75530897bf/pygrt/C_extension/src/dynamic/grn.c#L152-L164

For some users who want to do experiments, I add `-N+a` in `greenfn` module and bool-type argument `keepAllFreq` in Python.

I need to add a document to introduce about this.