### PR TITLE
BUILD: avoid using formats like "-l:libXYZ.a" to link libraries in Mac

### DIFF
--- a/pygrt/C_extension/Makefile
+++ b/pygrt/C_extension/Makefile
@@ -11,24 +11,13 @@ VERSION := v$(shell cat version )
 DATE := $(shell date +%Y-%m-%d)
 
 
+# 在Github构建时，仅编译出静态库，这样 -lfftw3 类似的表述既能用于Github构建也能在本地链接动态库时构建
+
 # link options for FFTW
 # NEED EXPLICITY SET LIBRARY PATH on MacOS
-LFFTW_FLAGS := -l:libfftw3.a  -l:libfftw3f.a
-ifneq ($(OS), Windows_NT)
-    UNAME_S := $(shell uname -s)
-    # macOS
-    ifeq ($(UNAME_S), Darwin)
-		LFFTW_FLAGS := -lfftw3 -lfftw3f
-    endif
-endif
-# detect macOS environment template
-UNAME_S := $(shell uname -s)
-IS_MACOS := $(filter Darwin,$(UNAME_S))
-
-
+LFFTW_FLAGS := -lfftw3 -lfftw3f
 
 CC := gcc
-
 
 # add -static to enforce gcc link the static library, no matter standard-lib or custom-lib,
 # -l like "-l:libXYZ.a" should be saved for conditional compile.

--- a/pygrt/C_extension/Makefile
+++ b/pygrt/C_extension/Makefile
@@ -14,6 +14,18 @@ DATE := $(shell date +%Y-%m-%d)
 # link options for FFTW
 # NEED EXPLICITY SET LIBRARY PATH on MacOS
 LFFTW_FLAGS := -l:libfftw3.a  -l:libfftw3f.a
+ifneq ($(OS), Windows_NT)
+    UNAME_S := $(shell uname -s)
+    # macOS
+    ifeq ($(UNAME_S), Darwin)
+		LFFTW_FLAGS := -lfftw3 -lfftw3f
+    endif
+endif
+# detect macOS environment template
+UNAME_S := $(shell uname -s)
+IS_MACOS := $(filter Darwin,$(UNAME_S))
+
+
 
 CC := gcc
 


### PR DESCRIPTION
+ 对于Mac和Linux系统，在Github构建时均已显式指定静态库，不受该PR影响
+ 对于Windows系统，已经直接使用了 -static 来链接静态库
+ 直接使用 -lXYZ 的形式更利于本地编译