### PR TITLE
FIX: ModuleNotFoundError of 'pkg_resources' from obspy

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,6 @@ sphinxcontrib-jsmath
 nbsphinx
 graphviz
 sphinx-tabs
-setuptools
 setuptools-scm  # 自动从git tag中构建版本
 sphinx-design==0.5.0
 sphinx-last-updated-by-git

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'scipy>=1.10',
         'matplotlib>=3.5',
         'obspy>=1.4',
+        'setuptools==80.10.2'  # 兼容 obspy 对 pkg_resources 的使用
     ],
     python_requires='>=3.6',
     zip_safe=False,  # not compress the binary file


### PR DESCRIPTION
之前RTD构建文档时运行 `python -m pip install --upgrade --no-cache-dir pip setuptools ` 安装的是 `setuptools==80.10.2` 版本，大概是最近升级为 `setuptools==82.0.0` ，新版本弃用了python的老程序包 `pkg_resouces` ，但 `obspy==1.4.2` 目前还在使用 `pkg_resouces` ，为了兼容性，在 `setup.py` 中明确安装 `setuptools==80.10.2` 