### PR TITLE
REFAC:  remove macro `GRT_QWV_NUM`, and some adjustments to the related date types.

### DIFF
--- a/pygrt/C_extension/include/grt/common/const.h
+++ b/pygrt/C_extension/include/grt/common/const.h
@@ -106,9 +106,8 @@ typedef double complex cplx_t;
 })
 
 // -----------------------------------------------------------------------------
-#define GRT_CHANNEL_NUM    3     ///< 3, 代码中分量个数（ZRT，ZNE）
+#define GRT_CHANNEL_NUM    3     ///< 3, 代码中分量个数（ZRT，ZNE），也是核函数类型个数(q, w, v)
 
-#define GRT_QWV_NUM     3   ///< 3, 代码中核函数类型个数(q, w, v)
 #define GRT_INTEG_NUM   4    ///< 4, 代码中积分类型个数
 #define GRT_MORDER_MAX   2    ///< 2, 代码中阶数m的最大值
 #define GRT_SRC_M_NUM    6   ///< 6, 代码中不同震源、不同阶数的个数
@@ -123,7 +122,11 @@ typedef double complex cplx_t;
 
 #define GRT_GTYPES_MAX   2      ///< 2, 所有震源根据是否使用格林函数导数分为两类
 
-typedef cplx_t cplxQWVGrid[GRT_SRC_M_NUM][GRT_QWV_NUM];
+typedef cplx_t     cplxChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+typedef cplx_t *pt_cplxChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+typedef real_t     realChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+typedef real_t *pt_realChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+typedef int        intChnlGrid [GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
 
 typedef cplx_t cplxIntegGrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];
 typedef real_t realIntegGrid[GRT_SRC_M_NUM][GRT_INTEG_NUM];

--- a/pygrt/C_extension/include/grt/common/integral.h
+++ b/pygrt/C_extension/include/grt/common/integral.h
@@ -24,7 +24,7 @@
  * @param[out]    SUM            该dk区间内的积分值
  * 
  */
-void grt_int_Pk(real_t k, real_t r, const cplxQWVGrid QWV, bool calc_uir, cplxIntegGrid SUM);
+void grt_int_Pk(real_t k, real_t r, const cplxChnlGrid QWV, bool calc_uir, cplxIntegGrid SUM);
 
 
 
@@ -35,7 +35,7 @@ void grt_int_Pk(real_t k, real_t r, const cplxQWVGrid QWV, bool calc_uir, cplxIn
  * @param[in]     sum_J           积分结果
  * @param[out]    tol             Z、R、T分量结果
  */
-void grt_merge_Pk(const cplxIntegGrid sum_J, cplx_t tol[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]);
+void grt_merge_Pk(const cplxIntegGrid sum_J, cplxChnlGrid tol);
 
 
 
@@ -53,7 +53,7 @@ void grt_merge_Pk(const cplxIntegGrid sum_J, cplx_t tol[GRT_SRC_M_NUM][GRT_CHANN
  * @param[out]    SUM            该dk区间内的积分值
  *  
  */
-void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const cplxQWVGrid QWV, bool calc_uir, cplxIntegGrid SUM);
+void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const cplxChnlGrid QWV, bool calc_uir, cplxIntegGrid SUM);
 
 
 /**
@@ -68,4 +68,4 @@ void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const cplxQWVGrid QWV, boo
  * @param[out]    SUM           该三点区间内的积分值
  * 
  */
-void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const cplxQWVGrid QWV3[3], bool calc_uir, cplxIntegGrid SUM);
+void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const cplxChnlGrid QWV3[3], bool calc_uir, cplxIntegGrid SUM);

--- a/pygrt/C_extension/include/grt/common/iostats.h
+++ b/pygrt/C_extension/include/grt/common/iostats.h
@@ -26,7 +26,7 @@
  * @note     文件记录的值均为波数积分的中间结果，与最终的结果还差一系列的系数，
  *           记录其值主要用于参考其变化趋势。
  */
-void grt_write_stats(FILE *f0, real_t k, const cplxQWVGrid QWV);
+void grt_write_stats(FILE *f0, real_t k, const cplxChnlGrid QWV);
 
 
 /**

--- a/pygrt/C_extension/include/grt/common/kernel.h
+++ b/pygrt/C_extension/include/grt/common/kernel.h
@@ -16,8 +16,8 @@
  * 计算核函数的函数指针，动态与静态的接口一致
  */
 typedef void (*GRT_KernelFunc) (
-    GRT_MODEL1D *mod1d, const real_t k, cplxQWVGrid QWV,
-    bool calc_uiz, cplxQWVGrid QWV_uiz);
+    GRT_MODEL1D *mod1d, const real_t k, cplxChnlGrid QWV,
+    bool calc_uiz, cplxChnlGrid QWV_uiz);
 
 
 /**
@@ -89,26 +89,26 @@ typedef void (*GRT_KernelFunc) (
  * 
  */
 void grt_kernel(
-    GRT_MODEL1D *mod1d, const real_t k, cplxQWVGrid QWV,
-    bool calc_uiz, cplxQWVGrid QWV_uiz);
+    GRT_MODEL1D *mod1d, const real_t k, cplxChnlGrid QWV,
+    bool calc_uiz, cplxChnlGrid QWV_uiz);
 
 /** 构建广义反射透射系数矩阵。作为 kernel 函数中的第一部分 */
 void grt_GRT_matrix(GRT_MODEL1D *mod1d, const real_t k);
 
 /** 从广义 R/T 矩阵出发，计算每个震源对应的核函数 QWV。 作为 kernel 函数中的第二部分 */
 void grt_GRT_build_QWV(
-    GRT_MODEL1D *mod1d, cplxQWVGrid QWV,
-    bool calc_uiz, cplxQWVGrid QWV_uiz);
+    GRT_MODEL1D *mod1d, cplxChnlGrid QWV,
+    bool calc_uiz, cplxChnlGrid QWV_uiz);
 
 /** 静态解的核函数 */
 void grt_static_kernel(
-    GRT_MODEL1D *mod1d, const real_t k, cplxQWVGrid QWV,
-    bool calc_uiz, cplxQWVGrid QWV_uiz);
+    GRT_MODEL1D *mod1d, const real_t k, cplxChnlGrid QWV,
+    bool calc_uiz, cplxChnlGrid QWV_uiz);
 
 /** 静态广义反射透射系数矩阵 */
 void grt_static_GRT_matrix(GRT_MODEL1D *mod1d, const real_t k);
 
 /** 静态 QWV */
 void grt_static_GRT_build_QWV(
-    GRT_MODEL1D *mod1d, cplxQWVGrid QWV,
-    bool calc_uiz, cplxQWVGrid QWV_uiz);
+    GRT_MODEL1D *mod1d, cplxChnlGrid QWV,
+    bool calc_uiz, cplxChnlGrid QWV_uiz);

--- a/pygrt/C_extension/include/grt/common/model.h
+++ b/pygrt/C_extension/include/grt/common/model.h
@@ -68,8 +68,8 @@ typedef struct {
     cplx_t uiz_R_EVL;
 
     /* 震源处的震源系数 \f$ P_m, SV_m, SH_m  */
-    cplxQWVGrid src_coefD;
-    cplxQWVGrid src_coefU;
+    cplxChnlGrid src_coefD;
+    cplxChnlGrid src_coefU;
 
 } GRT_MODEL1D;
 

--- a/pygrt/C_extension/include/grt/common/radiation.h
+++ b/pygrt/C_extension/include/grt/common/radiation.h
@@ -34,6 +34,6 @@
  *                                   对于张量源，mchn={Mxx, Mxy, Mxz, Myy, Myz, Mzz}
  */
 void grt_set_source_radiation(
-    real_t srcRadi[GRT_SRC_M_NUM][GRT_CHANNEL_NUM], const int computeType, const bool par_theta,
+    realChnlGrid srcRadi, const int computeType, const bool par_theta,
     const real_t M0, const real_t coef, const real_t azrad, const real_t mchn[GRT_MECHANISM_NUM]
 );

--- a/pygrt/C_extension/include/grt/common/util.h
+++ b/pygrt/C_extension/include/grt/common/util.h
@@ -131,6 +131,6 @@ void grt_GF_freq2time_write_to_file(
     const real_t delayT0, const real_t delayV0, const bool calc_upar,
     const bool doEX, const bool doVF, const bool doHF, const bool doDC, 
     const char *chalst,
-    cplx_t *grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM], 
-    cplx_t *grn_uiz[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM], 
-    cplx_t *grn_uir[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM]);
+    pt_cplxChnlGrid grn[nr], 
+    pt_cplxChnlGrid grn_uiz[nr], 
+    pt_cplxChnlGrid grn_uir[nr]);

--- a/pygrt/C_extension/include/grt/dynamic/grn.h
+++ b/pygrt/C_extension/include/grt/dynamic/grn.h
@@ -56,11 +56,11 @@ void grt_integ_grn_spec(
     bool print_progressbar, 
 
     // 返回值，代表Z、R、T分量
-    cplx_t *grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
+    pt_cplxChnlGrid grn[nr],
 
     bool calc_upar,
-    cplx_t *grn_uiz[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
-    cplx_t *grn_uir[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
+    pt_cplxChnlGrid grn_uiz[nr],
+    pt_cplxChnlGrid grn_uir[nr],
 
     const char *statsstr, // 积分过程输出
     size_t  nstatsidxs, // 仅输出特定频点

--- a/pygrt/C_extension/include/grt/static/static_grn.h
+++ b/pygrt/C_extension/include/grt/static/static_grn.h
@@ -46,11 +46,11 @@ void grt_integ_static_grn(
     real_t filonLength, real_t safilonTol, real_t filonCut, 
 
     // 返回值，代表Z、R、T分量
-    real_t grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
+    realChnlGrid grn[nr],
 
     bool calc_upar,
-    real_t grn_uiz[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
-    real_t grn_uir[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
+    realChnlGrid grn_uiz[nr],
+    realChnlGrid grn_uir[nr],
 
     const char *statsstr // 积分结果输出
 );

--- a/pygrt/C_extension/src/common/dwm.c
+++ b/pygrt/C_extension/src/common/dwm.c
@@ -36,8 +36,8 @@ real_t grt_discrete_integ(
     cplxIntegGrid SUM = {0};
 
     // 不同震源不同阶数的核函数 F(k, w) 
-    cplxQWVGrid QWV = {0};
-    cplxQWVGrid QWV_uiz = {0};
+    cplxChnlGrid QWV = {0};
+    cplxChnlGrid QWV_uiz = {0};
     
     real_t k = 0.0;
     size_t ik = 0;

--- a/pygrt/C_extension/src/common/fim.c
+++ b/pygrt/C_extension/src/common/fim.c
@@ -39,8 +39,8 @@ real_t grt_linear_filon_integ(
     cplxIntegGrid SUM;
 
     // 不同震源不同阶数的核函数 F(k, w) 
-    cplxQWVGrid QWV = {0};
-    cplxQWVGrid QWV_uiz = {0};
+    cplxChnlGrid QWV = {0};
+    cplxChnlGrid QWV_uiz = {0};
 
     real_t k=k0; 
     size_t ik=0;

--- a/pygrt/C_extension/src/common/integral.c
+++ b/pygrt/C_extension/src/common/integral.c
@@ -19,7 +19,7 @@
 
 
 
-void grt_int_Pk(real_t k, real_t r, const cplxQWVGrid QWV, bool calc_uir, cplxIntegGrid SUM)
+void grt_int_Pk(real_t k, real_t r, const cplxChnlGrid QWV, bool calc_uir, cplxIntegGrid SUM)
 {
     real_t bjmk[GRT_MORDER_MAX+1] = {0};
     real_t kr = k*r;
@@ -64,7 +64,7 @@ void grt_int_Pk(real_t k, real_t r, const cplxQWVGrid QWV, bool calc_uir, cplxIn
 }
 
 
-void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const cplxQWVGrid QWV, bool calc_uir, cplxIntegGrid SUM)
+void grt_int_Pk_filon(real_t k, real_t r, bool iscos, const cplxChnlGrid QWV, bool calc_uir, cplxIntegGrid SUM)
 {
     real_t phi0 = 0.0;
     if(! iscos)  phi0 = - HALFPI;  // 在cos函数中添加的相位差，用于计算sin函数
@@ -149,7 +149,7 @@ static cplx_t interg_quad_cos(
 
 
 
-void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const cplxQWVGrid QWV3[3], bool calc_uir, cplxIntegGrid SUM)
+void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const cplxChnlGrid QWV3[3], bool calc_uir, cplxIntegGrid SUM)
 {
     // 使用bessel递推公式 Jm'(x) = m/x * Jm(x) - J_{m+1}(x)
     // 考虑大震中距，忽略第一项，再使用bessel渐近公式
@@ -159,12 +159,12 @@ void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const cplxQWVGrid QWV3[3]
 
     // 对sqrt(k)*F(k,w)进行二次曲线拟合，再计算 (a*k^2 + b*k + c) * cos(kr - (2m+1)/4) 的积分
     // 拟合二次函数的参数
-    cplxQWVGrid quad_a={0};
-    cplxQWVGrid quad_b={0};
-    cplxQWVGrid quad_c={0};
+    cplxChnlGrid quad_a={0};
+    cplxChnlGrid quad_b={0};
+    cplxChnlGrid quad_c={0};
     for(int im=0; im<GRT_SRC_M_NUM; ++im){
         int modr = GRT_SRC_M_ORDERS[im];
-        for(int c=0; c<GRT_QWV_NUM; ++c){
+        for(int c=0; c<GRT_CHANNEL_NUM; ++c){
             if(modr==0 && GRT_QWV_CODES[c] == 'v')  continue;
 
             cplx_t F3[3];
@@ -194,7 +194,7 @@ void grt_int_Pk_sa_filon(const real_t k3[3], real_t r, const cplxQWVGrid QWV3[3]
 
 
 
-void grt_merge_Pk(const cplxIntegGrid sum_J, cplx_t tol[GRT_SRC_M_NUM][GRT_CHANNEL_NUM])
+void grt_merge_Pk(const cplxIntegGrid sum_J, cplxChnlGrid tol)
 {   
     for(int i=0; i<GRT_SRC_M_NUM; ++i){
         int modr = GRT_SRC_M_ORDERS[i];

--- a/pygrt/C_extension/src/common/iostats.c
+++ b/pygrt/C_extension/src/common/iostats.c
@@ -17,13 +17,13 @@
 
 
 
-void grt_write_stats(FILE *f0, real_t k, const cplxQWVGrid QWV)
+void grt_write_stats(FILE *f0, real_t k, const cplxChnlGrid QWV)
 {
     fwrite(&k, sizeof(real_t), 1, f0);
 
     for(int im=0; im<GRT_SRC_M_NUM; ++im){
         int modr = GRT_SRC_M_ORDERS[im];
-        for(int c=0; c<GRT_QWV_NUM; ++c){
+        for(int c=0; c<GRT_CHANNEL_NUM; ++c){
             if(modr == 0 && GRT_QWV_CODES[c] == 'v')   continue;
 
             fwrite(&QWV[im][c], sizeof(cplx_t), 1, f0);
@@ -41,7 +41,7 @@ int grt_extract_stats(FILE *bf0, FILE *af0){
 
         for(int im=0; im<GRT_SRC_M_NUM; ++im){
             int modr = GRT_SRC_M_ORDERS[im];
-            for(int c=0; c<GRT_QWV_NUM; ++c){
+            for(int c=0; c<GRT_CHANNEL_NUM; ++c){
                 if(modr == 0 && GRT_QWV_CODES[c] == 'v')   continue;
 
                 snprintf(K, sizeof(K), "%s_%c", GRT_SRC_M_NAME_ABBR[im], GRT_QWV_CODES[c]);
@@ -60,7 +60,7 @@ int grt_extract_stats(FILE *bf0, FILE *af0){
 
     for(int im=0; im<GRT_SRC_M_NUM; ++im){
         int modr = GRT_SRC_M_ORDERS[im];
-        for(int c=0; c<GRT_QWV_NUM; ++c){
+        for(int c=0; c<GRT_CHANNEL_NUM; ++c){
             if(modr == 0 && GRT_QWV_CODES[c] == 'v')   continue;
 
             if(1 != fread(&val, sizeof(cplx_t), 1, bf0))  return -1;

--- a/pygrt/C_extension/src/common/kernel.c
+++ b/pygrt/C_extension/src/common/kernel.c
@@ -48,7 +48,7 @@ inline GCC_ALWAYS_INLINE void grt_construct_qwv(
     bool ircvup, 
     const cplx_t R1[2][2], cplx_t RL1, 
     const cplx_t R2[2][2], cplx_t RL2, 
-    const cplxQWVGrid coefD, const cplxQWVGrid coefU, cplxQWVGrid QWV)
+    const cplxChnlGrid coefD, const cplxChnlGrid coefU, cplxChnlGrid QWV)
 {
     for(int i = 0; i < GRT_SRC_M_NUM; ++i)
     {

--- a/pygrt/C_extension/src/common/kernel_template.c_
+++ b/pygrt/C_extension/src/common/kernel_template.c_
@@ -154,12 +154,12 @@ void __GRT_MATRIX_FUNC__(GRT_MODEL1D *mod1d, const real_t k)
 
 
 void __BUILD_QWV__(
-    GRT_MODEL1D *mod1d, cplxQWVGrid QWV,
-    bool calc_uiz, cplxQWVGrid QWV_uiz)
+    GRT_MODEL1D *mod1d, cplxChnlGrid QWV,
+    bool calc_uiz, cplxChnlGrid QWV_uiz)
 {
     // 初始化qwv为0
-    memset(QWV, 0, sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
-    if(calc_uiz)  memset(QWV_uiz, 0, sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
+    memset(QWV, 0, sizeof(cplxChnlGrid));
+    if(calc_uiz)  memset(QWV_uiz, 0, sizeof(cplxChnlGrid));
 
     bool ircvup = mod1d->ircvup;
     // 广义层的反射透射系数
@@ -254,7 +254,7 @@ void __BUILD_QWV__(
     // 当震源和场点均位于地表时，可理论验证DS分量恒为0，这里直接赋0以避免后续的精度干扰
     if(mod1d->depsrc == 0.0 && mod1d->deprcv == 0.0)
     {
-        for(int c=0; c<GRT_QWV_NUM; ++c){
+        for(int c=0; c<GRT_CHANNEL_NUM; ++c){
             QWV[GRT_SRC_M_DS_INDEX][c] = 0.0;
             if(calc_uiz)  QWV_uiz[GRT_SRC_M_DS_INDEX][c] = 0.0;
         }
@@ -263,8 +263,8 @@ void __BUILD_QWV__(
 
 
 void __KERNEL_FUNC__(
-    GRT_MODEL1D *mod1d, const real_t k, cplxQWVGrid QWV,
-    bool calc_uiz, cplxQWVGrid QWV_uiz)
+    GRT_MODEL1D *mod1d, const real_t k, cplxChnlGrid QWV,
+    bool calc_uiz, cplxChnlGrid QWV_uiz)
 {
     __GRT_MATRIX_FUNC__(mod1d, k);
     __BUILD_QWV__(mod1d, QWV, calc_uiz, QWV_uiz);

--- a/pygrt/C_extension/src/common/ptam.c
+++ b/pygrt/C_extension/src/common/ptam.c
@@ -227,8 +227,8 @@ void grt_PTA_method(
     real_t k=0.0;
 
     // 不同震源不同阶数的核函数 F(k, w) 
-    cplxQWVGrid QWV = {0};
-    cplxQWVGrid QWV_uiz = {0};
+    cplxChnlGrid QWV = {0};
+    cplxChnlGrid QWV_uiz = {0};
 
     // 使用宏函数，方便定义
     #define __CALLOC_ARRAY(VAR, TYP, __ARR) \

--- a/pygrt/C_extension/src/common/radiation.c
+++ b/pygrt/C_extension/src/common/radiation.c
@@ -13,7 +13,7 @@
 #include "grt/common/const.h"
 
 void grt_set_source_radiation(
-    real_t srcRadi[GRT_SRC_M_NUM][GRT_CHANNEL_NUM], const int computeType, const bool par_theta,
+    realChnlGrid srcRadi, const int computeType, const bool par_theta,
     const real_t M0, const real_t coef, const real_t azrad, const real_t mchn[GRT_MECHANISM_NUM]
 ){
     real_t mult;

--- a/pygrt/C_extension/src/common/safim.c
+++ b/pygrt/C_extension/src/common/safim.c
@@ -51,8 +51,8 @@ typedef enum {
 // 区间结构体
 typedef struct { 
     real_t k3[3];
-    cplxQWVGrid F3[3]; 
-    cplxQWVGrid F3_uiz[3]; 
+    cplxChnlGrid F3[3]; 
+    cplxChnlGrid F3_uiz[3]; 
 } KInterval;
 
 // 区间栈结构体
@@ -104,7 +104,7 @@ static KInterval stack_pop(KIntervalStack *stack) {
 static cplx_t simpson(const KInterval *item_pt, int im, int iqwv, bool isuiz, SIMPSON_INTV stats) {
     cplx_t Fint = 0.0;
     real_t klen = item_pt->k3[2] -  item_pt->k3[0];
-    const cplxQWVGrid *F3 = (isuiz)? item_pt->F3_uiz : item_pt->F3;
+    const cplxChnlGrid *F3 = (isuiz)? item_pt->F3_uiz : item_pt->F3;
     
     // 使用F(k)*sqrt(k)来衡量积分值，这可以平衡后续计算F(k)*Jm(kr)k积分时的系数
     real_t sk[3];
@@ -136,10 +136,10 @@ static cplx_t simpson(const KInterval *item_pt, int im, int iqwv, bool isuiz, SI
 }
 
 /** 比较QWV的最大绝对值 */
-static void get_maxabsQWV(const cplxQWVGrid F, real_t maxabsF[GRT_GTYPES_MAX]){
+static void get_maxabsQWV(const cplxChnlGrid F, real_t maxabsF[GRT_GTYPES_MAX]){
     real_t tmp;
     for(int i=0; i<GRT_SRC_M_NUM; ++i){
-        for(int c=0; c<GRT_QWV_NUM; ++c){
+        for(int c=0; c<GRT_CHANNEL_NUM; ++c){
             tmp = fabs(F[i][c]);
             if(tmp > maxabsF[GRT_SRC_M_GTYPES[i]]){
                 maxabsF[GRT_SRC_M_GTYPES[i]] = tmp;
@@ -158,8 +158,8 @@ static bool check_fit(
     cplx_t S11, S12, S21, S22;
 
     // 核函数
-    const cplxQWVGrid *F3L = (isuiz)? ptKitvL->F3_uiz : ptKitvL->F3;
-    const cplxQWVGrid *F3R = (isuiz)? ptKitvR->F3_uiz : ptKitvR->F3;
+    const cplxChnlGrid *F3L = (isuiz)? ptKitvL->F3_uiz : ptKitvL->F3;
+    const cplxChnlGrid *F3R = (isuiz)? ptKitvR->F3_uiz : ptKitvR->F3;
 
     // 取近似积分 \int_k1^k2 k^0.5 dk
     real_t kcoef13 = RTWOTHIRD*( ptKitv->k3[2]*sqrt(ptKitv->k3[2]) - ptKitv->k3[0]*sqrt(ptKitv->k3[0]) );
@@ -170,7 +170,7 @@ static bool check_fit(
     bool badtol = false;
     for(int im=0; im<GRT_SRC_M_NUM; ++im){
         int igtyp = GRT_SRC_M_GTYPES[im];
-        for(int c=0; c<GRT_QWV_NUM; ++c){
+        for(int c=0; c<GRT_CHANNEL_NUM; ++c){
             if(GRT_SRC_M_ORDERS[im]==0 && GRT_QWV_CODES[c]=='v')  continue;
             // qw和v分开采样?
             // if(isqw && GRT_QWV_CODES[c]=='v')  continue;
@@ -360,15 +360,15 @@ real_t grt_sa_filon_integ(
             .F3 = {{{0}}}, 
             .F3_uiz = {{{0}}} 
         };
-        memcpy(Kitv_left.F3[0], Kitv.F3[0], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
-        memcpy(Kitv_left.F3[2], Kitv.F3[1], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
-        memcpy(Kitv_right.F3[0], Kitv.F3[1], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
-        memcpy(Kitv_right.F3[2], Kitv.F3[2], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
+        memcpy(Kitv_left.F3[0], Kitv.F3[0], sizeof(cplxChnlGrid));
+        memcpy(Kitv_left.F3[2], Kitv.F3[1], sizeof(cplxChnlGrid));
+        memcpy(Kitv_right.F3[0], Kitv.F3[1], sizeof(cplxChnlGrid));
+        memcpy(Kitv_right.F3[2], Kitv.F3[2], sizeof(cplxChnlGrid));
         if(calc_upar){
-            memcpy(Kitv_left.F3_uiz[0], Kitv.F3_uiz[0], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
-            memcpy(Kitv_left.F3_uiz[2], Kitv.F3_uiz[1], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
-            memcpy(Kitv_right.F3_uiz[0], Kitv.F3_uiz[1], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
-            memcpy(Kitv_right.F3_uiz[2], Kitv.F3_uiz[2], sizeof(cplx_t)*GRT_SRC_M_NUM*GRT_QWV_NUM);
+            memcpy(Kitv_left.F3_uiz[0], Kitv.F3_uiz[0], sizeof(cplxChnlGrid));
+            memcpy(Kitv_left.F3_uiz[2], Kitv.F3_uiz[1], sizeof(cplxChnlGrid));
+            memcpy(Kitv_right.F3_uiz[0], Kitv.F3_uiz[1], sizeof(cplxChnlGrid));
+            memcpy(Kitv_right.F3_uiz[2], Kitv.F3_uiz[2], sizeof(cplxChnlGrid));
         }
         
         kerfunc(mod1d, Kitv_left.k3[1], Kitv_left.F3[1], calc_upar, Kitv_left.F3_uiz[1]);

--- a/pygrt/C_extension/src/common/util.c
+++ b/pygrt/C_extension/src/common/util.c
@@ -300,9 +300,9 @@ static void single_freq2time_write_to_file(
     const real_t delayT0, const real_t delayV0, const bool calc_upar,
     const bool doEX, const bool doVF, const bool doHF, const bool doDC, 
     SACHEAD *pt_hd, const char *chalst,
-    cplx_t *grn[GRT_SRC_M_NUM][GRT_CHANNEL_NUM], 
-    cplx_t *grn_uiz[GRT_SRC_M_NUM][GRT_CHANNEL_NUM], 
-    cplx_t *grn_uir[GRT_SRC_M_NUM][GRT_CHANNEL_NUM])
+    pt_cplxChnlGrid grn, 
+    pt_cplxChnlGrid grn_uiz, 
+    pt_cplxChnlGrid grn_uir)
 {
     // 文件保存子目录
     char *s_output_subdir = NULL;
@@ -377,9 +377,9 @@ void grt_GF_freq2time_write_to_file(
     const real_t delayT0, const real_t delayV0, const bool calc_upar,
     const bool doEX, const bool doVF, const bool doHF, const bool doDC, 
     const char *chalst,
-    cplx_t *grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM], 
-    cplx_t *grn_uiz[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM], 
-    cplx_t *grn_uir[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM])
+    pt_cplxChnlGrid grn[nr], 
+    pt_cplxChnlGrid grn_uiz[nr], 
+    pt_cplxChnlGrid grn_uir[nr])
 {
     // 建立SAC头文件，包含必要的头变量
     SACHEAD hd = new_sac_head(pt_fh->dt, pt_fh->nt, delayT0);

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -45,11 +45,10 @@
  */
 static void recordin_GRN(
     size_t iw, size_t nr, cplx_t coef, cplxIntegGrid sum_J[nr],
-    cplx_t *grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM]
-)
+    pt_cplxChnlGrid grn[nr])
 {
     // 局部变量，将某个频点的格林函数谱临时存放
-    cplx_t (*tmp_grn)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (cplx_t(*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM])calloc(nr, sizeof(*tmp_grn));
+    cplxChnlGrid *tmp_grn = (cplxChnlGrid *)calloc(nr, sizeof(*tmp_grn));
 
     for(size_t ir=0; ir<nr; ++ir){
         grt_merge_Pk(sum_J[ir], tmp_grn[ir]);
@@ -77,11 +76,11 @@ void grt_integ_grn_spec(
     bool print_progressbar, 
 
     // 返回值，代表Z、R、T分量
-    cplx_t *grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
+    pt_cplxChnlGrid grn[nr],
 
     bool calc_upar,
-    cplx_t *grn_uiz[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
-    cplx_t *grn_uir[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
+    pt_cplxChnlGrid grn_uiz[nr],
+    pt_cplxChnlGrid grn_uir[nr],
 
     const char *statsstr, // 积分结果输出
     size_t  nstatsidxs, // 仅输出特定频点

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -876,9 +876,9 @@ int greenfn_main(int argc, char **argv) {
     }
 
     // 建立格林函数的complex数组
-    cplx_t *(*grn)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (cplx_t*(*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]) calloc(Ctrl->R.nr, sizeof(*grn));
-    cplx_t *(*grn_uiz)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (Ctrl->e.active)? (cplx_t*(*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]) calloc(Ctrl->R.nr, sizeof(*grn_uiz)) : NULL;
-    cplx_t *(*grn_uir)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (Ctrl->e.active)? (cplx_t*(*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]) calloc(Ctrl->R.nr, sizeof(*grn_uir)) : NULL;
+    pt_cplxChnlGrid *grn = (pt_cplxChnlGrid *) calloc(Ctrl->R.nr, sizeof(*grn));
+    pt_cplxChnlGrid *grn_uiz = (Ctrl->e.active)? (pt_cplxChnlGrid *) calloc(Ctrl->R.nr, sizeof(*grn_uiz)) : NULL;
+    pt_cplxChnlGrid *grn_uir = (Ctrl->e.active)? (pt_cplxChnlGrid *) calloc(Ctrl->R.nr, sizeof(*grn_uir)) : NULL;
 
     for(size_t ir=0; ir<Ctrl->R.nr; ++ir){
         for(int i=0; i<GRT_SRC_M_NUM; ++i){

--- a/pygrt/C_extension/src/dynamic/grt_syn.c
+++ b/pygrt/C_extension/src/dynamic/grt_syn.c
@@ -95,7 +95,7 @@ typedef struct {
     real_t mchn[GRT_MECHANISM_NUM];
 
     // 方向因子数组
-    real_t srcRadi[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+    realChnlGrid srcRadi;
 
     // 最终要计算的震源类型
     int computeType;

--- a/pygrt/C_extension/src/dynamic/source.c
+++ b/pygrt/C_extension/src/dynamic/source.c
@@ -18,7 +18,7 @@
 
 inline GCC_ALWAYS_INLINE void _source_PSV(
     const cplx_t xa, const cplx_t caca, 
-    const cplx_t xb, const cplx_t cbcb, const real_t k, cplxQWVGrid coefD, cplxQWVGrid coefU)
+    const cplx_t xb, const cplx_t cbcb, const real_t k, cplxChnlGrid coefD, cplxChnlGrid coefU)
 {
     cplx_t tmp;
 
@@ -47,7 +47,7 @@ inline GCC_ALWAYS_INLINE void _source_PSV(
 
 }
 
-inline GCC_ALWAYS_INLINE void _source_SH(const cplx_t xb, const cplx_t cbcb, const real_t k, cplxQWVGrid coefD, cplxQWVGrid coefU)
+inline GCC_ALWAYS_INLINE void _source_SH(const cplx_t xb, const cplx_t cbcb, const real_t k, cplxChnlGrid coefD, cplxChnlGrid coefU)
 {
     cplx_t tmp;
 
@@ -66,8 +66,8 @@ inline GCC_ALWAYS_INLINE void _source_SH(const cplx_t xb, const cplx_t cbcb, con
 void grt_source_coef(GRT_MODEL1D *mod1d)
 {
     // 先全部赋0 
-    memset(mod1d->src_coefD, 0, sizeof(cplxQWVGrid));
-    memset(mod1d->src_coefU, 0, sizeof(cplxQWVGrid));
+    memset(mod1d->src_coefD, 0, sizeof(cplxChnlGrid));
+    memset(mod1d->src_coefU, 0, sizeof(cplxChnlGrid));
 
     grt_source_coef_PSV(mod1d);
     grt_source_coef_SH(mod1d);

--- a/pygrt/C_extension/src/static/grt_static_greenfn.c
+++ b/pygrt/C_extension/src/static/grt_static_greenfn.c
@@ -496,9 +496,9 @@ int static_greenfn_main(int argc, char **argv){
     }
 
     // 建立格林函数的浮点数
-    real_t (*grn)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (real_t (*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]) calloc(Ctrl->nr, sizeof(*grn));
-    real_t (*grn_uiz)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (Ctrl->e.active)? (real_t (*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]) calloc(Ctrl->nr, sizeof(*grn_uiz)) : NULL;
-    real_t (*grn_uir)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (Ctrl->e.active)? (real_t (*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM]) calloc(Ctrl->nr, sizeof(*grn_uir)) : NULL;
+    realChnlGrid *grn = (realChnlGrid *) calloc(Ctrl->nr, sizeof(*grn));
+    realChnlGrid *grn_uiz = (Ctrl->e.active)? (realChnlGrid *) calloc(Ctrl->nr, sizeof(*grn_uiz)) : NULL;
+    realChnlGrid *grn_uir = (Ctrl->e.active)? (realChnlGrid *) calloc(Ctrl->nr, sizeof(*grn_uir)) : NULL;
 
 
     //==============================================================================
@@ -525,9 +525,9 @@ int static_greenfn_main(int argc, char **argv){
     const int ndims = 2;
     int dimids[ndims];
     int x_varid, y_varid;
-    int u_varids[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
-    int uiz_varids[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
-    int uir_varids[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+    intChnlGrid u_varids;
+    intChnlGrid uiz_varids;
+    intChnlGrid uir_varids;
 
     // 创建 NC 文件
     NC_CHECK(nc_create(Ctrl->O.s_outgrid, NC_CLOBBER, &ncid));

--- a/pygrt/C_extension/src/static/grt_static_syn.c
+++ b/pygrt/C_extension/src/static/grt_static_syn.c
@@ -61,7 +61,7 @@ typedef struct {
     real_t mchn[GRT_MECHANISM_NUM];
 
     // 方向因子数组
-    real_t srcRadi[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+    realChnlGrid srcRadi;
 
     // 最终要计算的震源类型
     int computeType;
@@ -311,9 +311,9 @@ int static_syn_main(int argc, char **argv){
     int in_x_dimid, in_y_dimid;
     int in_x_varid, in_y_varid;
     const int ndims = 2;
-    int in_u_varids[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
-    int in_uiz_varids[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
-    int in_uir_varids[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+    intChnlGrid in_u_varids;
+    intChnlGrid in_uiz_varids;
+    intChnlGrid in_uir_varids;
     int out_ncid;
     int out_x_dimid, out_y_dimid;
     int out_x_varid, out_y_varid;
@@ -435,9 +435,9 @@ int static_syn_main(int argc, char **argv){
 
     // 先将所有格林函数及其偏导读入内存，
     // 否则连续使用 nc_grt_var1 式读入效率太慢
-    real_t *u[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
-    real_t *uiz[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
-    real_t *uir[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
+    pt_realChnlGrid u;
+    pt_realChnlGrid uiz;
+    pt_realChnlGrid uir;
     for(int i=0; i<GRT_SRC_M_NUM; ++i){
         int modr = GRT_SRC_M_ORDERS[i];
         for(int c=0; c<GRT_CHANNEL_NUM; ++c){

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -41,10 +41,10 @@
  */
 static void recordin_GRN(
     size_t nr, cplx_t coef, cplxIntegGrid sum_J[nr],
-    real_t grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM]
-){
+    realChnlGrid grn[nr])
+{
     // 局部变量，将某个频点的格林函数谱临时存放
-    cplx_t (*tmp_grn)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM] = (cplx_t(*)[GRT_SRC_M_NUM][GRT_CHANNEL_NUM])calloc(nr, sizeof(*tmp_grn));
+    cplxChnlGrid *tmp_grn = (cplxChnlGrid *)calloc(nr, sizeof(*tmp_grn));
 
     for(size_t ir=0; ir<nr; ++ir){
         grt_merge_Pk(sum_J[ir], tmp_grn[ir]);
@@ -67,11 +67,11 @@ void grt_integ_static_grn(
     real_t filonLength, real_t safilonTol, real_t filonCut, 
 
     // 返回值，代表Z、R、T分量
-    real_t grn[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
+    realChnlGrid grn[nr],
 
     bool calc_upar,
-    real_t grn_uiz[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
-    real_t grn_uir[nr][GRT_SRC_M_NUM][GRT_CHANNEL_NUM],
+    realChnlGrid grn_uiz[nr],
+    realChnlGrid grn_uir[nr],
 
     const char *statsstr // 积分结果输出
 ){

--- a/pygrt/C_extension/src/static/static_source.c
+++ b/pygrt/C_extension/src/static/static_source.c
@@ -17,7 +17,7 @@
 #include "grt/static/static_source.h"
 
 
-inline GCC_ALWAYS_INLINE void _source_PSV(const cplx_t delta, const real_t k, cplxQWVGrid coefD, cplxQWVGrid coefU)
+inline GCC_ALWAYS_INLINE void _source_PSV(const cplx_t delta, const real_t k, cplxChnlGrid coefD, cplxChnlGrid coefU)
 {
     cplx_t tmp;
     cplx_t A = 1.0+delta;
@@ -46,7 +46,7 @@ inline GCC_ALWAYS_INLINE void _source_PSV(const cplx_t delta, const real_t k, cp
 }
 
 
-inline GCC_ALWAYS_INLINE void _source_SH(const real_t k, cplxQWVGrid coefD, cplxQWVGrid coefU)
+inline GCC_ALWAYS_INLINE void _source_SH(const real_t k, cplxChnlGrid coefD, cplxChnlGrid coefU)
 {
     cplx_t tmp;
 
@@ -64,8 +64,8 @@ inline GCC_ALWAYS_INLINE void _source_SH(const real_t k, cplxQWVGrid coefD, cplx
 void grt_static_source_coef(GRT_MODEL1D *mod1d)
 {
     // 先全部赋0 
-    memset(mod1d->src_coefD, 0, sizeof(cplxQWVGrid));
-    memset(mod1d->src_coefU, 0, sizeof(cplxQWVGrid));
+    memset(mod1d->src_coefD, 0, sizeof(cplxChnlGrid));
+    memset(mod1d->src_coefU, 0, sizeof(cplxChnlGrid));
     
     grt_static_source_coef_PSV(mod1d);
     grt_static_source_coef_SH(mod1d);


### PR DESCRIPTION
``` C
typedef cplx_t     cplxChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
typedef cplx_t *pt_cplxChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
typedef real_t     realChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
typedef real_t *pt_realChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
typedef int        intChnlGrid [GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
```