### PR TITLE
REFAC: rename data type `QWVgrid` and `INTEGgrid`

### DIFF
--- a/pygrt/C_extension/include/grt/common/const.h
+++ b/pygrt/C_extension/include/grt/common/const.h
@@ -123,10 +123,11 @@ typedef double complex cplx_t;
 
 #define GRT_GTYPES_MAX   2      ///< 2, 所有震源根据是否使用格林函数导数分为两类
 
-typedef cplx_t QWVgrid[GRT_SRC_M_NUM][GRT_QWV_NUM];
-typedef cplx_t INTEGgrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
-typedef real_t r_INTEGgrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
-typedef size_t s_INTEGgrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
+typedef cplx_t cplxQWVGrid[GRT_SRC_M_NUM][GRT_QWV_NUM];
+
+typedef cplx_t cplxIntegGrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
+typedef real_t realIntegGrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
+typedef size_t sizeIntegGrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
 
 /** 不同震源类型在大小为 GRT_SRC_M_NUM 的数组中的索引 */
 enum {

--- a/pygrt/C_extension/include/grt/common/dwm.h
+++ b/pygrt/C_extension/include/grt/common/dwm.h
@@ -44,8 +44,8 @@
 real_t grt_discrete_integ(
     GRT_MODEL1D *mod1d, real_t dk, real_t kmax, real_t keps,
     size_t nr, real_t *rs,
-    INTEGgrid sum_J[nr],
+    cplxIntegGrid sum_J[nr],
     bool calc_upar,
-    INTEGgrid sum_uiz_J[nr],
-    INTEGgrid sum_uir_J[nr],
+    cplxIntegGrid sum_uiz_J[nr],
+    cplxIntegGrid sum_uir_J[nr],
     FILE *fstats, GRT_KernelFunc kerfunc);

--- a/pygrt/C_extension/include/grt/common/fim.h
+++ b/pygrt/C_extension/include/grt/common/fim.h
@@ -51,10 +51,10 @@
 real_t grt_linear_filon_integ(
     GRT_MODEL1D *mod1d, real_t k0, real_t dk0, real_t filondk, real_t kmax, real_t keps,
     size_t nr, real_t *rs,
-    INTEGgrid sum_J[nr],
+    cplxIntegGrid sum_J[nr],
     bool calc_upar,
-    INTEGgrid sum_uiz_J[nr],
-    INTEGgrid sum_uir_J[nr],
+    cplxIntegGrid sum_uiz_J[nr],
+    cplxIntegGrid sum_uir_J[nr],
     FILE *fstats, GRT_KernelFunc kerfunc);
 
 

--- a/pygrt/C_extension/include/grt/common/integral.h
+++ b/pygrt/C_extension/include/grt/common/integral.h
@@ -24,7 +24,7 @@
  * @param[out]    SUM            该dk区间内的积分值
  * 
  */
-void grt_int_Pk(real_t k, real_t r, const QWVgrid QWV, bool calc_uir, INTEGgrid SUM);
+void grt_int_Pk(real_t k, real_t r, const cplxQWVGrid QWV, bool calc_uir, cplxIntegGrid SUM);
 
 
 
@@ -35,7 +35,7 @@ void grt_int_Pk(real_t k, real_t r, const QWVgrid QWV, bool calc_uir, INTEGgrid 
  * @param[in]     sum_J           积分结果
  * @param[out]    tol             Z、R、T分量结果
  */
-void grt_merge_Pk(const INTEGgrid sum_J, cplx_t tol[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]);
+void grt_merge_Pk(const cplxIntegGrid sum_J, cplx_t tol[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]);
 
 
 
@@ -53,7 +53,7 @@ void grt_merge_Pk(const INTEGgrid sum_J, cplx_t tol[GRT_SRC_M_NUM][GRT_CHANNEL_N
  * @param[out]    SUM            该dk区间内的积分值
  *  
  */
-void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const QWVgrid QWV, bool calc_uir, INTEGgrid SUM);
+void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const cplxQWVGrid QWV, bool calc_uir, cplxIntegGrid SUM);
 
 
 /**
@@ -68,4 +68,4 @@ void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const QWVgrid QWV, bool ca
  * @param[out]    SUM           该三点区间内的积分值
  * 
  */
-void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const QWVgrid QWV3[3], bool calc_uir, INTEGgrid SUM);
+void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const cplxQWVGrid QWV3[3], bool calc_uir, cplxIntegGrid SUM);

--- a/pygrt/C_extension/include/grt/common/iostats.h
+++ b/pygrt/C_extension/include/grt/common/iostats.h
@@ -26,7 +26,7 @@
  * @note     文件记录的值均为波数积分的中间结果，与最终的结果还差一系列的系数，
  *           记录其值主要用于参考其变化趋势。
  */
-void grt_write_stats(FILE *f0, real_t k, const QWVgrid QWV);
+void grt_write_stats(FILE *f0, real_t k, const cplxQWVGrid QWV);
 
 
 /**
@@ -54,8 +54,8 @@ int grt_extract_stats(FILE *bf0, FILE *af0);
  */
 void grt_write_stats_ptam(
     FILE *f0, 
-    r_INTEGgrid Kpt[GRT_PTAM_PT_MAX],
-    INTEGgrid Fpt[GRT_PTAM_PT_MAX]);
+    realIntegGrid Kpt[GRT_PTAM_PT_MAX],
+    cplxIntegGrid Fpt[GRT_PTAM_PT_MAX]);
 
 
 /**

--- a/pygrt/C_extension/include/grt/common/kernel.h
+++ b/pygrt/C_extension/include/grt/common/kernel.h
@@ -16,8 +16,8 @@
  * 计算核函数的函数指针，动态与静态的接口一致
  */
 typedef void (*GRT_KernelFunc) (
-    GRT_MODEL1D *mod1d, const real_t k, QWVgrid QWV,
-    bool calc_uiz, QWVgrid QWV_uiz);
+    GRT_MODEL1D *mod1d, const real_t k, cplxQWVGrid QWV,
+    bool calc_uiz, cplxQWVGrid QWV_uiz);
 
 
 /**
@@ -89,26 +89,26 @@ typedef void (*GRT_KernelFunc) (
  * 
  */
 void grt_kernel(
-    GRT_MODEL1D *mod1d, const real_t k, QWVgrid QWV,
-    bool calc_uiz, QWVgrid QWV_uiz);
+    GRT_MODEL1D *mod1d, const real_t k, cplxQWVGrid QWV,
+    bool calc_uiz, cplxQWVGrid QWV_uiz);
 
 /** 构建广义反射透射系数矩阵。作为 kernel 函数中的第一部分 */
 void grt_GRT_matrix(GRT_MODEL1D *mod1d, const real_t k);
 
 /** 从广义 R/T 矩阵出发，计算每个震源对应的核函数 QWV。 作为 kernel 函数中的第二部分 */
 void grt_GRT_build_QWV(
-    GRT_MODEL1D *mod1d, QWVgrid QWV,
-    bool calc_uiz, QWVgrid QWV_uiz);
+    GRT_MODEL1D *mod1d, cplxQWVGrid QWV,
+    bool calc_uiz, cplxQWVGrid QWV_uiz);
 
 /** 静态解的核函数 */
 void grt_static_kernel(
-    GRT_MODEL1D *mod1d, const real_t k, QWVgrid QWV,
-    bool calc_uiz, QWVgrid QWV_uiz);
+    GRT_MODEL1D *mod1d, const real_t k, cplxQWVGrid QWV,
+    bool calc_uiz, cplxQWVGrid QWV_uiz);
 
 /** 静态广义反射透射系数矩阵 */
 void grt_static_GRT_matrix(GRT_MODEL1D *mod1d, const real_t k);
 
 /** 静态 QWV */
 void grt_static_GRT_build_QWV(
-    GRT_MODEL1D *mod1d, QWVgrid QWV,
-    bool calc_uiz, QWVgrid QWV_uiz);
+    GRT_MODEL1D *mod1d, cplxQWVGrid QWV,
+    bool calc_uiz, cplxQWVGrid QWV_uiz);

--- a/pygrt/C_extension/include/grt/common/model.h
+++ b/pygrt/C_extension/include/grt/common/model.h
@@ -68,8 +68,8 @@ typedef struct {
     cplx_t uiz_R_EVL;
 
     /* 震源处的震源系数 \f$ P_m, SV_m, SH_m  */
-    QWVgrid src_coefD;
-    QWVgrid src_coefU;
+    cplxQWVGrid src_coefD;
+    cplxQWVGrid src_coefU;
 
 } GRT_MODEL1D;
 

--- a/pygrt/C_extension/include/grt/common/ptam.h
+++ b/pygrt/C_extension/include/grt/common/ptam.h
@@ -47,9 +47,9 @@
 void grt_PTA_method(
     GRT_MODEL1D *mod1d, real_t k0, real_t predk,
     size_t nr, real_t *rs,
-    INTEGgrid sum_J0[nr],
+    cplxIntegGrid sum_J0[nr],
     bool calc_upar,
-    INTEGgrid sum_uiz_J0[nr],
-    INTEGgrid sum_uir_J0[nr],
+    cplxIntegGrid sum_uiz_J0[nr],
+    cplxIntegGrid sum_uir_J0[nr],
     FILE *ptam_fstatsnr[nr][2], GRT_KernelFunc kerfunc);
 

--- a/pygrt/C_extension/include/grt/common/safim.h
+++ b/pygrt/C_extension/include/grt/common/safim.h
@@ -52,10 +52,10 @@
 real_t grt_sa_filon_integ(
     GRT_MODEL1D *mod1d, real_t k0, real_t dk0, real_t tol, real_t kmax, real_t kref, 
     size_t nr, real_t *rs,
-    INTEGgrid sum_J0[nr],
+    cplxIntegGrid sum_J0[nr],
     bool calc_upar,
-    INTEGgrid sum_uiz_J0[nr],
-    INTEGgrid sum_uir_J0[nr],
+    cplxIntegGrid sum_uiz_J0[nr],
+    cplxIntegGrid sum_uir_J0[nr],
     FILE *fstats, GRT_KernelFunc kerfunc);
 
 

--- a/pygrt/C_extension/src/common/dwm.c
+++ b/pygrt/C_extension/src/common/dwm.c
@@ -27,17 +27,17 @@
 real_t grt_discrete_integ(
     GRT_MODEL1D *mod1d, real_t dk, real_t kmax, real_t keps,
     size_t nr, real_t *rs,
-    INTEGgrid sum_J[nr],
+    cplxIntegGrid sum_J[nr],
     bool calc_upar,
-    INTEGgrid sum_uiz_J[nr],
-    INTEGgrid sum_uir_J[nr],
+    cplxIntegGrid sum_uiz_J[nr],
+    cplxIntegGrid sum_uir_J[nr],
     FILE *fstats, GRT_KernelFunc kerfunc)
 {
-    INTEGgrid SUM = {0};
+    cplxIntegGrid SUM = {0};
 
     // 不同震源不同阶数的核函数 F(k, w) 
-    QWVgrid QWV = {0};
-    QWVgrid QWV_uiz = {0};
+    cplxQWVGrid QWV = {0};
+    cplxQWVGrid QWV_uiz = {0};
     
     real_t k = 0.0;
     size_t ik = 0;

--- a/pygrt/C_extension/src/common/fim.c
+++ b/pygrt/C_extension/src/common/fim.c
@@ -25,22 +25,22 @@
 real_t grt_linear_filon_integ(
     GRT_MODEL1D *mod1d, real_t k0, real_t dk0, real_t dk, real_t kmax, real_t keps,
     size_t nr, real_t *rs,
-    INTEGgrid sum_J0[nr],
+    cplxIntegGrid sum_J0[nr],
     bool calc_upar,
-    INTEGgrid sum_uiz_J0[nr],
-    INTEGgrid sum_uir_J0[nr],
+    cplxIntegGrid sum_uiz_J0[nr],
+    cplxIntegGrid sum_uir_J0[nr],
     FILE *fstats, GRT_KernelFunc kerfunc)
 {   
     // 从0开始，存储第二部分Filon积分的结果
-    INTEGgrid *sum_J = (INTEGgrid *)calloc(nr, sizeof(*sum_J));
-    INTEGgrid *sum_uiz_J = (calc_upar)? (INTEGgrid *)calloc(nr, sizeof(*sum_uiz_J)) : NULL;
-    INTEGgrid *sum_uir_J = (calc_upar)? (INTEGgrid *)calloc(nr, sizeof(*sum_uir_J)) : NULL;
+    cplxIntegGrid *sum_J = (cplxIntegGrid *)calloc(nr, sizeof(*sum_J));
+    cplxIntegGrid *sum_uiz_J = (calc_upar)? (cplxIntegGrid *)calloc(nr, sizeof(*sum_uiz_J)) : NULL;
+    cplxIntegGrid *sum_uir_J = (calc_upar)? (cplxIntegGrid *)calloc(nr, sizeof(*sum_uir_J)) : NULL;
 
-    INTEGgrid SUM;
+    cplxIntegGrid SUM;
 
     // 不同震源不同阶数的核函数 F(k, w) 
-    QWVgrid QWV = {0};
-    QWVgrid QWV_uiz = {0};
+    cplxQWVGrid QWV = {0};
+    cplxQWVGrid QWV_uiz = {0};
 
     real_t k=k0; 
     size_t ik=0;
@@ -158,8 +158,8 @@ real_t grt_linear_filon_integ(
 
     // -------------------------------------------------------------------------------
     // 计算余项, [2]表示k积分的第一个点和最后一个点
-    INTEGgrid SUM_Gc[2] = {0};
-    INTEGgrid SUM_Gs[2] = {0};
+    cplxIntegGrid SUM_Gc[2] = {0};
+    cplxIntegGrid SUM_Gs[2] = {0};
 
 
     // 计算来自第一个点和最后一个点的余项

--- a/pygrt/C_extension/src/common/integral.c
+++ b/pygrt/C_extension/src/common/integral.c
@@ -19,7 +19,7 @@
 
 
 
-void grt_int_Pk(real_t k, real_t r, const QWVgrid QWV, bool calc_uir, INTEGgrid SUM)
+void grt_int_Pk(real_t k, real_t r, const cplxQWVGrid QWV, bool calc_uir, cplxIntegGrid SUM)
 {
     real_t bjmk[GRT_MORDER_MAX+1] = {0};
     real_t kr = k*r;
@@ -64,7 +64,7 @@ void grt_int_Pk(real_t k, real_t r, const QWVgrid QWV, bool calc_uir, INTEGgrid 
 }
 
 
-void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const QWVgrid QWV, bool calc_uir, INTEGgrid SUM)
+void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const cplxQWVGrid QWV, bool calc_uir, cplxIntegGrid SUM)
 {
     real_t phi0 = 0.0;
     if(! iscos)  phi0 = - HALFPI;  // 在cos函数中添加的相位差，用于计算sin函数
@@ -149,7 +149,7 @@ static cplx_t interg_quad_cos(
 
 
 
-void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const QWVgrid QWV3[3], bool calc_uir, INTEGgrid SUM)
+void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const cplxQWVGrid QWV3[3], bool calc_uir, cplxIntegGrid SUM)
 {
     // 使用bessel递推公式 Jm'(x) = m/x * Jm(x) - J_{m+1}(x)
     // 考虑大震中距，忽略第一项，再使用bessel渐近公式
@@ -159,9 +159,9 @@ void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const QWVgrid QWV3[3], bo
 
     // 对sqrt(k)*F(k,w)进行二次曲线拟合，再计算 (a*k^2 + b*k + c) * cos(kr - (2m+1)/4) 的积分
     // 拟合二次函数的参数
-    QWVgrid quad_a={0};
-    QWVgrid quad_b={0};
-    QWVgrid quad_c={0};
+    cplxQWVGrid quad_a={0};
+    cplxQWVGrid quad_b={0};
+    cplxQWVGrid quad_c={0};
     for(int im=0; im<GRT_SRC_M_NUM; ++im){
         int modr = GRT_SRC_M_ORDERS[im];
         for(int c=0; c<GRT_QWV_NUM; ++c){
@@ -194,7 +194,7 @@ void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const QWVgrid QWV3[3], bo
 
 
 
-void grt_merge_Pk(const INTEGgrid sum_J, cplx_t tol[GRT_SRC_M_NUM][GRT_CHANNEL_NUM])
+void grt_merge_Pk(const cplxIntegGrid sum_J, cplx_t tol[GRT_SRC_M_NUM][GRT_CHANNEL_NUM])
 {   
     for(int i=0; i<GRT_SRC_M_NUM; ++i){
         int modr = GRT_SRC_M_ORDERS[i];

--- a/pygrt/C_extension/src/common/iostats.c
+++ b/pygrt/C_extension/src/common/iostats.c
@@ -17,7 +17,7 @@
 
 
 
-void grt_write_stats(FILE *f0, real_t k, const QWVgrid QWV)
+void grt_write_stats(FILE *f0, real_t k, const cplxQWVGrid QWV)
 {
     fwrite(&k, sizeof(real_t), 1, f0);
 
@@ -74,8 +74,8 @@ int grt_extract_stats(FILE *bf0, FILE *af0){
 
 void grt_write_stats_ptam(
     FILE *f0, 
-    r_INTEGgrid Kpt[GRT_PTAM_PT_MAX],
-    INTEGgrid Fpt[GRT_PTAM_PT_MAX]
+    realIntegGrid Kpt[GRT_PTAM_PT_MAX],
+    cplxIntegGrid Fpt[GRT_PTAM_PT_MAX]
 ){
 
     for(int i=0; i<GRT_PTAM_PT_MAX; ++i){

--- a/pygrt/C_extension/src/common/kernel.c
+++ b/pygrt/C_extension/src/common/kernel.c
@@ -48,7 +48,7 @@ inline GCC_ALWAYS_INLINE void grt_construct_qwv(
     bool ircvup, 
     const cplx_t R1[2][2], cplx_t RL1, 
     const cplx_t R2[2][2], cplx_t RL2, 
-    const QWVgrid coefD, const QWVgrid coefU, QWVgrid QWV)
+    const cplxQWVGrid coefD, const cplxQWVGrid coefU, cplxQWVGrid QWV)
 {
     for(int i = 0; i < GRT_SRC_M_NUM; ++i)
     {

--- a/pygrt/C_extension/src/common/kernel_template.c_
+++ b/pygrt/C_extension/src/common/kernel_template.c_
@@ -154,8 +154,8 @@ void __GRT_MATRIX_FUNC__(GRT_MODEL1D *mod1d, const real_t k)
 
 
 void __BUILD_QWV__(
-    GRT_MODEL1D *mod1d, QWVgrid QWV,
-    bool calc_uiz, QWVgrid QWV_uiz)
+    GRT_MODEL1D *mod1d, cplxQWVGrid QWV,
+    bool calc_uiz, cplxQWVGrid QWV_uiz)
 {
     // 初始化qwv为0
     memset(QWV, 0, sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
@@ -263,8 +263,8 @@ void __BUILD_QWV__(
 
 
 void __KERNEL_FUNC__(
-    GRT_MODEL1D *mod1d, const real_t k, QWVgrid QWV,
-    bool calc_uiz, QWVgrid QWV_uiz)
+    GRT_MODEL1D *mod1d, const real_t k, cplxQWVGrid QWV,
+    bool calc_uiz, cplxQWVGrid QWV_uiz)
 {
     __GRT_MATRIX_FUNC__(mod1d, k);
     __BUILD_QWV__(mod1d, QWV, calc_uiz, QWV_uiz);

--- a/pygrt/C_extension/src/common/safim.c
+++ b/pygrt/C_extension/src/common/safim.c
@@ -51,8 +51,8 @@ typedef enum {
 // 区间结构体
 typedef struct { 
     real_t k3[3];
-    QWVgrid F3[3]; 
-    QWVgrid F3_uiz[3]; 
+    cplxQWVGrid F3[3]; 
+    cplxQWVGrid F3_uiz[3]; 
 } KInterval;
 
 // 区间栈结构体
@@ -104,7 +104,7 @@ static KInterval stack_pop(KIntervalStack *stack) {
 static cplx_t simpson(const KInterval *item_pt, int im, int iqwv, bool isuiz, SIMPSON_INTV stats) {
     cplx_t Fint = 0.0;
     real_t klen = item_pt->k3[2] -  item_pt->k3[0];
-    const QWVgrid *F3 = (isuiz)? item_pt->F3_uiz : item_pt->F3;
+    const cplxQWVGrid *F3 = (isuiz)? item_pt->F3_uiz : item_pt->F3;
     
     // 使用F(k)*sqrt(k)来衡量积分值，这可以平衡后续计算F(k)*Jm(kr)k积分时的系数
     real_t sk[3];
@@ -136,7 +136,7 @@ static cplx_t simpson(const KInterval *item_pt, int im, int iqwv, bool isuiz, SI
 }
 
 /** 比较QWV的最大绝对值 */
-static void get_maxabsQWV(const QWVgrid F, real_t maxabsF[GRT_GTYPES_MAX]){
+static void get_maxabsQWV(const cplxQWVGrid F, real_t maxabsF[GRT_GTYPES_MAX]){
     real_t tmp;
     for(int i=0; i<GRT_SRC_M_NUM; ++i){
         for(int c=0; c<GRT_QWV_NUM; ++c){
@@ -158,8 +158,8 @@ static bool check_fit(
     cplx_t S11, S12, S21, S22;
 
     // 核函数
-    const QWVgrid *F3L = (isuiz)? ptKitvL->F3_uiz : ptKitvL->F3;
-    const QWVgrid *F3R = (isuiz)? ptKitvR->F3_uiz : ptKitvR->F3;
+    const cplxQWVGrid *F3L = (isuiz)? ptKitvL->F3_uiz : ptKitvL->F3;
+    const cplxQWVGrid *F3R = (isuiz)? ptKitvR->F3_uiz : ptKitvR->F3;
 
     // 取近似积分 \int_k1^k2 k^0.5 dk
     real_t kcoef13 = RTWOTHIRD*( ptKitv->k3[2]*sqrt(ptKitv->k3[2]) - ptKitv->k3[0]*sqrt(ptKitv->k3[0]) );
@@ -239,12 +239,12 @@ static bool check_fit(
 static void interv_integ(
     const KInterval *ptKitv,
     size_t nr, real_t *rs,
-    INTEGgrid sum_J[nr],
+    cplxIntegGrid sum_J[nr],
     bool calc_upar,
-    INTEGgrid sum_uiz_J[nr],
-    INTEGgrid sum_uir_J[nr])
+    cplxIntegGrid sum_uiz_J[nr],
+    cplxIntegGrid sum_uir_J[nr])
 {
-    INTEGgrid SUM={0};
+    cplxIntegGrid SUM={0};
 
     // 震中距rs循环
     for(size_t ir=0; ir<nr; ++ir){
@@ -295,16 +295,16 @@ static void interv_integ(
 real_t grt_sa_filon_integ(
     GRT_MODEL1D *mod1d, real_t k0, real_t dk0, real_t tol, real_t kmax, real_t kref, 
     size_t nr, real_t *rs,
-    INTEGgrid sum_J0[nr],
+    cplxIntegGrid sum_J0[nr],
     bool calc_upar,
-    INTEGgrid sum_uiz_J0[nr],
-    INTEGgrid sum_uir_J0[nr],
+    cplxIntegGrid sum_uiz_J0[nr],
+    cplxIntegGrid sum_uir_J0[nr],
     FILE *fstats, GRT_KernelFunc kerfunc)
 {   
     // 从0开始，存储第二部分Filon积分的结果
-    INTEGgrid *sum_J = (INTEGgrid *)calloc(nr, sizeof(*sum_J));
-    INTEGgrid *sum_uiz_J = (calc_upar)? (INTEGgrid *)calloc(nr, sizeof(*sum_uiz_J)) : NULL;
-    INTEGgrid *sum_uir_J = (calc_upar)? (INTEGgrid *)calloc(nr, sizeof(*sum_uir_J)) : NULL;
+    cplxIntegGrid *sum_J = (cplxIntegGrid *)calloc(nr, sizeof(*sum_J));
+    cplxIntegGrid *sum_uiz_J = (calc_upar)? (cplxIntegGrid *)calloc(nr, sizeof(*sum_uiz_J)) : NULL;
+    cplxIntegGrid *sum_uir_J = (calc_upar)? (cplxIntegGrid *)calloc(nr, sizeof(*sum_uir_J)) : NULL;
 
     real_t kmin = k0;
     

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -44,7 +44,7 @@
  * @param[out]   grn            三分量频谱
  */
 static void recordin_GRN(
-    size_t iw, size_t nr, cplx_t coef, INTEGgrid sum_J[nr],
+    size_t iw, size_t nr, cplx_t coef, cplxIntegGrid sum_J[nr],
     cplx_t *grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM]
 )
 {
@@ -169,9 +169,9 @@ void grt_integ_grn_spec(
 
         // 局部变量，用于求和 sum F(ki,w)Jm(ki*r)ki 
         // 关于形状详见int_Pk()函数内的注释
-        INTEGgrid *sum_J = (INTEGgrid *)calloc(nr, sizeof(*sum_J));
-        INTEGgrid *sum_uiz_J = (calc_upar)? (INTEGgrid *)calloc(nr, sizeof(*sum_uiz_J)) : NULL;
-        INTEGgrid *sum_uir_J = (calc_upar)? (INTEGgrid *)calloc(nr, sizeof(*sum_uir_J)) : NULL;
+        cplxIntegGrid *sum_J = (cplxIntegGrid *)calloc(nr, sizeof(*sum_J));
+        cplxIntegGrid *sum_uiz_J = (calc_upar)? (cplxIntegGrid *)calloc(nr, sizeof(*sum_uiz_J)) : NULL;
+        cplxIntegGrid *sum_uir_J = (calc_upar)? (cplxIntegGrid *)calloc(nr, sizeof(*sum_uir_J)) : NULL;
 
         GRT_MODEL1D *local_mod1d = NULL;
     #ifdef _OPENMP 

--- a/pygrt/C_extension/src/dynamic/source.c
+++ b/pygrt/C_extension/src/dynamic/source.c
@@ -18,7 +18,7 @@
 
 inline GCC_ALWAYS_INLINE void _source_PSV(
     const cplx_t xa, const cplx_t caca, 
-    const cplx_t xb, const cplx_t cbcb, const real_t k, QWVgrid coefD, QWVgrid coefU)
+    const cplx_t xb, const cplx_t cbcb, const real_t k, cplxQWVGrid coefD, cplxQWVGrid coefU)
 {
     cplx_t tmp;
 
@@ -47,7 +47,7 @@ inline GCC_ALWAYS_INLINE void _source_PSV(
 
 }
 
-inline GCC_ALWAYS_INLINE void _source_SH(const cplx_t xb, const cplx_t cbcb, const real_t k, QWVgrid coefD, QWVgrid coefU)
+inline GCC_ALWAYS_INLINE void _source_SH(const cplx_t xb, const cplx_t cbcb, const real_t k, cplxQWVGrid coefD, cplxQWVGrid coefU)
 {
     cplx_t tmp;
 
@@ -66,8 +66,8 @@ inline GCC_ALWAYS_INLINE void _source_SH(const cplx_t xb, const cplx_t cbcb, con
 void grt_source_coef(GRT_MODEL1D *mod1d)
 {
     // 先全部赋0 
-    memset(mod1d->src_coefD, 0, sizeof(QWVgrid));
-    memset(mod1d->src_coefU, 0, sizeof(QWVgrid));
+    memset(mod1d->src_coefD, 0, sizeof(cplxQWVGrid));
+    memset(mod1d->src_coefU, 0, sizeof(cplxQWVGrid));
 
     grt_source_coef_PSV(mod1d);
     grt_source_coef_SH(mod1d);

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -40,7 +40,7 @@
  * @param[out]   grn            三分量结果，浮点数数组
  */
 static void recordin_GRN(
-    size_t nr, cplx_t coef, INTEGgrid sum_J[nr],
+    size_t nr, cplx_t coef, cplxIntegGrid sum_J[nr],
     real_t grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM]
 ){
     // 局部变量，将某个频点的格林函数谱临时存放
@@ -93,9 +93,9 @@ void grt_integ_static_grn(
     const real_t kmax = k0;
     // 求和 sum F(ki,w)Jm(ki*r)ki 
     // 关于形状详见int_Pk()函数内的注释
-    INTEGgrid *sum_J = (INTEGgrid *)calloc(nr, sizeof(*sum_J));
-    INTEGgrid *sum_uiz_J = (calc_upar)? (INTEGgrid *)calloc(nr, sizeof(*sum_uiz_J)) : NULL;
-    INTEGgrid *sum_uir_J = (calc_upar)? (INTEGgrid *)calloc(nr, sizeof(*sum_uir_J)) : NULL;
+    cplxIntegGrid *sum_J = (cplxIntegGrid *)calloc(nr, sizeof(*sum_J));
+    cplxIntegGrid *sum_uiz_J = (calc_upar)? (cplxIntegGrid *)calloc(nr, sizeof(*sum_uiz_J)) : NULL;
+    cplxIntegGrid *sum_uir_J = (calc_upar)? (cplxIntegGrid *)calloc(nr, sizeof(*sum_uir_J)) : NULL;
 
     // 是否要输出积分过程文件
     bool needfstats = (statsstr!=NULL);

--- a/pygrt/C_extension/src/static/static_source.c
+++ b/pygrt/C_extension/src/static/static_source.c
@@ -17,7 +17,7 @@
 #include "grt/static/static_source.h"
 
 
-inline GCC_ALWAYS_INLINE void _source_PSV(const cplx_t delta, const real_t k, QWVgrid coefD, QWVgrid coefU)
+inline GCC_ALWAYS_INLINE void _source_PSV(const cplx_t delta, const real_t k, cplxQWVGrid coefD, cplxQWVGrid coefU)
 {
     cplx_t tmp;
     cplx_t A = 1.0+delta;
@@ -46,7 +46,7 @@ inline GCC_ALWAYS_INLINE void _source_PSV(const cplx_t delta, const real_t k, QW
 }
 
 
-inline GCC_ALWAYS_INLINE void _source_SH(const real_t k, QWVgrid coefD, QWVgrid coefU)
+inline GCC_ALWAYS_INLINE void _source_SH(const real_t k, cplxQWVGrid coefD, cplxQWVGrid coefU)
 {
     cplx_t tmp;
 
@@ -64,8 +64,8 @@ inline GCC_ALWAYS_INLINE void _source_SH(const real_t k, QWVgrid coefD, QWVgrid 
 void grt_static_source_coef(GRT_MODEL1D *mod1d)
 {
     // 先全部赋0 
-    memset(mod1d->src_coefD, 0, sizeof(QWVgrid));
-    memset(mod1d->src_coefU, 0, sizeof(QWVgrid));
+    memset(mod1d->src_coefD, 0, sizeof(cplxQWVGrid));
+    memset(mod1d->src_coefU, 0, sizeof(cplxQWVGrid));
     
     grt_static_source_coef_PSV(mod1d);
     grt_static_source_coef_SH(mod1d);


### PR DESCRIPTION
``` C
typedef cplx_t cplxQWVGrid[GRT_SRC_M_NUM][GRT_QWV_NUM];

typedef cplx_t cplxIntegGrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
typedef real_t realIntegGrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
typedef size_t sizeIntegGrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
```