### PR TITLE
FEAT: save z-derivative kernels when set `-e` or `calc_upar=True`

### DIFF
--- a/example/view_integ_stats/run_stgrt.sh
+++ b/example/view_integ_stats/run_stgrt.sh
@@ -1,4 +1,4 @@
 #!/bin/bash 
 
 
-grt static greenfn -Mhalfspace2 -D0.1/0 -X-3/3/0.6 -Y-5/5/0.5 -Ostgrn.nc -e -S
+grt static greenfn -Mhalfspace2 -D0.1/0 -X-3/3/0.6 -Y-5/5/0.5 -Ostgrn.nc -S

--- a/pygrt/C_extension/src/integral/dwm.c
+++ b/pygrt/C_extension/src/integral/dwm.c
@@ -55,7 +55,7 @@ real_t grt_discrete_integ(
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
         
         // 记录积分核函数
-        if(fstats!=NULL)  grt_write_stats(fstats, k, QWV);
+        if(fstats!=NULL)  grt_write_stats(fstats, k, (K->calc_upar)? QWV_uiz : QWV);
 
         // 震中距rs循环
         iendk = true;

--- a/pygrt/C_extension/src/integral/fim.c
+++ b/pygrt/C_extension/src/integral/fim.c
@@ -56,7 +56,7 @@ real_t grt_linear_filon_integ(
         if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
 
         // 记录积分结果
-        if(fstats!=NULL)  grt_write_stats(fstats, k, QWV);
+        if(fstats!=NULL)  grt_write_stats(fstats, k, (K->calc_upar)? QWV_uiz : QWV);
 
         // 震中距rs循环
         iendk = true;

--- a/pygrt/C_extension/src/integral/ptam.c
+++ b/pygrt/C_extension/src/integral/ptam.c
@@ -284,7 +284,7 @@ void grt_PTA_method(
             if(mod1d->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
 
             // 记录核函数
-            if(ptam_fstatsnr != NULL)  grt_write_stats(ptam_fstatsnr[ir][0], k, QWV);
+            if(ptam_fstatsnr != NULL)  grt_write_stats(ptam_fstatsnr[ir][0], k, (K->calc_upar)? QWV_uiz : QWV);
 
             // 计算被积函数一项 F(k,w)Jm(kr)k
             grt_int_Pk(k, rs[ir], QWV, false, SUM3[ir][GRT_PTAM_WINDOW_SIZE-1]);  // [GRT_PTAM_WINDOW_SIZE-1]表示把新点值放在最后
@@ -315,7 +315,7 @@ void grt_PTA_method(
     // 做缩减序列，赋值最终解
     for(size_t ir=0; ir<nr; ++ir){
         // 记录到文件
-        if(ptam_fstatsnr != NULL)  grt_write_stats_ptam(ptam_fstatsnr[ir][1], Kpt[ir], Fpt[ir]);
+        if(ptam_fstatsnr != NULL)  grt_write_stats_ptam(ptam_fstatsnr[ir][1], Kpt[ir], (K->calc_upar)? Fpt_uiz[ir] : Fpt[ir]);
 
         GRT_LOOP_IntegGrid(im, v){
             _cplx_shrink(Ipt[ir][im][v], ir, im, v, Fpt);  

--- a/pygrt/C_extension/src/integral/safim.c
+++ b/pygrt/C_extension/src/integral/safim.c
@@ -316,7 +316,7 @@ real_t grt_sa_filon_integ(
     real_t maxabsQWV_uiz[GRT_GTYPES_MAX]={0};
 
     // 记录第一个值
-    if(fstats!=NULL)  grt_write_stats(fstats, Kitv.k3[0], Kitv.F3[0]);
+    if(fstats!=NULL)  grt_write_stats(fstats, Kitv.k3[0], (K->calc_upar)? Kitv.F3_uiz[0] : Kitv.F3[0]);
 
     // 自适应采样
     while(stack.size > 0) {
@@ -386,10 +386,10 @@ real_t grt_sa_filon_integ(
             // 记录后四个采样值
             if(fstats!=NULL){
                 for(int i=1; i<3; ++i){
-                    grt_write_stats(fstats, Kitv_left.k3[i], Kitv_left.F3[i]);
+                    grt_write_stats(fstats, Kitv_left.k3[i], (K->calc_upar)? Kitv_left.F3_uiz[i] : Kitv_left.F3[i]);
                 }
                 for(int i=1; i<3; ++i){
-                    grt_write_stats(fstats, Kitv_right.k3[i], Kitv_right.F3[i]);
+                    grt_write_stats(fstats, Kitv_right.k3[i], (K->calc_upar)? Kitv_right.F3_uiz[i] : Kitv_right.F3[i]);
                 }
             }
             // 计算积分


### PR DESCRIPTION
``` C
grt_write_stats(fstats, k, (K->calc_upar)? QWV_uiz : QWV);
```