### PR TITLE
FEAT+FIX: support small epicentral distance, support adaptive upper bound, fix DCM for z-directive

### DIFF
--- a/docs/source/Advanced/integ_converg/ptam.rst
+++ b/docs/source/Advanced/integ_converg/ptam.rst
@@ -109,7 +109,7 @@
 
 + **只使用离散波数积分**
 
-.. figure:: run_ptam/SS_0_0.1_static.svg
+.. figure:: run_ptam/SS_0_0.05_static.svg
     :align: center
 
 ----------------------------------
@@ -117,7 +117,7 @@
 
 + **使用峰谷平均法**
   
-.. figure:: run_ptam/SS_0_0.1_ptam_static.svg
+.. figure:: run_ptam/SS_0_0.05_ptam_static.svg
     :align: center
 
 

--- a/docs/source/Advanced/integ_converg/run_dcm/run.sh
+++ b/docs/source/Advanced/integ_converg/run_dcm/run.sh
@@ -26,7 +26,7 @@ zeta=0.8
 L="-L20"
 # 取不同震源深度，输出核函数的变化 seq 0 0.02 0.2; 
 for depsrc in $(seq 0 0.02 0.4); do
-    grt greenfn -M${modname} -O${out} -N${nt}/${dt}/$zeta -D${depsrc}/${deprcv} -R${dist} $L -H5/5 -S25 -K+k50+s5 -Cn
+    grt greenfn -M${modname} -O${out} -N${nt}/${dt}/$zeta -D${depsrc}/${deprcv} -R${dist} $L -H5/5 -S25 -K+k50+s5+f -Cn
 done
 
 python plot_depth_kernel.py

--- a/docs/source/Advanced/integ_converg/run_ptam/run.py
+++ b/docs/source/Advanced/integ_converg/run_ptam/run.py
@@ -40,7 +40,7 @@ import pygrt
 
 modarr = np.loadtxt("milrow")
 
-depsrc = 0.1
+depsrc = 0.05
 deprcv = 0.0
 pymod = pygrt.PyModel1D(modarr, depsrc=depsrc, deprcv=deprcv)
 

--- a/docs/source/Advanced/integ_converg/run_ptam/run.sh
+++ b/docs/source/Advanced/integ_converg/run_ptam/run.sh
@@ -26,10 +26,10 @@ echo "..." >> ptam_stats_head
 # -------------------------------------------------------------------
 # BEGIN SGRN
 # -S 表示输出核函数文件
-grt static greenfn -Mmilrow -D0.1/0 -X2/2/1 -Y2/2/1 -Cp -S -Ostgrn.nc
+grt static greenfn -Mmilrow -D0.05/0 -X2/2/1 -Y2/2/1 -Cp -S -Ostgrn.nc
 
 # grt.ker2asc 也可以读取静态解输出的核函数文件，格式一致
-grt ker2asc stgrtstats/milrow_0.1_0/K > static_stats
+grt ker2asc stgrtstats/milrow_0.05_0/K > static_stats
 
 # 绘制图像部分见Python
 # END SGRN

--- a/docs/source/Gallery/ex14/plot.py
+++ b/docs/source/Gallery/ex14/plot.py
@@ -30,9 +30,11 @@ t = np.arange(0, nt)*dt * Vs/r
 
 pymod = pygrt.PyModel1D(modarr, depsrc, deprcv)  # 整理好的模型对象
 # 计算格林函数
-st_none = pymod.compute_grn(distarr=rs, nt=nt, dt=dt, converg_method='none')[0]
-st_dcm = pymod.compute_grn(distarr=rs, nt=nt, dt=dt, converg_method='DCM')[0]
-st_ptam = pymod.compute_grn(distarr=rs, nt=nt, dt=dt, converg_method='DCM')[0]
+# 限制 k0 不太高以进行对比
+k0 = 10
+st_none = pymod.compute_grn(distarr=rs, nt=nt, dt=dt, k0=k0, converg_method='none')[0]
+st_dcm = pymod.compute_grn(distarr=rs, nt=nt, dt=dt, k0=k0, converg_method='DCM')[0]
+st_ptam = pymod.compute_grn(distarr=rs, nt=nt, dt=dt, k0=k0, converg_method='DCM')[0]
 
 # 卷积阶跃函数
 pygrt.utils.stream_integral(st_none)

--- a/docs/source/Tutorial/modal/run/plot_dispersion.sh
+++ b/docs/source/Tutorial/modal/run/plot_dispersion.sh
@@ -6,15 +6,21 @@ function _plot(){
     filepath=$1
     title=$2
     args=$3
+
+    # 在 mac 上运行 ncap2 总是需要指定“输出文件”， weird
+    JUNK=".JUNK"
+
     # 最高阶
-    maxmode=$(ncap2 -s 'print(max(mode))' $filepath | awk '{print $NF}')
+    maxmode=$(ncap2 -O -s 'print(max(mode))' $filepath $JUNK | awk '{print $NF}')
     # 最高频率
-    maxfreq=$(ncap2 -s 'print(max(freq))' $filepath | awk '{print $NF}')
+    maxfreq=$(ncap2 -O -s 'print(max(freq))' $filepath $JUNK | awk '{print $NF}')
     # 取合适的速度范围
-    minc=$(ncap2 -s 'print(min(c))' $filepath | awk '{print $NF}')
-    maxc=$(ncap2 -s 'print(max(c))' $filepath | awk '{print $NF}')
+    minc=$(ncap2 -O -s 'print(min(c))' $filepath $JUNK | awk '{print $NF}')
+    maxc=$(ncap2 -O -s 'print(max(c))' $filepath $JUNK | awk '{print $NF}')
     c1=$(echo "scale=1; $minc - ($maxc - $minc) * 0.05" | bc)
     c2=$(echo "scale=1; $maxc + ($maxc - $minc) * 0.05" | bc)
+
+    rm $JUNK
 
     gmt basemap -R0/$maxfreq/$c1/$c2 -JX10c/7c -Bxa1f+l"Frequency (Hz)" -Bya0.2f+l"Phase velocity (km/s)" -BWSen+t"$title" $args
     for i in $(seq 0 $maxmode); do

--- a/docs/source/Tutorial/modal/run/plot_dispersion_group.sh
+++ b/docs/source/Tutorial/modal/run/plot_dispersion_group.sh
@@ -6,15 +6,21 @@ function _plot(){
     filepath=$1
     title=$2
     args=$3
+
+    # 在 mac 上运行 ncap2 总是需要指定“输出文件”， weird
+    JUNK=".JUNK"
+
     # 最高阶
-    maxmode=$(ncap2 -s 'print(max(mode))' $filepath | awk '{print $NF}')
+    maxmode=$(ncap2 -O -s 'print(max(mode))' $filepath $JUNK | awk '{print $NF}')
     # 最高频率
-    maxfreq=$(ncap2 -s 'print(max(freq))' $filepath | awk '{print $NF}')
+    maxfreq=$(ncap2 -O -s 'print(max(freq))' $filepath $JUNK | awk '{print $NF}')
     # 取合适的速度范围
-    minc=$(ncap2 -s 'print(min(u))' $filepath | awk '{print $NF}')
-    maxc=$(ncap2 -s 'print(max(u))' $filepath | awk '{print $NF}')
+    minc=$(ncap2 -O -s 'print(min(u))' $filepath $JUNK | awk '{print $NF}')
+    maxc=$(ncap2 -O -s 'print(max(u))' $filepath $JUNK | awk '{print $NF}')
     c1=$(echo "scale=1; $minc - ($maxc - $minc) * 0.05" | bc)
     c2=$(echo "scale=1; $maxc + ($maxc - $minc) * 0.05" | bc)
+
+    rm $JUNK
 
     gmt basemap -R0/$maxfreq/$c1/$c2 -JX10c/7c -Bxa1f+l"Frequency (Hz)" -Bya0.2f+l"Group velocity (km/s)" -BWSen+t"$title" $args
     for i in $(seq 0 $maxmode); do

--- a/docs/source/Tutorial/modal/surface_wave.rst
+++ b/docs/source/Tutorial/modal/surface_wave.rst
@@ -41,4 +41,4 @@ C 模块为 :doc:`/Module/modsum` （Python函数将于后续版本增加），
 
 + **所有阶面波**
 
-.. figure:: run_modsum/compare_2.svg
+.. figure:: run_modsum/compare_all.svg

--- a/pygrt/C_extension/include/grt.h
+++ b/pygrt/C_extension/include/grt.h
@@ -65,7 +65,7 @@
 #include "grt/integral/dcm.h"
 #include "grt/integral/dwm.h"
 #include "grt/integral/fim.h"
-#include "grt/integral/integ_method.h"
+#include "grt/integral/integ_process.h"
 #include "grt/integral/iostats.h"
 #include "grt/integral/k_integ.h"
 #include "grt/integral/kernel.h"

--- a/pygrt/C_extension/include/grt/common/checkerror.h
+++ b/pygrt/C_extension/include/grt/common/checkerror.h
@@ -33,7 +33,7 @@
 
 // GRT自定义警告信息，不结束程序
 #define GRTRaiseWarning(WarnMessage, ...) ({\
-    fprintf(stdout, BOLD_WHITE "%s:%d: In function ‘%s’: \n" BOLD_YELLOW "[WARNING][%s] " WarnMessage "\n" DEFAULT_RESTORE, __FILE__, __LINE__, __func__, GRT_MODULE_NAME, ##__VA_ARGS__);\
+    fprintf(stdout, REGULAR_YELLOW "[WARNING][%s] " WarnMessage "\n" DEFAULT_RESTORE, GRT_MODULE_NAME, ##__VA_ARGS__);\
     fflush(stdout);\
 })
 

--- a/pygrt/C_extension/include/grt/common/checkerror.h
+++ b/pygrt/C_extension/include/grt/common/checkerror.h
@@ -20,20 +20,20 @@
 
 // GRT自定义报错信息
 #define GRTRaiseError(ErrorMessage, ...) ({\
-    fprintf(stderr, BOLD_WHITE "%s:%d: In function ‘%s’: \n" BOLD_RED "[%s] Error! " ErrorMessage "\n" DEFAULT_RESTORE, __FILE__, __LINE__, __func__, GRT_MODULE_NAME, ##__VA_ARGS__);\
+    fprintf(stderr, BOLD_WHITE "%s:%d: In function ‘%s’: \n" BOLD_RED "[ERROR][%s] " ErrorMessage "\n" DEFAULT_RESTORE, __FILE__, __LINE__, __func__, GRT_MODULE_NAME, ##__VA_ARGS__);\
     fflush(stderr);\
     exit(EXIT_FAILURE);\
 })
 
 // GRT自定义一般信息
 #define GRTRaiseInfo(ErrorMessage, ...) ({\
-    fprintf(stdout, REGULAR_GREEN "[%s] " ErrorMessage "\n" DEFAULT_RESTORE, GRT_MODULE_NAME, ##__VA_ARGS__);\
+    fprintf(stdout, REGULAR_GREEN "[INFO][%s] " ErrorMessage "\n" DEFAULT_RESTORE, GRT_MODULE_NAME, ##__VA_ARGS__);\
     fflush(stdout);\
 })
 
 // GRT自定义警告信息，不结束程序
 #define GRTRaiseWarning(WarnMessage, ...) ({\
-    fprintf(stdout, BOLD_WHITE "%s:%d: In function ‘%s’: \n" BOLD_YELLOW "[%s] Warning! " WarnMessage "\n" DEFAULT_RESTORE, __FILE__, __LINE__, __func__, GRT_MODULE_NAME, ##__VA_ARGS__);\
+    fprintf(stdout, BOLD_WHITE "%s:%d: In function ‘%s’: \n" BOLD_YELLOW "[WARNING][%s] " WarnMessage "\n" DEFAULT_RESTORE, __FILE__, __LINE__, __func__, GRT_MODULE_NAME, ##__VA_ARGS__);\
     fflush(stdout);\
 })
 

--- a/pygrt/C_extension/include/grt/common/const.h
+++ b/pygrt/C_extension/include/grt/common/const.h
@@ -60,6 +60,7 @@ typedef double complex cplx_t;
 
 #define GRT_SWAP(type, a, b) { type temp = a; a = b; b = temp; } ///< 交换两个变量的值
 #define GRT_MIN_DISTANCE    1e-5   ///< 最小震中距，用于限制
+#define GRT_IS_SMALLE_DISTANCE(r)  ((r) <= GRT_MIN_DISTANCE)   ///< 判断是否是过小的震中距 
 
 #define GRT_STRING_FMT "%18s"  ///< 字符串输出格式
 #define GRT_REAL_FMT "%18.8e"  ///< 浮点数输出格式
@@ -130,6 +131,8 @@ typedef double complex cplx_t;
 #define GRT_INVERSE_FAILURE   -1     ///< 求逆或除法遇到除0错误
 
 #define GRT_GTYPES_MAX   2      ///< 2, 所有震源根据是否使用格林函数导数分为两类
+
+#define GRT_MIN_STATIC_NK  500    ///< 波数积分中 k0 部分最少的点数，若不够则对应调整 dk
 
 typedef cplx_t     cplxChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];
 typedef cplx_t*   pcplxChnlGrid[GRT_SRC_M_NUM][GRT_CHANNEL_NUM];

--- a/pygrt/C_extension/include/grt/dynamic/grn.h
+++ b/pygrt/C_extension/include/grt/dynamic/grn.h
@@ -16,7 +16,7 @@
 
 #include "grt/common/model.h"
 #include "grt/dynamic/grnspec.h"
-#include "grt/integral/integ_method.h"
+#include "grt/integral/integ_process.h"
 
 /**
  * 积分计算Z, R, T三个分量格林函数的频谱的核心函数（被Python调用）  

--- a/pygrt/C_extension/include/grt/dynamic/grn.h
+++ b/pygrt/C_extension/include/grt/dynamic/grn.h
@@ -22,12 +22,12 @@
  * 积分计算Z, R, T三个分量格林函数的频谱的核心函数（被Python调用）  
  * 
  * @param[in,out]   mod1d            `MODEL1D` 结构体指针 
- * @param[in,out]   Kmet             波数积分相关参数的结构体指针
+ * @param[in,out]   Kproc             波数积分相关参数的结构体指针
  * @param[in,out]   grn              计算的格林函数频谱
  * @param[in]       print_progressbar        是否打印进度条
  * 
  */ 
-void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, const bool print_progressbar);
+void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, const bool print_progressbar);
 
 
 

--- a/pygrt/C_extension/include/grt/dynamic/grn.h
+++ b/pygrt/C_extension/include/grt/dynamic/grn.h
@@ -27,7 +27,7 @@
  * @param[in]       print_progressbar        是否打印进度条
  * 
  */ 
-void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_METHOD *Kmet, GRNSPEC *grn, const bool print_progressbar);
+void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, const bool print_progressbar);
 
 
 

--- a/pygrt/C_extension/include/grt/integral/dcm.h
+++ b/pygrt/C_extension/include/grt/integral/dcm.h
@@ -17,7 +17,8 @@
  * 
  * @param[in]        nr      震中距数
  * @param[in]        rs      震中距数组
+ * @param[in]        kcut    截止波数
  * @param[in,out]    Kint    K_INTEG 结构体指针，对应着积分结果
  * @param[in]        keep_nearfield   是否要作用于近场项(p==1项)
  */
-void grt_dcm_correction(size_t nr, real_t *rs, K_INTEG *Kint, bool keep_nearfield);
+void grt_dcm_correction(size_t nr, real_t *rs, real_t kcut, K_INTEG *Kint, bool keep_nearfield);

--- a/pygrt/C_extension/include/grt/integral/integ_method.h
+++ b/pygrt/C_extension/include/grt/integral/integ_method.h
@@ -53,20 +53,20 @@ typedef struct {
  * @param[in]          rs           震中距数组 
  * @param[in]          statsstr     积分过程输出目录
  * @param[in]          suffix       文件名后缀
- * @param[in,out]      Kmet         K_INTEG_PROCESS 结构体指针
+ * @param[in,out]      Kproc         K_INTEG_PROCESS 结构体指针
  * 
  */
-void grt_KMET_init_fstats(
+void grt_KPROC_init_fstats(
     const size_t nr, const real_t *rs, 
-    const char *statsstr, const char *suffix, K_INTEG_PROCESS *Kmet);
+    const char *statsstr, const char *suffix, K_INTEG_PROCESS *Kproc);
 
 /**
  * 关闭 K_INTEG_PROCESS 结构体中的文件指针，并释放内存
  * 
  * @param[in]          nr           震中距数量
- * @param[in,out]      Kmet         K_INTEG_PROCESS 结构体指针
+ * @param[in,out]      Kproc         K_INTEG_PROCESS 结构体指针
  */
-void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kmet);
+void grt_KPROC_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kproc);
 
 
 
@@ -77,7 +77,7 @@ void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kmet);
  * @param[in,out]      mstat        `MODEL1D_STATE` 结构体指针
  * @param[in]          nr           震中距数量
  * @param[in]          rs           震中距数组 
- * @param[in,out]      Kmet         K_INTEG_PROCESS 结构体指针
+ * @param[in,out]      Kproc         K_INTEG_PROCESS 结构体指针
  * @param[in]          calc_upar    是否计算位移u的空间导数
  * @param[in]          kerfunc      计算核函数的函数指针
  * 
@@ -85,4 +85,4 @@ void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kmet);
  * 
  */
 K_INTEG * grt_wavenumber_integral(
-    MODEL1D_STATE *mstat, size_t nr, real_t *rs, K_INTEG_PROCESS *Kmet, bool calc_upar, GRT_KernelFunc kerfunc);
+    MODEL1D_STATE *mstat, size_t nr, real_t *rs, K_INTEG_PROCESS *Kproc, bool calc_upar, GRT_KernelFunc kerfunc);

--- a/pygrt/C_extension/include/grt/integral/integ_method.h
+++ b/pygrt/C_extension/include/grt/integral/integ_method.h
@@ -43,30 +43,30 @@ typedef struct {
     FILE *fstats;  ///< 保存核函数的文件指针
     FILE *(*ptam_fstatsnr)[2];  ///< 保存 PTAM 中核函数以及波峰波谷的文件指针
     
-} K_INTEG_METHOD;
+} K_INTEG_PROCESS;
 
 
 /**
- * 初始化 K_INTEG_METHOD 结构体中的文件指针
+ * 初始化 K_INTEG_PROCESS 结构体中的文件指针
  * 
  * @param[in]          nr           震中距数量
  * @param[in]          rs           震中距数组 
  * @param[in]          statsstr     积分过程输出目录
  * @param[in]          suffix       文件名后缀
- * @param[in,out]      Kmet         K_INTEG_METHOD 结构体指针
+ * @param[in,out]      Kmet         K_INTEG_PROCESS 结构体指针
  * 
  */
 void grt_KMET_init_fstats(
     const size_t nr, const real_t *rs, 
-    const char *statsstr, const char *suffix, K_INTEG_METHOD *Kmet);
+    const char *statsstr, const char *suffix, K_INTEG_PROCESS *Kmet);
 
 /**
- * 关闭 K_INTEG_METHOD 结构体中的文件指针，并释放内存
+ * 关闭 K_INTEG_PROCESS 结构体中的文件指针，并释放内存
  * 
  * @param[in]          nr           震中距数量
- * @param[in,out]      Kmet         K_INTEG_METHOD 结构体指针
+ * @param[in,out]      Kmet         K_INTEG_PROCESS 结构体指针
  */
-void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_METHOD *Kmet);
+void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kmet);
 
 
 
@@ -77,7 +77,7 @@ void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_METHOD *Kmet);
  * @param[in,out]      mstat        `MODEL1D_STATE` 结构体指针
  * @param[in]          nr           震中距数量
  * @param[in]          rs           震中距数组 
- * @param[in,out]      Kmet         K_INTEG_METHOD 结构体指针
+ * @param[in,out]      Kmet         K_INTEG_PROCESS 结构体指针
  * @param[in]          calc_upar    是否计算位移u的空间导数
  * @param[in]          kerfunc      计算核函数的函数指针
  * 
@@ -85,4 +85,4 @@ void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_METHOD *Kmet);
  * 
  */
 K_INTEG * grt_wavenumber_integral(
-    MODEL1D_STATE *mstat, size_t nr, real_t *rs, K_INTEG_METHOD *Kmet, bool calc_upar, GRT_KernelFunc kerfunc);
+    MODEL1D_STATE *mstat, size_t nr, real_t *rs, K_INTEG_PROCESS *Kmet, bool calc_upar, GRT_KernelFunc kerfunc);

--- a/pygrt/C_extension/include/grt/integral/integ_process.h
+++ b/pygrt/C_extension/include/grt/integral/integ_process.h
@@ -35,6 +35,7 @@ typedef enum {
 // 描述不同波数积分方法的结构体
 typedef struct {
     real_t k0;      ///< 波数积分的上限 \f$ \tilde{k_{max}}=\sqrt{(k_{0}*\pi/hs)^2 + (ampk*w/vmin_{ref})^2} \f$ ，k循环必须退出, hs=max(震源和台站深度差,1.0) 
+    bool fixed_k0;  ///< 固定 k0，默认在程序中自动调整 k0
     real_t ampk;    ///< 影响波数k积分上限的系数
     real_t keps;    ///< 波数积分的收敛条件，要求在某震中距下所有格林函数都收敛，为负数代表不提前判断收敛，按照波数积分上限进行积分 
     real_t vmin;    ///< 参考最小速度，用于定义波数积分的上限

--- a/pygrt/C_extension/include/grt/integral/integ_process.h
+++ b/pygrt/C_extension/include/grt/integral/integ_process.h
@@ -1,5 +1,5 @@
 /**
- * @file   integ_method.h
+ * @file   integ_process.h
  * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
  * @date   2025-12
  * 
@@ -16,6 +16,21 @@
 #include "grt/integral/k_integ.h"
 #include "grt/integral/kernel.h"
 
+// 波数积分收敛方法
+typedef enum {
+    K_INTEG_CONVERG_AUTO = 0,  ///< 默认收敛处理由程序根据情况来决定
+    K_INTEG_CONVERG_REFUSE,  ///< 绝对不做收敛处理
+    K_INTEG_CONVERG_DCM,   ///< 直接收敛法
+    K_INTEG_CONVERG_PTAM       ///< 峰谷平均法
+} K_INTEG_CONVERG_METHOD;
+
+#define GRT_EXPLAIN_CVGMETHOD(code) (\
+    (code == K_INTEG_CONVERG_AUTO)     ? "Auto" : \
+    (code == K_INTEG_CONVERG_REFUSE)      ? "No Convergence" : \
+    (code == K_INTEG_CONVERG_DCM)         ? "Direct Convergence Method" : \
+    (code == K_INTEG_CONVERG_PTAM)        ? "Peak-Trough Averaging Method" : \
+    "Unsupported code" \
+)
 
 // 描述不同波数积分方法的结构体
 typedef struct {
@@ -36,9 +51,7 @@ typedef struct {
     bool applySAFIM;  ///< 是否使用 SAFIM
     real_t sa_tol;    ///< SAFIM 的收敛极限
     
-    // 积分显式收敛方法
-    bool applyDCM;    ///< 是否使用 DCM
-    bool applyPTAM;   ///< 是否使用 PTAM
+    K_INTEG_CONVERG_METHOD cvgmet;  ///< 波数积分收敛方法
     
     FILE *fstats;  ///< 保存核函数的文件指针
     FILE *(*ptam_fstatsnr)[2];  ///< 保存 PTAM 中核函数以及波峰波谷的文件指针

--- a/pygrt/C_extension/include/grt/integral/integ_process.h
+++ b/pygrt/C_extension/include/grt/integral/integ_process.h
@@ -35,7 +35,7 @@ typedef enum {
 // 描述不同波数积分方法的结构体
 typedef struct {
     real_t k0;      ///< 波数积分的上限 \f$ \tilde{k_{max}}=\sqrt{(k_{0}*\pi/hs)^2 + (ampk*w/vmin_{ref})^2} \f$ ，k循环必须退出, hs=max(震源和台站深度差,1.0) 
-    bool fixed_k0;  ///< 固定 k0，默认在程序中自动调整 k0
+    bool k0_is_fixed;  ///< 固定 k0，默认在程序中自动调整 k0
     real_t ampk;    ///< 影响波数k积分上限的系数
     real_t keps;    ///< 波数积分的收敛条件，要求在某震中距下所有格林函数都收敛，为负数代表不提前判断收敛，按照波数积分上限进行积分 
     real_t vmin;    ///< 参考最小速度，用于定义波数积分的上限

--- a/pygrt/C_extension/include/grt/integral/k_integ.h
+++ b/pygrt/C_extension/include/grt/integral/k_integ.h
@@ -19,6 +19,8 @@ typedef struct {
     // 不同震源不同阶数的核函数 F(k, w) 
     cplxChnlGrid QWV;
     cplxChnlGrid QWVz;
+    cplxChnlGrid QWV_raw;  ///< 不受 DCM 影响，仅为计算出的核函数
+    cplxChnlGrid QWVz_raw;
 
     // 最大波数时的核函数，用于 DCM
     bool applyDCM;

--- a/pygrt/C_extension/include/grt/static/static_grn.h
+++ b/pygrt/C_extension/include/grt/static/static_grn.h
@@ -36,7 +36,7 @@
  * 
  */
 void grt_integ_static_grn(
-    MODEL1D *mod1d, size_t nr, real_t *rs, K_INTEG_METHOD *Kmet,
+    MODEL1D *mod1d, size_t nr, real_t *rs, K_INTEG_PROCESS *Kmet,
     bool calc_upar, 
     realChnlGrid grn[nr],
     realChnlGrid grn_uiz[nr],

--- a/pygrt/C_extension/include/grt/static/static_grn.h
+++ b/pygrt/C_extension/include/grt/static/static_grn.h
@@ -26,7 +26,7 @@
  * @param[in,out]      mod1d            `MODEL1D` 结构体指针 
  * @param[in]      nr               震中距数量
  * @param[in]      rs               震中距数组 
- * @param[in,out]   Kmet            波数积分相关参数的结构体指针
+ * @param[in,out]   Kproc            波数积分相关参数的结构体指针
  * @param[in]       calc_upar         是否计算位移u的空间导数
  * @param[out]      grn               浮点数数组，不同震源不同阶数的静态格林函数的Z、R、T分量
  * @param[out]      grn_uiz           浮点数数组，不同震源不同阶数的ui_z的Z、R、T分量
@@ -36,7 +36,7 @@
  * 
  */
 void grt_integ_static_grn(
-    MODEL1D *mod1d, size_t nr, real_t *rs, K_INTEG_PROCESS *Kmet,
+    MODEL1D *mod1d, size_t nr, real_t *rs, K_INTEG_PROCESS *Kproc,
     bool calc_upar, 
     realChnlGrid grn[nr],
     realChnlGrid grn_uiz[nr],

--- a/pygrt/C_extension/include/grt/static/static_grn.h
+++ b/pygrt/C_extension/include/grt/static/static_grn.h
@@ -17,7 +17,7 @@
 
 
 #include "grt/common/model.h"
-#include "grt/integral/integ_method.h"
+#include "grt/integral/integ_process.h"
 
 
 /**

--- a/pygrt/C_extension/include/grt/static/static_util.h
+++ b/pygrt/C_extension/include/grt/static/static_util.h
@@ -1,0 +1,22 @@
+/**
+ * @file   static_util.h
+ * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
+ * @date   2026-06
+ * 
+ * 一些关于静态解的辅助函数
+ * 
+ */
+
+#pragma once
+
+#include "grt/common/model.h"
+
+/**
+ * 根据核函数的振幅，估计静态解波数积分中合适的 kmax
+ * 
+ * @param[in]      mod1d        模型指针
+ * @param[in]      kmax_ref     最大上限
+ * @param[out]     Ncount       估计过程中计算静态核函数的次数
+ * @return     估计的 kmax
+ */
+real_t grt_predict_static_kmax(MODEL1D *mod1d, real_t kmax_ref, size_t *Ncount);

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -138,7 +138,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, co
         // ===================================================================================
         //                          Wavenumber Integration
         // 波数积分上限
-        local_Kproc->kmax = hypot(static_kmax, local_Kproc->ampk * w / local_Kproc->vmin);
+        local_Kproc->kmax = hypot(local_Kproc->k0, local_Kproc->ampk * w / local_Kproc->vmin);
         K_INTEG *Kint = grt_wavenumber_integral(local_mstat, grn->nr, grn->rs, local_Kproc, grn->calc_upar, grt_kernel);
 
         // 记录到格林函数结构体内

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -59,7 +59,7 @@ static void recordin_GRN(size_t iw, size_t nr, cplx_t coef, cplxIntegGrid sumJ[n
 
 
 
-void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, const bool print_progressbar)
+void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, const bool print_progressbar)
 {
     // 程序运行开始时间
     struct timeval begin_t;
@@ -67,7 +67,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, con
 
     const real_t Rho = mod1d->Rho[mod1d->isrc]; // 震源区密度
     const real_t fac = 1.0/(4.0*PI*Rho);
-    const real_t dk = Kmet->dk;
+    const real_t dk = Kproc->dk;
 
     // 进度条变量 
     int progress=0;
@@ -106,13 +106,13 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, con
 
         cplx_t coef = - dk*fac / GRT_SQUARE(omega); // 最终要乘上的系数
 
-        K_INTEG_PROCESS *local_Kmet = NULL;
+        K_INTEG_PROCESS *local_Kproc = NULL;
     #ifdef _OPENMP 
         // 定义局部对象
-        K_INTEG_PROCESS __KMET = *Kmet;  // 只需浅拷贝
-        local_Kmet = &__KMET;
+        K_INTEG_PROCESS __KPROC = *Kproc;  // 只需浅拷贝
+        local_Kproc = &__KPROC;
     #else 
-        local_Kmet = Kmet;
+        local_Kproc = Kproc;
     #endif
 
         MODEL1D_STATE *local_mstat = grt_init_mod1d_state(mod1d);
@@ -127,7 +127,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, con
         if(needfstats){
             char *suffix = NULL;
             GRT_SAFE_ASPRINTF(&suffix, "_%04zu_%.5e", iw, grn->freqs[iw]);
-            grt_KMET_init_fstats(grn->nr, grn->rs, grn->statsstr, suffix, local_Kmet);
+            grt_KPROC_init_fstats(grn->nr, grn->rs, grn->statsstr, suffix, local_Kproc);
             GRT_SAFE_FREE_PTR(suffix);
         }
         
@@ -139,7 +139,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, con
         //                          Wavenumber Integration
         // 波数积分上限
         local_Kmet->kmax = hypot(local_Kmet->k0, local_Kmet->ampk * w / local_Kmet->vmin);
-        K_INTEG *Kint = grt_wavenumber_integral(local_mstat, grn->nr, grn->rs, local_Kmet, grn->calc_upar, grt_kernel);
+        K_INTEG *Kint = grt_wavenumber_integral(local_mstat, grn->nr, grn->rs, local_Kproc, grn->calc_upar, grt_kernel);
 
         // 记录到格林函数结构体内
         // 如果计算核函数过程中存在除零错误，则放弃该频率【通常在大震中距的低频段】
@@ -152,7 +152,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, con
 
         freq_invstats[iw] = local_mstat->stats;
 
-        if(needfstats)  grt_KMET_destroy_fstats(grn->nr, local_Kmet);
+        if(needfstats)  grt_KPROC_destroy_fstats(grn->nr, local_Kproc);
 
         grt_free_mod1d_state(local_mstat);
 

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -59,7 +59,7 @@ static void recordin_GRN(size_t iw, size_t nr, cplx_t coef, cplxIntegGrid sumJ[n
 
 
 
-void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_METHOD *Kmet, GRNSPEC *grn, const bool print_progressbar)
+void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kmet, GRNSPEC *grn, const bool print_progressbar)
 {
     // 程序运行开始时间
     struct timeval begin_t;
@@ -106,10 +106,10 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_METHOD *Kmet, GRNSPEC *grn, cons
 
         cplx_t coef = - dk*fac / GRT_SQUARE(omega); // 最终要乘上的系数
 
-        K_INTEG_METHOD *local_Kmet = NULL;
+        K_INTEG_PROCESS *local_Kmet = NULL;
     #ifdef _OPENMP 
         // 定义局部对象
-        K_INTEG_METHOD __KMET = *Kmet;  // 只需浅拷贝
+        K_INTEG_PROCESS __KMET = *Kmet;  // 只需浅拷贝
         local_Kmet = &__KMET;
     #else 
         local_Kmet = Kmet;

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -138,7 +138,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, co
         // ===================================================================================
         //                          Wavenumber Integration
         // 波数积分上限
-        local_Kmet->kmax = hypot(local_Kmet->k0, local_Kmet->ampk * w / local_Kmet->vmin);
+        local_Kproc->kmax = hypot(static_kmax, local_Kproc->ampk * w / local_Kproc->vmin);
         K_INTEG *Kint = grt_wavenumber_integral(local_mstat, grn->nr, grn->rs, local_Kproc, grn->calc_upar, grt_kernel);
 
         // 记录到格林函数结构体内

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -21,6 +21,7 @@
 
 #include "grt/dynamic/grn.h"
 #include "grt/dynamic/grnspec.h"
+#include "grt/static/static_util.h"
 #include "grt/integral/integ_process.h"
 
 #include "grt/common/const.h"
@@ -80,6 +81,30 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, co
 
     mod1d->omgref = PI2*grn->freqs[grn->nf2];
 
+    // 静态解的 kmax ，用于动态解积分上限中的 k0
+    real_t static_kmax = 0.0;
+    if(Kproc->fixed_k0){
+        static_kmax = Kproc->k0;
+    } else {
+        size_t ncount = 0;
+        static_kmax = grt_predict_static_kmax(mod1d, Kproc->k0, &ncount);
+        GRTRaiseInfo(
+            "for a proper k0, ncount = %zu, k0 = %.3e, k0_ref = %.3e, nk = %zu", 
+            ncount, static_kmax, Kproc->k0, (size_t)(static_kmax / Kproc->dk));
+        
+        if(Kproc->cvgmet == K_INTEG_CONVERG_AUTO){
+            // 如果上限触发边界，且未指定收敛算法，则强制使用 DCM 进行收敛
+            if(static_kmax >= Kproc->k0){
+                Kproc->cvgmet = K_INTEG_CONVERG_DCM;
+                Kproc->keps = 0.0;
+                GRTRaiseWarning("k0 reaches k0_ref, apply %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
+            }
+        } else if(Kproc->cvgmet != K_INTEG_CONVERG_REFUSE) {
+            // 正常打印手动选择的收敛方法
+            GRTRaiseInfo("manually set the %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
+        }
+    }
+
     // 频率omega循环
     // schedule语句可以动态调度任务，最大程度地使用计算资源
     #pragma omp parallel for schedule(guided) default(shared) 
@@ -138,7 +163,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, co
         // ===================================================================================
         //                          Wavenumber Integration
         // 波数积分上限
-        local_Kproc->kmax = hypot(local_Kproc->k0, local_Kproc->ampk * w / local_Kproc->vmin);
+        local_Kproc->kmax = hypot(static_kmax, local_Kproc->ampk * w / local_Kproc->vmin);
         K_INTEG *Kint = grt_wavenumber_integral(local_mstat, grn->nr, grn->rs, local_Kproc, grn->calc_upar, grt_kernel);
 
         // 记录到格林函数结构体内

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -83,7 +83,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, co
 
     // 静态解的 kmax ，用于动态解积分上限中的 k0
     real_t static_kmax = 0.0;
-    if(Kproc->fixed_k0){
+    if(Kproc->k0_is_fixed){
         static_kmax = Kproc->k0;
     } else {
         size_t ncount = 0;

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -21,7 +21,7 @@
 
 #include "grt/dynamic/grn.h"
 #include "grt/dynamic/grnspec.h"
-#include "grt/integral/integ_method.h"
+#include "grt/integral/integ_process.h"
 
 #include "grt/common/const.h"
 #include "grt/common/model.h"

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -86,22 +86,25 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, co
     if(Kproc->k0_is_fixed){
         static_kmax = Kproc->k0;
     } else {
-        size_t ncount = 0;
+        size_t ncount = 0, nk = 0;
         static_kmax = grt_predict_static_kmax(mod1d, Kproc->k0, &ncount);
+        nk = floor(static_kmax / Kproc->dk) + 1;
         GRTRaiseInfo(
-            "for a proper k0, ncount = %zu, k0 = %.3e, k0_ref = %.3e, nk = %zu", 
-            ncount, static_kmax, Kproc->k0, (size_t)(static_kmax / Kproc->dk));
+            "For a proper kc, ncount = %zu, kc = %.3e, k0 = %.3e, nk = %zu", 
+            ncount, static_kmax, Kproc->k0, nk);
         
         if(Kproc->cvgmet == K_INTEG_CONVERG_AUTO){
             // 如果上限触发边界，且未指定收敛算法，则强制使用 DCM 进行收敛
             if(static_kmax >= Kproc->k0){
                 Kproc->cvgmet = K_INTEG_CONVERG_DCM;
                 Kproc->keps = 0.0;
-                GRTRaiseWarning("k0 reaches k0_ref, apply %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
+                GRTRaiseWarning(
+                    "kc reaches k0, apply %s. "
+                    "You should consider to increase the k0 (maximum upper bound)", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
             }
         } else if(Kproc->cvgmet != K_INTEG_CONVERG_REFUSE) {
             // 正常打印手动选择的收敛方法
-            GRTRaiseInfo("manually set the %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
+            GRTRaiseInfo("Manually set the %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
         }
     }
 

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -94,9 +94,7 @@ typedef struct {
     /** 波数积分收敛方法 */
     struct {
         bool active;
-        bool applyDCM;
-        bool applyPTAM;
-        bool applyNoConverg;
+        K_INTEG_CONVERG_METHOD convmet;
     } C;
     /** 波数积分上限 */
     struct {
@@ -361,7 +359,7 @@ printf("\n"
 "                 + d: Direct Convergence Method (DCM).\n"
 "                 + p: Peak-Trough Averaging Method (PTAM).\n"
 "                 + n: None.\n"
-"                 Default use +cd when fabs(depsrc-deprcv) <= %.1f.\n", GRT_MIN_DEPTH_GAP_SRC_RCV); printf(
+"                 Default use -Cd when fabs(depsrc-deprcv) <= %.1f.\n", GRT_MIN_DEPTH_GAP_SRC_RCV); printf(
 "\n"
 "    -E[p]<t0>[/<v0>]\n"
 "                 Introduce the time delay in results. The total \n"
@@ -643,20 +641,17 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                 }
                 switch (optarg[0]){
                     case 'p':
-                        Ctrl->C.applyPTAM = true;
+                        Ctrl->C.convmet = K_INTEG_CONVERG_PTAM;
                         break;
                     case 'd':
-                        Ctrl->C.applyDCM = true;
+                        Ctrl->C.convmet = K_INTEG_CONVERG_DCM;
                         break;
                     case 'n':
-                        Ctrl->C.applyNoConverg = true;
+                        Ctrl->C.convmet = K_INTEG_CONVERG_REFUSE;
                         break;
                     default:
                         GRTBadOptionError(C, "-C+%s is not supported.", optarg);
                         break;
-                }
-                if(Ctrl->C.applyPTAM && Ctrl->C.applyDCM){
-                    GRTBadOptionError(C, "You can't set -Cd and -Cp both.");
                 }
                 break;
 
@@ -929,11 +924,6 @@ int greenfn_main(int argc, char **argv) {
     // 参考最小速度
     if(Ctrl->K.vmin == 0.0){
         Ctrl->K.vmin = GRT_MAX(vmin, GRT_GREENFN_K_VMIN);
-    } 
-
-    // 判断是否要自动使用收敛方法
-    if( ! Ctrl->C.active && fabs(Ctrl->D.deprcv - Ctrl->D.depsrc) <= GRT_MIN_DEPTH_GAP_SRC_RCV) {
-        Ctrl->C.applyDCM = true;
     }
 
     // 时窗长度 
@@ -1015,7 +1005,7 @@ int greenfn_main(int argc, char **argv) {
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
         KPROC.k0 = Ctrl->K.k0 * PI / hs;
         KPROC.ampk = Ctrl->K.ampk;
-        KPROC.keps = (Ctrl->C.applyPTAM || Ctrl->C.applyDCM)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
+        KPROC.keps = (Ctrl->C.convmet != K_INTEG_CONVERG_AUTO)? 0.0 : Ctrl->K.keps; // 如果使用了显式收敛方法，则不使用keps进行收敛判断
         KPROC.vmin = Ctrl->K.vmin;
         
         KPROC.kcut = Ctrl->L.kcut / rmax;
@@ -1028,13 +1018,7 @@ int greenfn_main(int argc, char **argv) {
         KPROC.applySAFIM = Ctrl->L.SAFIM.active;
         KPROC.sa_tol = Ctrl->L.SAFIM.tol;
         
-        KPROC.applyDCM = Ctrl->C.applyDCM;
-        KPROC.applyPTAM = Ctrl->C.applyPTAM;
-    }
-
-    // 在计算前打印所有参数
-    if(! Ctrl->s.active){
-        print_Ctrl(Ctrl);
+        KPROC.cvgmet = Ctrl->C.convmet;
     }
 
     // 格林函数频谱

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -103,7 +103,7 @@ typedef struct {
         real_t ampk;
         real_t k0;
         real_t vmin;
-        bool fixed_k0;
+        bool k0_is_fixed;
     } K;
     /** 时间延迟 */
     struct {
@@ -666,7 +666,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                             break;
 
                         case 'f':
-                            Ctrl->K.fixed_k0 = true;
+                            Ctrl->K.k0_is_fixed = true;
                             break;
 
                         default:
@@ -956,7 +956,7 @@ int greenfn_main(int argc, char **argv) {
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
         KPROC.k0 = Ctrl->K.k0 * PI / hs;
-        KPROC.fixed_k0 = Ctrl->K.fixed_k0;
+        KPROC.k0_is_fixed = Ctrl->K.k0_is_fixed;
         KPROC.ampk = Ctrl->K.ampk;
         KPROC.keps = (Ctrl->C.convmet != K_INTEG_CONVERG_AUTO)? 0.0 : Ctrl->K.keps; // 如果使用了显式收敛方法，则不使用keps进行收敛判断
         KPROC.vmin = Ctrl->K.vmin;

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -1010,7 +1010,7 @@ int greenfn_main(int argc, char **argv) {
 
         
     // 波数积分方法
-    K_INTEG_METHOD KMET = {0};
+    K_INTEG_PROCESS KMET = {0};
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
         KMET.k0 = Ctrl->K.k0 * PI / hs;

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -1010,26 +1010,26 @@ int greenfn_main(int argc, char **argv) {
 
         
     // 波数积分方法
-    K_INTEG_PROCESS KMET = {0};
+    K_INTEG_PROCESS KPROC = {0};
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
-        KMET.k0 = Ctrl->K.k0 * PI / hs;
-        KMET.ampk = Ctrl->K.ampk;
-        KMET.keps = (Ctrl->C.applyPTAM || Ctrl->C.applyDCM)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
-        KMET.vmin = Ctrl->K.vmin;
+        KPROC.k0 = Ctrl->K.k0 * PI / hs;
+        KPROC.ampk = Ctrl->K.ampk;
+        KPROC.keps = (Ctrl->C.applyPTAM || Ctrl->C.applyDCM)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
+        KPROC.vmin = Ctrl->K.vmin;
         
-        KMET.kcut = Ctrl->L.kcut / rmax;
+        KPROC.kcut = Ctrl->L.kcut / rmax;
 
-        KMET.dk = PI2 / (Ctrl->L.Length * rmax);
+        KPROC.dk = PI2 / (Ctrl->L.Length * rmax);
 
-        KMET.applyFIM = Ctrl->L.FIM.active;
-        KMET.filondk = (Ctrl->L.FIM.active) ? PI2 / (Ctrl->L.FIM.Length * rmax) : 0.0;
+        KPROC.applyFIM = Ctrl->L.FIM.active;
+        KPROC.filondk = (Ctrl->L.FIM.active) ? PI2 / (Ctrl->L.FIM.Length * rmax) : 0.0;
 
-        KMET.applySAFIM = Ctrl->L.SAFIM.active;
-        KMET.sa_tol = Ctrl->L.SAFIM.tol;
+        KPROC.applySAFIM = Ctrl->L.SAFIM.active;
+        KPROC.sa_tol = Ctrl->L.SAFIM.tol;
         
-        KMET.applyDCM = Ctrl->C.applyDCM;
-        KMET.applyPTAM = Ctrl->C.applyPTAM;
+        KPROC.applyDCM = Ctrl->C.applyDCM;
+        KPROC.applyPTAM = Ctrl->C.applyPTAM;
     }
 
     // 在计算前打印所有参数
@@ -1059,7 +1059,7 @@ int greenfn_main(int argc, char **argv) {
 
     //==============================================================================
     // 计算格林函数
-    grt_integ_grn_spec(mod1d, &KMET, grn, !Ctrl->s.active);
+    grt_integ_grn_spec(mod1d, &KPROC, grn, !Ctrl->s.active);
     //==============================================================================
 
     // 使用fftw3做反傅里叶变换，并保存到 SAC 

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -184,59 +184,6 @@ static void free_Ctrl(GRT_MODULE_CTRL *Ctrl){
     GRT_SAFE_FREE_PTR(Ctrl);
 }
 
-
-/** 打印结构体中的参数 */
-static void print_Ctrl(const GRT_MODULE_CTRL *Ctrl){
-    grt_print_mod1d(Ctrl->M.mod1d);
-
-    const char format[]      = "   \%-20s  \%s\n";
-    const char format_real[] = "   \%-20s  \%.3f\n";
-    const char format_size[]  = "   \%-20s  \%zu\n";
-    char line[100];
-    printf("------------------------------------------------\n");
-    printf(format, "PARAMETER", "VALUE");
-    printf(format, "model_path", Ctrl->M.s_modelpath);
-    printf(format_real, "k0", Ctrl->K.k0);
-    printf(format_real, "ampk", Ctrl->K.ampk);
-    printf(format_real, "keps", Ctrl->K.keps);
-    printf(format_real, "vmin", Ctrl->K.vmin);
-    printf(format_real, "Length", Ctrl->L.Length);
-    printf(format_real, "kcut",   Ctrl->L.kcut);
-    printf(format_real, "filonLength",   Ctrl->L.FIM.Length);
-    printf(format_real, "safilonTol",   Ctrl->L.SAFIM.tol);
-    printf(format, "applyDCM", (Ctrl->C.applyDCM)? "true" : "false");
-    printf(format, "applyPTAM", (Ctrl->C.applyPTAM)? "true" : "false");
-
-    printf(format_size, "topbound", (size_t)Ctrl->B.topbound);
-    printf(format_size, "botbound", (size_t)Ctrl->B.botbound);
-
-    printf(format_size, "nt", Ctrl->N.nt);
-    printf(format_real, "dt", Ctrl->N.dt);
-    printf(format_real, "winT", Ctrl->N.winT);
-    printf(format_real, "zeta", Ctrl->N.zeta);
-    printf(format_real, "delayT0", Ctrl->E.delayT0);
-    printf(format_real, "delayV0", Ctrl->E.delayV0);
-    printf(format_real, "tmax", Ctrl->E.delayT0 + Ctrl->N.winT);
-    
-    printf(format_real, "maxfreq(Hz)", Ctrl->N.freqs[Ctrl->N.nf-1]);
-    printf(format_real, "f1(Hz)", Ctrl->N.freqs[Ctrl->H.nf1]);
-    printf(format_real, "f2(Hz)", Ctrl->N.freqs[Ctrl->H.nf2]);
-    printf(format, "distances(km)", Ctrl->R.s_raw);
-    if(Ctrl->S.nstatsidxs > 0){
-        printf(format, "statsfile_index", Ctrl->S.s_raw);
-    }
-    line[0] = '\0';
-    if(Ctrl->G.doEX) snprintf(line+strlen(line), sizeof(line)-strlen(line), "EX,");
-    if(Ctrl->G.doVF)  snprintf(line+strlen(line), sizeof(line)-strlen(line), "VF,");
-    if(Ctrl->G.doHF)  snprintf(line+strlen(line), sizeof(line)-strlen(line), "HF,");
-    if(Ctrl->G.doDC)  snprintf(line+strlen(line), sizeof(line)-strlen(line), "DC,");
-    printf(format, "sources", line);
-    
-    printf("------------------------------------------------\n");
-
-    printf("\n\n");
-}
-
 /** 打印使用说明 */
 static void print_help(){
 printf("\n"
@@ -1109,20 +1056,6 @@ int greenfn_main(int argc, char **argv) {
         GRTRaiseWarning(
             "The source is located in the liquid layer, "
             "therefore only the Green's Funtions for the Explosion source will be computed.\n");
-    }
-
-
-    
-    // 打印走时
-    if( ! Ctrl->s.active){
-        printf("\n\n");
-        printf("------------------------------------------------\n");
-        printf(" Distance(km)     Tp(secs)         Ts(secs)     \n");
-        for(size_t ir=0; ir<Ctrl->R.nr; ++ir){
-            printf(" %-15s  %-15.3f  %-15.3f\n", Ctrl->R.s_rs[ir], travtPS[ir][0], travtPS[ir][1]);
-        }
-        printf("------------------------------------------------\n");
-        printf("\n");
     }
 
     // 释放内存

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -17,7 +17,7 @@
 #define GRT_GREENFN_H_FREQ1      -1.0
 #define GRT_GREENFN_H_FREQ2      -1.0
 #define GRT_GREENFN_K_VMIN        0.1
-#define GRT_GREENFN_K_K0          5.0
+#define GRT_GREENFN_K_K0         50.0
 #define GRT_GREENFN_K_AMPK       1.15
 #define GRT_GREENFN_G_EX       true
 #define GRT_GREENFN_G_VF       true
@@ -103,6 +103,7 @@ typedef struct {
         real_t ampk;
         real_t k0;
         real_t vmin;
+        bool fixed_k0;
     } K;
     /** 时间延迟 */
     struct {
@@ -234,7 +235,7 @@ printf("\n"
 "        -R<r1>,<r2>[,...]|<r1>/<r2>/<dr>|<file>\n"
 "        -O<outdir>     [-H<f1>/<f2>] \n"
 "        [-L<length>] [-C[d|p|n]] [-E[p]<t0>[/<v0>]] \n" 
-"        [-K[+k<k0>][+s<ampk>][+e<keps>][+v<vmin>]]\n"
+"        [-K[+k<k0>][+f][+s<ampk>][+e<keps>][+v<vmin>]]\n"
 "        [-P<nthreads>] [-Ge|v|h|s]  [-Bf|F|r|R|h|H]\n"
 "        [-S[<i1>,<i2>,...]] [-e] [-s]\n"
 "\n\n"
@@ -320,15 +321,15 @@ printf("\n"
 "                       the delay (the begining time) will be <t0> + first P, \n"
 "                       e.g., -Ep-10.\n"
 "\n"
-"    -K[+k<k0>][+s<ampk>][+e<keps>][+v<vmin>]\n"
-"                 Several parameters designed to define the\n"
-"                 behavior in wavenumber integration. The upper\n"
-"                 bound is \n"
+"    -K[+k<k0>][+f][+s<ampk>][+e<keps>][+v<vmin>]\n"
+"                 Define the wavenumber integration upper bound\n"
 "                 sqrt( <k0>^2 + (<ampk>*w/<vmin_ref>)^2 ),\n"
-"                 <k0>:   designed to give residual k at\n"
-"                         0 frequency, default is %.1f, and \n", GRT_GREENFN_K_K0); printf(
-"                         multiply PI/hs in program, \n"
+"                 <k0>:   maximum upper bound residual k for 0 frequency, \n"
+"                         default is %.1f, and multiply PI/hs in program, \n", GRT_GREENFN_K_K0); printf(
 "                         where hs = max(fabs(depsrc-deprcv), %.1f).\n", GRT_MIN_DEPTH_GAP_SRC_RCV); printf(
+"                         The program will choose the proper residual in [0, k0].\n"
+"                         If k0 is not enough, convergence method will be applied.\n"
+"                         If use +f, directly set k0 as the residual.\n"
 "                 <ampk>: amplification factor, default is %.2f.\n", GRT_GREENFN_K_AMPK); printf(
 "                 <keps>: a threshold for break wavenumber \n"
 "                         integration in advance. See \n"
@@ -623,7 +624,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                 }
                 break;
 
-            // 波数积分相关变量 -K[+k<k0>][+s<ampk>][+e<keps>][+v<vmin>]
+            // 波数积分相关变量 -K[+k<k0>][+f][+s<ampk>][+e<keps>][+v<vmin>]
             case 'K':
                 Ctrl->K.active = true;
                 {
@@ -662,6 +663,10 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                             if(Ctrl->K.vmin <= 0.0){
                                 GRTBadOptionError(K, "Illegal vmin (%f).", Ctrl->K.vmin);
                             }
+                            break;
+
+                        case 'f':
+                            Ctrl->K.fixed_k0 = true;
                             break;
 
                         default:
@@ -951,6 +956,7 @@ int greenfn_main(int argc, char **argv) {
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
         KPROC.k0 = Ctrl->K.k0 * PI / hs;
+        KPROC.fixed_k0 = Ctrl->K.fixed_k0;
         KPROC.ampk = Ctrl->K.ampk;
         KPROC.keps = (Ctrl->C.convmet != K_INTEG_CONVERG_AUTO)? 0.0 : Ctrl->K.keps; // 如果使用了显式收敛方法，则不使用keps进行收敛判断
         KPROC.vmin = Ctrl->K.vmin;

--- a/pygrt/C_extension/src/integral/dcm.c
+++ b/pygrt/C_extension/src/integral/dcm.c
@@ -35,7 +35,6 @@ void grt_dcm_correction(size_t nr, real_t *rs, real_t kcut, K_INTEG *Kint, bool 
 {
     for(size_t ir = 0; ir < nr; ++ir)    {
         real_t r = rs[ir];
-        if(GRT_IS_SMALLE_DISTANCE(r)) continue;
 
         real_t rinv = 1.0 / r;
         real_t cc;

--- a/pygrt/C_extension/src/integral/dcm.c
+++ b/pygrt/C_extension/src/integral/dcm.c
@@ -11,44 +11,49 @@
 #include "grt/integral/k_integ.h"
 
 /** DCM 的校正项，其中积分定义与 grt_int_Pk() 函数保持一致 */
-static void _correct_Wm(real_t coefs[GRT_MORDER_MAX+1], bool keep_nearfield, cplxChnlGrid QWV_kmax, cplxIntegGrid SUM)
+static void _correct_Wm(real_t coefs[GRT_MORDER_MAX+1], bool keep_nearfield, cplxChnlGrid QWV_kmax, real_t coef, cplxIntegGrid SUM)
 {
     for(int i = 0; i < GRT_SRC_M_NUM; ++i){
         int modr = GRT_SRC_M_ORDERS[i];  // 对应m阶数
         if(modr == 0){
-            SUM[i][0] += - QWV_kmax[i][0] * coefs[1];   // - q0*J1*k
-            SUM[i][2] +=   QWV_kmax[i][1] * coefs[0];   //   w0*J0*k
+            SUM[i][0] += - coef * QWV_kmax[i][0] * coefs[1];   // - q0*J1*k
+            SUM[i][2] +=   coef * QWV_kmax[i][1] * coefs[0];   //   w0*J0*k
         }
         else{
             // 近场项这里沿用coefs是公式恰好巧合
-            SUM[i][0]  +=   QWV_kmax[i][0] * coefs[modr-1];         // qm*Jm-1*k
+            SUM[i][0]  +=   coef * QWV_kmax[i][0] * coefs[modr-1];         // qm*Jm-1*k
             if(keep_nearfield) {
-                SUM[i][1]  += - (QWV_kmax[i][0] + QWV_kmax[i][2]) * coefs[modr];    // - m*(qm+vm)*Jm*k/kr
+                SUM[i][1]  += - modr * coef * (QWV_kmax[i][0] + QWV_kmax[i][2]) * coefs[modr];    // - m*(qm+vm)*Jm*k/kr
             }
-            SUM[i][2]  +=   QWV_kmax[i][1] * coefs[modr];           // wm*Jm*k
-            SUM[i][3]  += - QWV_kmax[i][2] * coefs[modr-1];         // -vm*Jm-1*k
+            SUM[i][2]  +=   coef * QWV_kmax[i][1] * coefs[modr];           // wm*Jm*k
+            SUM[i][3]  += - coef * QWV_kmax[i][2] * coefs[modr-1];         // -vm*Jm-1*k
         }
     }
 }
 
-void grt_dcm_correction(size_t nr, real_t *rs, K_INTEG *Kint, bool keep_nearfield)
+void grt_dcm_correction(size_t nr, real_t *rs, real_t kcut, K_INTEG *Kint, bool keep_nearfield)
 {
     for(size_t ir = 0; ir < nr; ++ir)    {
         real_t r = rs[ir];
-        real_t cc = 1.0 / r;
+        if(GRT_IS_SMALLE_DISTANCE(r)) continue;
+
+        real_t rinv = 1.0 / r;
+        real_t cc;
         
         // 1 / r^2
-        cc = cc * cc;
+        cc = rinv * rinv;
         real_t coefs[] = {0.0, cc, 2.0*cc};
 
         // 1 / r^3
-        cc = cc * cc;
+        cc = cc * rinv;
         real_t coefs_r[] = {0.0, - 2.0*cc, - 4.0*cc};
 
-        _correct_Wm(coefs, keep_nearfield, Kint->QWV_kmax, Kint->sumJ[ir]);
+        real_t coefs_z[] = {-1.0*cc, 0.0, 3.0*cc};
+
+        _correct_Wm(coefs, keep_nearfield, Kint->QWV_kmax, 1.0, Kint->sumJ[ir]);
         if(Kint->calc_upar){
-            _correct_Wm(coefs,   keep_nearfield, Kint->QWVz_kmax, Kint->sumJz[ir]);
-            _correct_Wm(coefs_r, keep_nearfield, Kint->QWV_kmax,  Kint->sumJr[ir]);
+            _correct_Wm(coefs_z, keep_nearfield, Kint->QWVz_kmax, 1.0 / kcut, Kint->sumJz[ir]);
+            _correct_Wm(coefs_r, keep_nearfield, Kint->QWV_kmax,  1.0, Kint->sumJr[ir]);
         }
     }
 }

--- a/pygrt/C_extension/src/integral/dcm.c
+++ b/pygrt/C_extension/src/integral/dcm.c
@@ -35,6 +35,7 @@ void grt_dcm_correction(size_t nr, real_t *rs, real_t kcut, K_INTEG *Kint, bool 
 {
     for(size_t ir = 0; ir < nr; ++ir)    {
         real_t r = rs[ir];
+        if(GRT_IS_SMALLE_DISTANCE(r)) continue;
 
         real_t rinv = 1.0 / r;
         real_t cc;

--- a/pygrt/C_extension/src/integral/dwm.c
+++ b/pygrt/C_extension/src/integral/dwm.c
@@ -52,8 +52,12 @@ real_t grt_discrete_integ(
 
         if(K->applyDCM){
             GRT_LOOP_ChnlGrid(im, c){
+                K->QWV_raw[im][c] = K->QWV[im][c];
                 K->QWV[im][c] -= K->QWV_kmax[im][c];
-                if(K->calc_upar) K->QWVz[im][c] -= K->QWVz_kmax[im][c];
+                if(K->calc_upar){
+                    K->QWVz_raw[im][c] = K->QWVz[im][c];
+                    K->QWVz[im][c] -= K->QWVz_kmax[im][c] * k / kmax;
+                }
             }
         }
 
@@ -68,7 +72,7 @@ real_t grt_discrete_integ(
             memset(K->SUM, 0, sizeof(cplxIntegGrid));
             
             // 计算被积函数一项 F(k,w)Jm(kr)k
-            grt_int_Pk(k, rs[ir], K->QWV, false, K->SUM);
+            grt_int_Pk(k, rs[ir], (K->applyDCM && GRT_IS_SMALLE_DISTANCE(rs[ir]))? K->QWV_raw : K->QWV, false, K->SUM);
             
             iendk0 = true;
 
@@ -94,7 +98,7 @@ real_t grt_discrete_integ(
             if(K->calc_upar){
                 // ------------------------------- ui_z -----------------------------------
                 // 计算被积函数一项 F(k,w)Jm(kr)k
-                grt_int_Pk(k, rs[ir], K->QWVz, false, K->SUM);
+                grt_int_Pk(k, rs[ir], (K->applyDCM && GRT_IS_SMALLE_DISTANCE(rs[ir]))? K->QWVz_raw : K->QWVz, false, K->SUM);
                 
                 // keps不参与计算位移空间导数的积分，背后逻辑认为u收敛，则uiz也收敛
                 GRT_LOOP_IntegGrid(im, v){
@@ -103,7 +107,7 @@ real_t grt_discrete_integ(
 
                 // ------------------------------- ui_r -----------------------------------
                 // 计算被积函数一项 F(k,w)Jm(kr)k
-                grt_int_Pk(k, rs[ir], K->QWV, true, K->SUM);
+                grt_int_Pk(k, rs[ir], (K->applyDCM && GRT_IS_SMALLE_DISTANCE(rs[ir]))? K->QWV_raw : K->QWV, true, K->SUM);
                 
                 // keps不参与计算位移空间导数的积分，背后逻辑认为u收敛，则uiz也收敛
                 GRT_LOOP_IntegGrid(im, v){

--- a/pygrt/C_extension/src/integral/fim.c
+++ b/pygrt/C_extension/src/integral/fim.c
@@ -55,7 +55,7 @@ real_t grt_linear_filon_integ(
         if(K->applyDCM){
             GRT_LOOP_ChnlGrid(im, c){
                 K->QWV[im][c] -= K->QWV_kmax[im][c];
-                if(K->calc_upar) K->QWVz[im][c] -= K->QWVz_kmax[im][c];
+                if(K->calc_upar) K->QWVz[im][c] -= K->QWVz_kmax[im][c] * k / kmax;
             }
         }
 
@@ -162,7 +162,7 @@ real_t grt_linear_filon_integ(
         if(K->applyDCM){
             GRT_LOOP_ChnlGrid(im, c){
                 K->QWV[im][c] -= K->QWV_kmax[im][c];
-                if(K->calc_upar) K->QWVz[im][c] -= K->QWVz_kmax[im][c];
+                if(K->calc_upar) K->QWVz[im][c] -= K->QWVz_kmax[im][c] * k0N / kmax;
             }
         }
 

--- a/pygrt/C_extension/src/integral/integ_method.c
+++ b/pygrt/C_extension/src/integral/integ_method.c
@@ -19,12 +19,12 @@
 
 void grt_KMET_init_fstats(
     const size_t nr, const real_t *rs, 
-    const char *statsstr, const char *suffix, K_INTEG_METHOD *Kmet)
+    const char *statsstr, const char *suffix, K_INTEG_PROCESS *Kmet)
 {
     if(statsstr == NULL)  return;
 
     if(Kmet->fstats != NULL){
-        GRTRaiseError("fstats != NULL in K_INTEG_METHOD.");
+        GRTRaiseError("fstats != NULL in K_INTEG_PROCESS.");
     }
 
     // 为当前频率创建波数积分记录文件
@@ -56,7 +56,7 @@ void grt_KMET_init_fstats(
 }
 
 
-void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_METHOD *Kmet)
+void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kmet)
 {
     if(Kmet->fstats!=NULL) fclose(Kmet->fstats);
 
@@ -78,7 +78,7 @@ void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_METHOD *Kmet)
 
 
 K_INTEG * grt_wavenumber_integral(
-    MODEL1D_STATE *mstat, size_t nr, real_t *rs, K_INTEG_METHOD *Kmet, bool calc_upar, GRT_KernelFunc kerfunc)
+    MODEL1D_STATE *mstat, size_t nr, real_t *rs, K_INTEG_PROCESS *Kmet, bool calc_upar, GRT_KernelFunc kerfunc)
 {
     real_t k = 0.0;
 

--- a/pygrt/C_extension/src/integral/integ_method.c
+++ b/pygrt/C_extension/src/integral/integ_method.c
@@ -17,37 +17,37 @@
 
 
 
-void grt_KMET_init_fstats(
+void grt_KPROC_init_fstats(
     const size_t nr, const real_t *rs, 
-    const char *statsstr, const char *suffix, K_INTEG_PROCESS *Kmet)
+    const char *statsstr, const char *suffix, K_INTEG_PROCESS *Kproc)
 {
     if(statsstr == NULL)  return;
 
-    if(Kmet->fstats != NULL){
+    if(Kproc->fstats != NULL){
         GRTRaiseError("fstats != NULL in K_INTEG_PROCESS.");
     }
 
     // 为当前频率创建波数积分记录文件
     // PTAM为每个震中距都创建波数积分记录文件
-    Kmet->ptam_fstatsnr = (FILE *(*)[2])calloc(nr, sizeof(*Kmet->ptam_fstatsnr));
+    Kproc->ptam_fstatsnr = (FILE *(*)[2])calloc(nr, sizeof(*Kproc->ptam_fstatsnr));
     char *fname = NULL;
     GRT_SAFE_ASPRINTF(&fname, "%s/K%s", statsstr, suffix);
-    Kmet->fstats = fopen(fname, "wb");
+    Kproc->fstats = fopen(fname, "wb");
 
     // PTAM的积分中间结果, 每个震中距两个文件，因为PTAM对不同震中距使用不同的dk
     // 在文件名后加后缀，区分不同震中距
     char *ptam_dirname = NULL;
-    if(Kmet->applyPTAM){
+    if(Kproc->applyPTAM){
         for(size_t ir = 0; ir < nr; ++ir){
             // 新建文件夹目录 
             GRT_SAFE_ASPRINTF(&ptam_dirname, "%s/PTAM_%04zu_%.5e", statsstr, ir, rs[ir]);
             GRTCheckMakeDir(ptam_dirname);
 
-            Kmet->ptam_fstatsnr[ir][0] = Kmet->ptam_fstatsnr[ir][1] = NULL;
+            Kproc->ptam_fstatsnr[ir][0] = Kproc->ptam_fstatsnr[ir][1] = NULL;
             GRT_SAFE_ASPRINTF(&fname, "%s/K%s", ptam_dirname, suffix);
-            Kmet->ptam_fstatsnr[ir][0] = fopen(fname, "wb");
+            Kproc->ptam_fstatsnr[ir][0] = fopen(fname, "wb");
             GRT_SAFE_ASPRINTF(&fname, "%s/PTAM%s", ptam_dirname, suffix);
-            Kmet->ptam_fstatsnr[ir][1] = fopen(fname, "wb");
+            Kproc->ptam_fstatsnr[ir][1] = fopen(fname, "wb");
         }
     }
     
@@ -56,20 +56,20 @@ void grt_KMET_init_fstats(
 }
 
 
-void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kmet)
+void grt_KPROC_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kproc)
 {
-    if(Kmet->fstats!=NULL) fclose(Kmet->fstats);
+    if(Kproc->fstats!=NULL) fclose(Kproc->fstats);
 
-    if(Kmet->ptam_fstatsnr != NULL){
+    if(Kproc->ptam_fstatsnr != NULL){
         for(size_t ir=0; ir<nr; ++ir){
-            if(Kmet->ptam_fstatsnr[ir][0]!=NULL){
-                fclose(Kmet->ptam_fstatsnr[ir][0]);
+            if(Kproc->ptam_fstatsnr[ir][0]!=NULL){
+                fclose(Kproc->ptam_fstatsnr[ir][0]);
             }
-            if(Kmet->ptam_fstatsnr[ir][1]!=NULL){
-                fclose(Kmet->ptam_fstatsnr[ir][1]);
+            if(Kproc->ptam_fstatsnr[ir][1]!=NULL){
+                fclose(Kproc->ptam_fstatsnr[ir][1]);
             }
         }
-        GRT_SAFE_FREE_PTR(Kmet->ptam_fstatsnr);
+        GRT_SAFE_FREE_PTR(Kproc->ptam_fstatsnr);
     }
 
 }
@@ -78,22 +78,22 @@ void grt_KMET_destroy_fstats(const size_t nr, K_INTEG_PROCESS *Kmet)
 
 
 K_INTEG * grt_wavenumber_integral(
-    MODEL1D_STATE *mstat, size_t nr, real_t *rs, K_INTEG_PROCESS *Kmet, bool calc_upar, GRT_KernelFunc kerfunc)
+    MODEL1D_STATE *mstat, size_t nr, real_t *rs, K_INTEG_PROCESS *Kproc, bool calc_upar, GRT_KernelFunc kerfunc)
 {
     real_t k = 0.0;
 
-    real_t kcut = Kmet->kmax;
+    real_t kcut = Kproc->kmax;
 
-    bool isFilon = Kmet->applyFIM || Kmet->applySAFIM;
+    bool isFilon = Kproc->applyFIM || Kproc->applySAFIM;
 
     if(isFilon){
-        kcut = GRT_MIN(Kmet->kcut, Kmet->kmax);
+        kcut = GRT_MIN(Kproc->kcut, Kproc->kmax);
     }
 
     // 求和 sum F(ki,w)Jm(ki*r)ki 
     K_INTEG *Kint = grt_init_K_INTEG(calc_upar, nr);
-    Kint->applyDCM = Kmet->applyDCM;
-    Kint->kmax = Kmet->kmax;
+    Kint->applyDCM = Kproc->applyDCM;
+    Kint->kmax = Kproc->kmax;
 
     // 准备 DCM，计算波数上限处的核函数
     if(Kint->applyDCM){
@@ -102,35 +102,35 @@ K_INTEG * grt_wavenumber_integral(
     
     // DWM
     k = grt_discrete_integ(
-        mstat, Kmet->dk, kcut, Kmet->keps, nr, rs, 
-        Kint, Kmet->fstats, kerfunc);
+        mstat, Kproc->dk, kcut, Kproc->keps, nr, rs, 
+        Kint, Kproc->fstats, kerfunc);
     if(mstat->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
 
     // 基于线性插值的Filon积分，固定采样间隔
-    if(Kmet->applyFIM){
+    if(Kproc->applyFIM){
         k = grt_linear_filon_integ(
-            mstat, k, Kmet->dk, Kmet->filondk, Kmet->kmax, Kmet->keps, nr, rs, 
-            Kint, Kmet->fstats, kerfunc);
+            mstat, k, Kproc->dk, Kproc->filondk, Kproc->kmax, Kproc->keps, nr, rs, 
+            Kint, Kproc->fstats, kerfunc);
         if(mstat->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
     }
     // 基于自适应采样的Filon积分
-    else if(Kmet->applySAFIM){
-        real_t kref = (creal(mstat->omega) > 0.0) ? creal(mstat->omega) / Kmet->vmin * Kmet->ampk : 0.0; // 静态解中频率位置给了负值
+    else if(Kproc->applySAFIM){
+        real_t kref = (creal(mstat->omega) > 0.0) ? creal(mstat->omega) / Kproc->vmin * Kproc->ampk : 0.0; // 静态解中频率位置给了负值
         k = grt_sa_filon_integ(
-            mstat, k, Kmet->dk, Kmet->sa_tol, Kmet->kmax, kref, nr, rs, 
-            Kint, Kmet->fstats, kerfunc);
+            mstat, k, Kproc->dk, Kproc->sa_tol, Kproc->kmax, kref, nr, rs, 
+            Kint, Kproc->fstats, kerfunc);
         if(mstat->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
     }
 
     // 显式收敛
-    if(Kmet->applyPTAM){
+    if(Kproc->applyPTAM){
         grt_PTA_method(
-            mstat, k, Kmet->dk, nr, rs, 
-            Kint, Kmet->ptam_fstatsnr, kerfunc);
+            mstat, k, Kproc->dk, nr, rs, 
+            Kint, Kproc->ptam_fstatsnr, kerfunc);
         if(mstat->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
     }
-    else if(Kmet->applyDCM){
-        grt_dcm_correction(nr, rs, Kint, !isFilon);
+    else if(Kproc->applyDCM){
+        grt_dcm_correction(nr, rs, kcut, Kint, !isFilon);
     }
 
 

--- a/pygrt/C_extension/src/integral/integ_process.c
+++ b/pygrt/C_extension/src/integral/integ_process.c
@@ -130,7 +130,7 @@ K_INTEG * grt_wavenumber_integral(
         if(mstat->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
     }
     else if(Kproc->cvgmet == K_INTEG_CONVERG_DCM){
-        grt_dcm_correction(nr, rs, Kint, !isFilon);
+        grt_dcm_correction(nr, rs, kcut, Kint, !isFilon);
     }
 
 

--- a/pygrt/C_extension/src/integral/integ_process.c
+++ b/pygrt/C_extension/src/integral/integ_process.c
@@ -1,5 +1,5 @@
 /**
- * @file   integ_method.c
+ * @file   integ_process.c
  * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
  * @date   2025-12
  * 
@@ -13,7 +13,7 @@
 #include "grt/integral/safim.h"
 #include "grt/integral/dwm.h"
 #include "grt/integral/dcm.h"
-#include "grt/integral/integ_method.h"
+#include "grt/integral/integ_process.h"
 
 
 
@@ -37,7 +37,7 @@ void grt_KPROC_init_fstats(
     // PTAM的积分中间结果, 每个震中距两个文件，因为PTAM对不同震中距使用不同的dk
     // 在文件名后加后缀，区分不同震中距
     char *ptam_dirname = NULL;
-    if(Kproc->applyPTAM){
+    if(Kproc->cvgmet == K_INTEG_CONVERG_PTAM){
         for(size_t ir = 0; ir < nr; ++ir){
             // 新建文件夹目录 
             GRT_SAFE_ASPRINTF(&ptam_dirname, "%s/PTAM_%04zu_%.5e", statsstr, ir, rs[ir]);
@@ -92,7 +92,7 @@ K_INTEG * grt_wavenumber_integral(
 
     // 求和 sum F(ki,w)Jm(ki*r)ki 
     K_INTEG *Kint = grt_init_K_INTEG(calc_upar, nr);
-    Kint->applyDCM = Kproc->applyDCM;
+    Kint->applyDCM = Kproc->cvgmet == K_INTEG_CONVERG_DCM;
     Kint->kmax = Kproc->kmax;
 
     // 准备 DCM，计算波数上限处的核函数
@@ -123,13 +123,13 @@ K_INTEG * grt_wavenumber_integral(
     }
 
     // 显式收敛
-    if(Kproc->applyPTAM){
+    if(Kproc->cvgmet == K_INTEG_CONVERG_PTAM){
         grt_PTA_method(
             mstat, k, Kproc->dk, nr, rs, 
             Kint, Kproc->ptam_fstatsnr, kerfunc);
         if(mstat->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
     }
-    else if(Kproc->applyDCM){
+    else if(Kproc->cvgmet == K_INTEG_CONVERG_DCM){
         grt_dcm_correction(nr, rs, kcut, Kint, !isFilon);
     }
 

--- a/pygrt/C_extension/src/integral/integ_process.c
+++ b/pygrt/C_extension/src/integral/integ_process.c
@@ -130,7 +130,7 @@ K_INTEG * grt_wavenumber_integral(
         if(mstat->stats==GRT_INVERSE_FAILURE)  goto BEFORE_RETURN;
     }
     else if(Kproc->cvgmet == K_INTEG_CONVERG_DCM){
-        grt_dcm_correction(nr, rs, kcut, Kint, !isFilon);
+        grt_dcm_correction(nr, rs, Kint, !isFilon);
     }
 
 

--- a/pygrt/C_extension/src/integral/k_integ.c
+++ b/pygrt/C_extension/src/integral/k_integ.c
@@ -76,13 +76,26 @@ void grt_int_Pk(real_t k, real_t r, const cplxChnlGrid QWV, bool calc_uir, cplxI
         real_t bjmk0[GRT_MORDER_MAX+1] = {0};
         for(int i=0; i<=GRT_MORDER_MAX; ++i)  bjmk0[i] = bjmk[i];
 
-        grt_besselp012(kr, &bjmk[0], &bjmk[1], &bjmk[2]); 
-        kcoef = k*k;
+        if(GRT_IS_SMALLE_DISTANCE(r)){
+            bjmk[0] = - bjmk0[1];
+            bjmk[1] = bjmk0[0] - 0.5;
+            bjmk[2] = bjmk0[1] - 0.25*kr;
+            Jmcoef[1] = - 0.125 * kr;
+            Jmcoef[2] = 0.125;
+        } else {
+            grt_besselp012(kr, &bjmk[0], &bjmk[1], &bjmk[2]); 
+            for(int i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] = kr_inv * (-kr_inv * bjmk0[i] + bjmk[i]);
+        }
 
-        for(int i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] = kr_inv * (-kr_inv * bjmk0[i] + bjmk[i]);
+        kcoef = k*k;
     } 
     else {
-        for(int i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] = bjmk[i]*kr_inv;
+        if(GRT_IS_SMALLE_DISTANCE(r)){
+            Jmcoef[1] = 0.5;
+            Jmcoef[2] = 0.125*kr;
+        } else {
+            for(int i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] = bjmk[i]*kr_inv;
+        }
     }
 
     for(int i=1; i<=GRT_MORDER_MAX; ++i)  Jmcoef[i] *= kcoef;
@@ -98,7 +111,7 @@ void grt_int_Pk(real_t k, real_t r, const cplxChnlGrid QWV, bool calc_uir, cplxI
         }
         else{
             SUM[i][0]  =   QWV[i][0] * bjmk[modr-1];         // qm*Jm-1*k
-            SUM[i][1]  = - modr*(QWV[i][0] + QWV[i][2]) * Jmcoef[modr];    // - m*(qm+vm)*Jm*k/kr
+            SUM[i][1]  = - modr * (QWV[i][0] + QWV[i][2]) * Jmcoef[modr];    // - m*(qm+vm)*Jm*k/kr
             SUM[i][2]  =   QWV[i][1] * bjmk[modr];           // wm*Jm*k
             SUM[i][3]  = - QWV[i][2] * bjmk[modr-1];         // -vm*Jm-1*k
         }

--- a/pygrt/C_extension/src/integral/safim.c
+++ b/pygrt/C_extension/src/integral/safim.c
@@ -306,7 +306,7 @@ real_t grt_sa_filon_integ(
         if(K->applyDCM){
             GRT_LOOP_ChnlGrid(im, c){
                 Kitv.F3[i][im][c] -= K->QWV_kmax[im][c];
-                if(K->calc_upar) Kitv.Fz3[i][im][c] -= K->QWVz_kmax[im][c];
+                if(K->calc_upar) Kitv.Fz3[i][im][c] -= K->QWVz_kmax[im][c] * Kitv.k3[i] / kmax;
             }
         }
     }
@@ -366,8 +366,8 @@ real_t grt_sa_filon_integ(
                 Kitv_left.F3[1][im][c] -= K->QWV_kmax[im][c];
                 Kitv_right.F3[1][im][c] -= K->QWV_kmax[im][c];
                 if(K->calc_upar){
-                    Kitv_left.Fz3[1][im][c] -= K->QWVz_kmax[im][c];
-                    Kitv_right.Fz3[1][im][c] -= K->QWVz_kmax[im][c];
+                    Kitv_left.Fz3[1][im][c]  -= K->QWVz_kmax[im][c] * Kitv_left.k3[1]  / kmax;
+                    Kitv_right.Fz3[1][im][c] -= K->QWVz_kmax[im][c] * Kitv_right.k3[1] / kmax;
                 }
             }
         }

--- a/pygrt/C_extension/src/static/grt_static_greenfn.c
+++ b/pygrt/C_extension/src/static/grt_static_greenfn.c
@@ -61,7 +61,7 @@ typedef struct {
         bool active;
         real_t keps;
         real_t k0;
-        bool fixed_k0;
+        bool k0_is_fixed;
     } K;
     /** 波数积分过程的核函数文件 */
     struct {
@@ -408,7 +408,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                             break;
 
                         case 'f':
-                            Ctrl->K.fixed_k0 = true;
+                            Ctrl->K.k0_is_fixed = true;
                             break;
 
                         default:
@@ -599,7 +599,7 @@ int static_greenfn_main(int argc, char **argv){
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
         KPROC.k0 = Ctrl->K.k0 * PI / hs;
-        KPROC.fixed_k0 = Ctrl->K.fixed_k0;
+        KPROC.k0_is_fixed = Ctrl->K.k0_is_fixed;
         KPROC.keps = (Ctrl->C.convmet != K_INTEG_CONVERG_AUTO)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
 
         // 最大震中距

--- a/pygrt/C_extension/src/static/grt_static_greenfn.c
+++ b/pygrt/C_extension/src/static/grt_static_greenfn.c
@@ -600,33 +600,33 @@ int static_greenfn_main(int argc, char **argv){
     realChnlGrid *grn_uir = (Ctrl->e.active)? (realChnlGrid *) calloc(Ctrl->nr, sizeof(*grn_uir)) : NULL;
 
     // 波数积分方法
-    K_INTEG_PROCESS KMET = {0};
+    K_INTEG_PROCESS KPROC = {0};
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
-        KMET.k0 = Ctrl->K.k0 * PI / hs;
-        KMET.keps = (Ctrl->C.applyPTAM || Ctrl->C.applyDCM)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
+        KPROC.k0 = Ctrl->K.k0 * PI / hs;
+        KPROC.keps = (Ctrl->C.applyPTAM || Ctrl->C.applyDCM)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
 
         // 最大震中距
         real_t rmax = Ctrl->rs[grt_findMax_real_t(Ctrl->rs, Ctrl->nr)];   
         
-        KMET.kcut = Ctrl->L.kcut / rmax;
+        KPROC.kcut = Ctrl->L.kcut / rmax;
 
-        KMET.dk = PI2 / (Ctrl->L.Length * rmax);
+        KPROC.dk = PI2 / (Ctrl->L.Length * rmax);
 
-        KMET.applyFIM = Ctrl->L.FIM.active;
-        KMET.filondk = (Ctrl->L.FIM.active) ? PI2 / (Ctrl->L.FIM.Length * rmax) : 0.0;
+        KPROC.applyFIM = Ctrl->L.FIM.active;
+        KPROC.filondk = (Ctrl->L.FIM.active) ? PI2 / (Ctrl->L.FIM.Length * rmax) : 0.0;
 
-        KMET.applySAFIM = Ctrl->L.SAFIM.active;
-        KMET.sa_tol = Ctrl->L.SAFIM.tol;
+        KPROC.applySAFIM = Ctrl->L.SAFIM.active;
+        KPROC.sa_tol = Ctrl->L.SAFIM.tol;
         
-        KMET.applyDCM = Ctrl->C.applyDCM;
-        KMET.applyPTAM = Ctrl->C.applyPTAM;
+        KPROC.applyDCM = Ctrl->C.applyDCM;
+        KPROC.applyPTAM = Ctrl->C.applyPTAM;
     }
 
     //==============================================================================
     // 计算静态格林函数
     grt_integ_static_grn(
-        mod1d, Ctrl->nr, Ctrl->rs, &KMET,
+        mod1d, Ctrl->nr, Ctrl->rs, &KPROC,
         Ctrl->e.active, grn, grn_uiz, grn_uir,
         Ctrl->S.s_statsdir
     );

--- a/pygrt/C_extension/src/static/grt_static_greenfn.c
+++ b/pygrt/C_extension/src/static/grt_static_greenfn.c
@@ -54,9 +54,7 @@ typedef struct {
     /** 波数积分收敛方法 */
     struct {
         bool active;
-        bool applyDCM;
-        bool applyPTAM;
-        bool applyNoConverg;
+        K_INTEG_CONVERG_METHOD convmet;
     } C;
     /** 波数积分上限 */
     struct {
@@ -208,7 +206,7 @@ printf("\n"
 "                 + d: Direct Convergence Method (DCM).\n"
 "                 + p: Peak-Trough Averaging Method (PTAM).\n"
 "                 + n: None.\n"
-"                 Default use +cd when fabs(depsrc-deprcv) <= %.1f.\n", GRT_MIN_DEPTH_GAP_SRC_RCV); printf(
+"                 Default use -Cd when fabs(depsrc-deprcv) <= %.1f.\n", GRT_MIN_DEPTH_GAP_SRC_RCV); printf(
 "\n"
 "    -Bf|F|r|R|h|H\n"
 "                 Boundary condition of top layer (lowercase) and\n"
@@ -371,20 +369,17 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                 }
                 switch (optarg[0]){
                     case 'p':
-                        Ctrl->C.applyPTAM = true;
+                        Ctrl->C.convmet = K_INTEG_CONVERG_PTAM;
                         break;
                     case 'd':
-                        Ctrl->C.applyDCM = true;
+                        Ctrl->C.convmet = K_INTEG_CONVERG_DCM;
                         break;
                     case 'n':
-                        Ctrl->C.applyNoConverg = true;
+                        Ctrl->C.convmet = K_INTEG_CONVERG_REFUSE;
                         break;
                     default:
                         GRTBadOptionError(C, "-C+%s is not supported.", optarg);
                         break;
-                }
-                if(Ctrl->C.applyPTAM && Ctrl->C.applyDCM){
-                    GRTBadOptionError(C, "You can't set -Cd and -Cp both.");
                 }
                 break;
 
@@ -575,11 +570,6 @@ int static_greenfn_main(int argc, char **argv){
 
     // 边界条件
     grt_set_mod1d_boundary(mod1d, Ctrl->B.topbound, Ctrl->B.botbound);
-
-    // 判断是否要自动使用收敛方法
-    if( ! Ctrl->C.active && fabs(Ctrl->D.deprcv - Ctrl->D.depsrc) <= GRT_MIN_DEPTH_GAP_SRC_RCV) {
-        Ctrl->C.applyDCM = true;
-    }
     
     // 设置积分间隔默认值
     if(Ctrl->L.Length == 0.0)  Ctrl->L.Length = GRT_GREENFN_L_LENGTH;
@@ -604,7 +594,7 @@ int static_greenfn_main(int argc, char **argv){
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
         KPROC.k0 = Ctrl->K.k0 * PI / hs;
-        KPROC.keps = (Ctrl->C.applyPTAM || Ctrl->C.applyDCM)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
+        KPROC.keps = (Ctrl->C.convmet != K_INTEG_CONVERG_AUTO)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
 
         // 最大震中距
         real_t rmax = Ctrl->rs[grt_findMax_real_t(Ctrl->rs, Ctrl->nr)];   
@@ -619,8 +609,7 @@ int static_greenfn_main(int argc, char **argv){
         KPROC.applySAFIM = Ctrl->L.SAFIM.active;
         KPROC.sa_tol = Ctrl->L.SAFIM.tol;
         
-        KPROC.applyDCM = Ctrl->C.applyDCM;
-        KPROC.applyPTAM = Ctrl->C.applyPTAM;
+        KPROC.cvgmet = Ctrl->C.convmet;
     }
 
     //==============================================================================

--- a/pygrt/C_extension/src/static/grt_static_greenfn.c
+++ b/pygrt/C_extension/src/static/grt_static_greenfn.c
@@ -600,7 +600,7 @@ int static_greenfn_main(int argc, char **argv){
     realChnlGrid *grn_uir = (Ctrl->e.active)? (realChnlGrid *) calloc(Ctrl->nr, sizeof(*grn_uir)) : NULL;
 
     // 波数积分方法
-    K_INTEG_METHOD KMET = {0};
+    K_INTEG_PROCESS KMET = {0};
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
         KMET.k0 = Ctrl->K.k0 * PI / hs;

--- a/pygrt/C_extension/src/static/grt_static_greenfn.c
+++ b/pygrt/C_extension/src/static/grt_static_greenfn.c
@@ -10,7 +10,7 @@
 #include "grt.h"
 
 // 一些变量的非零默认值
-#define GRT_GREENFN_K_K0          5.0
+#define GRT_GREENFN_K_K0         50.0
 #define GRT_GREENFN_L_LENGTH     15.0
 
 
@@ -61,6 +61,7 @@ typedef struct {
         bool active;
         real_t keps;
         real_t k0;
+        bool fixed_k0;
     } K;
     /** 波数积分过程的核函数文件 */
     struct {
@@ -141,7 +142,7 @@ printf("\n"
 "           [-X<x1>/<x2>/<dx>] [-Y<y1>/<y2>/<dy>] \n"
 "           [-R<r1>,<r2>[,...]|<r1>/<r2>/<dr>|<file>]\n" 
 "           [-L<length>]   [-C[d|p|n]]  [-Bf|F|r|R|h|H] \n"
-"           [-K[+k<k0>][+e<keps>]] [-S]  [-e]\n"
+"           [-K[+k<k0>][+f][+e<keps>]] [-S]  [-e]\n"
 "\n"
 "    There're two ways to define the \"epicentral distances\":\n"
 "    1. set both -X and -Y to define a XY grid in advance.\n"
@@ -215,13 +216,13 @@ printf("\n"
 "                 r|R: Rigid boundary.\n"
 "                 h|H: Halfspace.\n"
 "\n"
-"    -K[+k<k0>][+e<keps>]\n"
-"                 Several parameters designed to define the\n"
-"                 behavior in wavenumber integration. The upper\n"
-"                 bound is k0,\n"
-"                 <k0>:   default is %.1f, and \n", GRT_GREENFN_K_K0); printf(
-"                         multiply PI/hs in program, \n"
-"                         where hs = max(fabs(depsrc-deprcv), %.1f).\n", GRT_MIN_DEPTH_GAP_SRC_RCV); printf(
+"    -K[+k<k0>][+f][+e<keps>]\n"
+"                 Define the wavenumber integration upperbound\n"
+"                 <k0>:   maximum upper bound, default is %.1f, and multiply PI/hs \n", GRT_GREENFN_K_K0); printf(
+"                         in program, where hs = max(fabs(depsrc-deprcv), %.1f).\n", GRT_MIN_DEPTH_GAP_SRC_RCV); printf(
+"                         The program will choose the proper upper bound in [0, k0].\n"
+"                         If k0 is not enough, convergence method will be applied.\n"
+"                         If use +f, directly set k0 as the upper bound.\n"
 "                 <keps>: a threshold for break wavenumber \n"
 "                         integration in advance. See \n"
 "                         (Yao and Harkrider, 1983) for details.\n"
@@ -383,7 +384,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                 }
                 break;
 
-            // 波数积分相关变量 -K[+k<k0>][+e<keps>]
+            // 波数积分相关变量 -K[+k<k0>][+f][+e<keps>]
             case 'K':
                 Ctrl->K.active = true;
                 {
@@ -404,6 +405,10 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                             if(1 != sscanf(token+1, "%lf", &Ctrl->K.keps)){
                                 GRTBadOptionError(K+e, "");
                             }
+                            break;
+
+                        case 'f':
+                            Ctrl->K.fixed_k0 = true;
                             break;
 
                         default:
@@ -594,6 +599,7 @@ int static_greenfn_main(int argc, char **argv){
     {   
         real_t hs = GRT_MAX(fabs(mod1d->depsrc - mod1d->deprcv), GRT_MIN_DEPTH_GAP_SRC_RCV);
         KPROC.k0 = Ctrl->K.k0 * PI / hs;
+        KPROC.fixed_k0 = Ctrl->K.fixed_k0;
         KPROC.keps = (Ctrl->C.convmet != K_INTEG_CONVERG_AUTO)? 0.0 : Ctrl->K.keps;  // 如果使用了显式收敛方法，则不使用keps进行收敛判断
 
         // 最大震中距

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -94,7 +94,7 @@ void grt_integ_static_grn(
     // ===================================================================================
     //                          Wavenumber Integration
     // 波数积分上限
-    Kmet->kmax = Kmet->k0;
+    Kproc->kmax = Kproc->k0;
     // 模型状态
     MODEL1D_STATE *mstat = grt_init_mod1d_state(mod1d);
     grt_update_mod1d_state_omega(mstat, 1.0, true);

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -59,7 +59,7 @@ static void recordin_GRN(
 
 
 void grt_integ_static_grn(
-    MODEL1D *mod1d, size_t nr, real_t *rs, K_INTEG_METHOD *Kmet,
+    MODEL1D *mod1d, size_t nr, real_t *rs, K_INTEG_PROCESS *Kmet,
     bool calc_upar, 
     realChnlGrid grn[nr],
     realChnlGrid grn_uiz[nr],

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 
 #include "grt/static/static_grn.h"
+#include "grt/static/static_util.h"
 #include "grt/common/const.h"
 #include "grt/common/model.h"
 #include "grt/integral/integ_process.h"
@@ -94,7 +95,40 @@ void grt_integ_static_grn(
     // ===================================================================================
     //                          Wavenumber Integration
     // 波数积分上限
-    Kproc->kmax = Kproc->k0;
+    if(Kproc->fixed_k0){
+        Kproc->kmax = Kproc->k0;
+    } else {
+        size_t ncount = 0, nk = 0;
+        real_t static_kmax = 0.0;
+        static_kmax = grt_predict_static_kmax(mod1d, Kproc->k0, &ncount);
+        nk = (size_t)(static_kmax / Kproc->dk);
+        GRTRaiseInfo(
+            "for a proper k0, ncount = %zu, k0 = %.3e, k0_ref = %.3e, nk = %zu", 
+            ncount, static_kmax, Kproc->k0, nk);
+        
+        // 若 nk 不够，适当调整 dk
+        if(nk < GRT_MIN_STATIC_NK){
+            real_t new_dk = static_kmax / GRT_MIN_STATIC_NK;
+            GRTRaiseWarning("nk(%zu) < %d, adjust dk from %.3e to %.3e", nk, GRT_MIN_STATIC_NK, Kproc->dk, new_dk);
+            Kproc->dk = new_dk;
+        }
+        
+        if(Kproc->cvgmet == K_INTEG_CONVERG_AUTO){
+            // 如果上限触发边界，且未指定收敛算法，则强制使用 DCM 进行收敛
+            if(static_kmax >= Kproc->k0){
+                Kproc->cvgmet = K_INTEG_CONVERG_DCM;
+                Kproc->keps = 0.0;
+                GRTRaiseWarning("k0 reaches k0_ref, apply %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
+            }
+        } else if(Kproc->cvgmet != K_INTEG_CONVERG_REFUSE) {
+            // 正常打印手动选择的收敛方法
+            GRTRaiseInfo("manually set the %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
+        }
+
+        Kproc->kmax = static_kmax;
+    }
+
+
     // 模型状态
     MODEL1D_STATE *mstat = grt_init_mod1d_state(mod1d);
     grt_update_mod1d_state_omega(mstat, 1.0, true);

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -101,9 +101,9 @@ void grt_integ_static_grn(
         size_t ncount = 0, nk = 0;
         real_t static_kmax = 0.0;
         static_kmax = grt_predict_static_kmax(mod1d, Kproc->k0, &ncount);
-        nk = (size_t)(static_kmax / Kproc->dk);
+        nk = floor(static_kmax / Kproc->dk) + 1;
         GRTRaiseInfo(
-            "for a proper k0, ncount = %zu, k0 = %.3e, k0_ref = %.3e, nk = %zu", 
+            "For a proper kc, ncount = %zu, kc = %.3e, k0 = %.3e, nk = %zu", 
             ncount, static_kmax, Kproc->k0, nk);
         
         // 若 nk 不够，适当调整 dk
@@ -118,11 +118,13 @@ void grt_integ_static_grn(
             if(static_kmax >= Kproc->k0){
                 Kproc->cvgmet = K_INTEG_CONVERG_DCM;
                 Kproc->keps = 0.0;
-                GRTRaiseWarning("k0 reaches k0_ref, apply %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
+                GRTRaiseWarning(
+                    "kc reaches k0, apply %s. "
+                    "You should consider to increase the k0 (maximum upper bound)", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
             }
         } else if(Kproc->cvgmet != K_INTEG_CONVERG_REFUSE) {
             // 正常打印手动选择的收敛方法
-            GRTRaiseInfo("manually set the %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
+            GRTRaiseInfo("Manually set the %s.", GRT_EXPLAIN_CVGMETHOD(Kproc->cvgmet));
         }
 
         Kproc->kmax = static_kmax;

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -95,7 +95,7 @@ void grt_integ_static_grn(
     // ===================================================================================
     //                          Wavenumber Integration
     // 波数积分上限
-    if(Kproc->fixed_k0){
+    if(Kproc->k0_is_fixed){
         Kproc->kmax = Kproc->k0;
     } else {
         size_t ncount = 0, nk = 0;

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -22,7 +22,7 @@
 #include "grt/static/static_grn.h"
 #include "grt/common/const.h"
 #include "grt/common/model.h"
-#include "grt/integral/integ_method.h"
+#include "grt/integral/integ_process.h"
 #include "grt/common/search.h"
 
 

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -59,7 +59,7 @@ static void recordin_GRN(
 
 
 void grt_integ_static_grn(
-    MODEL1D *mod1d, size_t nr, real_t *rs, K_INTEG_PROCESS *Kmet,
+    MODEL1D *mod1d, size_t nr, real_t *rs, K_INTEG_PROCESS *Kproc,
     bool calc_upar, 
     realChnlGrid grn[nr],
     realChnlGrid grn_uiz[nr],
@@ -89,7 +89,7 @@ void grt_integ_static_grn(
     bool needfstats = (statsstr!=NULL);
 
     // 输出积分过程文件
-    if(needfstats) grt_KMET_init_fstats(uniq_nr, uniq_rs, statsstr, "", Kmet);
+    if(needfstats) grt_KPROC_init_fstats(uniq_nr, uniq_rs, statsstr, "", Kproc);
 
     // ===================================================================================
     //                          Wavenumber Integration
@@ -98,10 +98,11 @@ void grt_integ_static_grn(
     // 模型状态
     MODEL1D_STATE *mstat = grt_init_mod1d_state(mod1d);
     grt_update_mod1d_state_omega(mstat, 1.0, true);
-    K_INTEG *Kint = grt_wavenumber_integral(mstat, uniq_nr, uniq_rs, Kmet, calc_upar, grt_static_kernel);
+    
+    K_INTEG *Kint = grt_wavenumber_integral(mstat, uniq_nr, uniq_rs, Kproc, calc_upar, grt_static_kernel);
     
     cplx_t src_mu = mstat->mu[mod1d->isrc];
-    cplx_t fac = Kmet->dk * 1.0/(4.0*PI * src_mu);
+    cplx_t fac = Kproc->dk * 1.0/(4.0*PI * src_mu);
     
     // 将积分结果记录到浮点数数组中
     recordin_GRN(uniq_nr, fac, Kint->sumJ, grn);
@@ -130,7 +131,7 @@ void grt_integ_static_grn(
     grt_free_K_INTEG(Kint);
     grt_free_mod1d_state(mstat);
 
-    if(needfstats)  grt_KMET_destroy_fstats(uniq_nr, Kmet);
+    if(needfstats)  grt_KPROC_destroy_fstats(uniq_nr, Kproc);
 
     GRT_SAFE_FREE_PTR(uniq_rs);
     GRT_SAFE_FREE_PTR(rs_refidx);

--- a/pygrt/C_extension/src/static/static_util.c
+++ b/pygrt/C_extension/src/static/static_util.c
@@ -1,0 +1,48 @@
+/**
+ * @file   static_util.c
+ * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
+ * @date   2026-06
+ * 
+ * 一些关于静态解的辅助函数
+ * 
+ */
+
+#include "grt/static/static_util.h"
+#include "grt/integral/kernel.h"
+
+
+real_t grt_predict_static_kmax(MODEL1D *mod1d, real_t kmax_ref, size_t *Ncount)
+{
+    if(mod1d->depsrc == mod1d->deprcv){
+        return kmax_ref;
+    }
+
+    MODEL1D_STATE *mstat = grt_init_mod1d_state(mod1d);
+    grt_update_mod1d_state_omega(mstat, 1.0, true);
+
+    // 利用振幅来估计一个合适的积分上限
+    real_t Fmax = 0.0, F = 0.0, kmax = 0.0;
+    cplxChnlGrid QWV = {0}, QWVz = {0};
+    kmax = kmax_ref * 1e-3;
+    size_t ncount = 0;
+    while(kmax < kmax_ref){
+        F = 0.0;
+        grt_static_kernel(mstat, kmax, QWV, true, QWVz);
+        GRT_LOOP_ChnlGrid(im, c){
+            F += sqrt(kmax) * (fabs(QWV[im][c]) + fabs(QWVz[im][c]));
+        }
+        Fmax = GRT_MAX(F, Fmax);
+
+        if(F < 1e-3 * Fmax) break;
+
+        kmax *= 1.2;
+        ncount++;
+    }
+    grt_free_mod1d_state(mstat);
+
+    kmax = GRT_MIN(kmax, kmax_ref);
+
+    if(Ncount != NULL)  *Ncount = ncount;
+
+    return kmax;
+}

--- a/pygrt/c_interfaces.py
+++ b/pygrt/c_interfaces.py
@@ -29,14 +29,14 @@ libgrt = cdll.LoadLibrary(
 
 C_grt_integ_grn_spec = libgrt.grt_integ_grn_spec
 """C库中计算格林函数的主函数 integ_grn_spec, 详见C API同名函数"""
-C_grt_integ_grn_spec.argtypes = [POINTER(c_MODEL1D), POINTER(c_K_INTEG_METHOD), POINTER(c_GRNSPEC), c_bool]
+C_grt_integ_grn_spec.argtypes = [POINTER(c_MODEL1D), POINTER(c_K_INTEG_PROCESS), POINTER(c_GRNSPEC), c_bool]
 
 
 C_grt_integ_static_grn = libgrt.grt_integ_static_grn
 """计算静态格林函数"""
 C_grt_integ_static_grn.restype = None
 C_grt_integ_static_grn.argtypes = [
-    POINTER(c_MODEL1D), c_size_t, PREAL, POINTER(c_K_INTEG_METHOD),
+    POINTER(c_MODEL1D), c_size_t, PREAL, POINTER(c_K_INTEG_PROCESS),
     c_bool,
     POINTER((REAL*CHANNEL_NUM)*SRC_M_NUM),
     POINTER((REAL*CHANNEL_NUM)*SRC_M_NUM),

--- a/pygrt/c_structures.py
+++ b/pygrt/c_structures.py
@@ -27,6 +27,8 @@ __all__ = [
     "NPCT_REAL_TYPE",
     "NPCT_CMPLX_TYPE",
 
+    "K_INTEG_CVGMET_DICT",
+
     "REAL",
     "PREAL",
     "CPLX",
@@ -51,6 +53,13 @@ MECHANISM_NUM = 6
 
 NPCT_REAL_TYPE = 'f8'
 NPCT_CMPLX_TYPE = 'c16'
+
+K_INTEG_CVGMET_DICT = {
+    'AUTO': 0,
+    'NONE': 1,
+    'DCM': 2,
+    'PTAM': 3
+}
 
 
 class CPLX(Structure):
@@ -119,8 +128,7 @@ class c_K_INTEG_PROCESS(Structure):
         ('applySAFIM', c_bool),
         ('sa_tol', REAL),
 
-        ('applyDCM', c_bool),
-        ('applyPTAM', c_bool),
+        ('cvgmet', c_int),
 
         ('fstats', c_void_p),
         ('ptam_fstatsnr', c_void_p),

--- a/pygrt/c_structures.py
+++ b/pygrt/c_structures.py
@@ -113,7 +113,7 @@ class c_K_INTEG_PROCESS(Structure):
 
     _fields_ = [
         ('k0', REAL),
-        ('fixed_k0', c_bool),
+        ('k0_is_fixed', c_bool),
         ('ampk', REAL),
         ('keps', REAL),
         ('vmin', REAL),

--- a/pygrt/c_structures.py
+++ b/pygrt/c_structures.py
@@ -33,7 +33,7 @@ __all__ = [
     "PCPLX",
 
     "c_MODEL1D",
-    "c_K_INTEG_METHOD",
+    "c_K_INTEG_PROCESS",
     "c_GRNSPEC"
 ]
 
@@ -97,9 +97,9 @@ class c_MODEL1D(Structure):
     ]
 
 
-class c_K_INTEG_METHOD(Structure):
+class c_K_INTEG_PROCESS(Structure):
     """
-    和C结构体 K_INTEG_METHOD 作匹配
+    和C结构体 K_INTEG_PROCESS 作匹配
     """
 
     _fields_ = [

--- a/pygrt/c_structures.py
+++ b/pygrt/c_structures.py
@@ -113,6 +113,7 @@ class c_K_INTEG_PROCESS(Structure):
 
     _fields_ = [
         ('k0', REAL),
+        ('fixed_k0', c_bool),
         ('ampk', REAL),
         ('keps', REAL),
         ('vmin', REAL),

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -353,28 +353,28 @@ class PyModel1D:
 
 
         # ====================================================================
-        KMET = c_K_INTEG_PROCESS()
+        KPROC = c_K_INTEG_PROCESS()
         hs = max(abs(depsrc - deprcv), 1.0)
-        KMET.k0 = k0 * np.pi / hs
-        KMET.ampk = ampk
-        KMET.keps = keps if converg_method == 'none' else 0.0
-        KMET.vmin = vmin_ref
+        KPROC.k0 = k0 * np.pi / hs
+        KPROC.ampk = ampk
+        KPROC.keps = keps if converg_method == 'none' else 0.0
+        KPROC.vmin = vmin_ref
 
-        KMET.kcut = filonCut / rmax
+        KPROC.kcut = filonCut / rmax
         
-        KMET.dk = 2.0*np.pi / (Length * rmax)
+        KPROC.dk = 2.0*np.pi / (Length * rmax)
         
-        KMET.applyFIM = filonLength > 0.0
-        KMET.filondk = 2.0*np.pi / (filonLength * rmax) if filonLength > 0.0 else 0.0
+        KPROC.applyFIM = filonLength > 0.0
+        KPROC.filondk = 2.0*np.pi / (filonLength * rmax) if filonLength > 0.0 else 0.0
         
-        KMET.applySAFIM = safilonTol > 0.0
-        KMET.sa_tol = safilonTol
+        KPROC.applySAFIM = safilonTol > 0.0
+        KPROC.sa_tol = safilonTol
 
-        KMET.applyDCM = converg_method == 'DCM'
-        KMET.applyPTAM = converg_method == 'PTAM'
+        KPROC.applyDCM = converg_method == 'DCM'
+        KPROC.applyPTAM = converg_method == 'PTAM'
         # ====================================================================
 
-
+        
         # ====================================================================
         grn = c_GRNSPEC()
         grn.nf = nf
@@ -690,27 +690,27 @@ class PyModel1D:
             c_pygrn_uiz = c_pygrn_uir = None
         
 
-        KMET = c_K_INTEG_PROCESS()
+        KPROC = c_K_INTEG_PROCESS()
 
         hs = max(abs(depsrc - deprcv), 1.0)
-        KMET.k0 = k0 * np.pi / hs
-        KMET.keps = keps if converg_method == 'none' else 0.0
+        KPROC.k0 = k0 * np.pi / hs
+        KPROC.keps = keps if converg_method == 'none' else 0.0
 
         # 最大震中距
         rmax = np.max(rs)
 
-        KMET.kcut = filonCut / rmax
+        KPROC.kcut = filonCut / rmax
         
-        KMET.dk = 2.0*np.pi / (Length * rmax)
+        KPROC.dk = 2.0*np.pi / (Length * rmax)
         
-        KMET.applyFIM = filonLength > 0.0
-        KMET.filondk = 2.0*np.pi / (filonLength * rmax) if filonLength > 0.0 else 0.0
+        KPROC.applyFIM = filonLength > 0.0
+        KPROC.filondk = 2.0*np.pi / (filonLength * rmax) if filonLength > 0.0 else 0.0
         
-        KMET.applySAFIM = safilonTol > 0.0
-        KMET.sa_tol = safilonTol
+        KPROC.applySAFIM = safilonTol > 0.0
+        KPROC.sa_tol = safilonTol
 
-        KMET.applyDCM = converg_method == 'DCM'
-        KMET.applyPTAM = converg_method == 'PTAM'
+        KPROC.applyDCM = converg_method == 'DCM'
+        KPROC.applyPTAM = converg_method == 'PTAM'
 
         # 运行C库函数
         #/////////////////////////////////////////////////////////////////////////////////

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -353,7 +353,7 @@ class PyModel1D:
 
 
         # ====================================================================
-        KMET = c_K_INTEG_METHOD()
+        KMET = c_K_INTEG_PROCESS()
         hs = max(abs(depsrc - deprcv), 1.0)
         KMET.k0 = k0 * np.pi / hs
         KMET.ampk = ampk
@@ -690,7 +690,7 @@ class PyModel1D:
             c_pygrn_uiz = c_pygrn_uir = None
         
 
-        KMET = c_K_INTEG_METHOD()
+        KMET = c_K_INTEG_PROCESS()
 
         hs = max(abs(depsrc - deprcv), 1.0)
         KMET.k0 = k0 * np.pi / hs

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -176,7 +176,8 @@ class PyModel1D:
         vmin_ref:float=0.0,
         keps:float=-1.0,  
         ampk:float=1.15,
-        k0:float=5.0, 
+        k0:float=50.0, 
+        fixed_k0:bool=False,
         Length:float=0.0, 
         filonLength:float=0.0,
         safilonTol:float=0.0,
@@ -319,6 +320,7 @@ class PyModel1D:
         KPROC = c_K_INTEG_PROCESS()
         hs = max(abs(depsrc - deprcv), 1.0)
         KPROC.k0 = k0 * np.pi / hs
+        KPROC.fixed_k0 = fixed_k0
         KPROC.ampk = ampk
         KPROC.keps = keps if converg_method.upper() != 'AUTO' else 0.0
         KPROC.vmin = vmin_ref
@@ -461,7 +463,8 @@ class PyModel1D:
         vmin_ref:float=0.0,
         keps:float=-1.0,  
         ampk:float=1.15,
-        k0:float=5.0, 
+        k0:float=50.0, 
+        fixed_k0:bool=False,
         Length:float=0.0, 
         filonLength:float=0.0,
         safilonTol:float=0.0,
@@ -489,11 +492,12 @@ class PyModel1D:
                                      :math:`\tilde{\omega} = \omega - j*w_I, w_I = \zeta*\pi/T, T=nt*dt` .
                                      see Bouchon (1981) and 张海明 (2021) for more details and tests.
             :param    keepAllFreq:   calculate all frequency points, no matter how low the frequency is
-            :param    vmin_ref:      minimum reference velocity (km/s). the default vmin=max(minimum velocity, 0.1), used to define the upper limit of k integral
+            :param    vmin_ref:      minimum reference velocity (km/s). the default vmin=max(minimum velocity, 0.1), used to define the upper bound of k integral
             :param    keps:          automatic convergence condition, see Yao and Harkrider (1983) for more details.
                                      negative value denotes not use.
-            :param    ampk:          The factor that affect the upper limit of the k integral, see below.
-            :param    k0:            k0 used to define the upper limit :math:`\tilde{k_{max}}=\sqrt{(k_{0}*\pi/hs)^2 + (ampk*w/vmin_{ref})^2}` , hs=max(abs(depsrc-deprcv),1.0)
+            :param    ampk:          The factor that affect the upper bound of the k integral, see below.
+            :param    k0:            k0 used to define the maximum offset of upper bound :math:`\tilde{k_{max}}=\sqrt{(k_{0}*\pi/hs)^2 + (ampk*w/vmin_{ref})^2}` , hs=max(abs(depsrc-deprcv),1.0)
+            :param    fixed_k0:      directly use k0, rather than choosing a proper offset in [0, k0]
             :param    Length:        integration step `dk=2\pi / (L*rmax)`, see Bouchon (1981) and 张海明 (2021) for the criterion, default set automatically.
             :param    filonLength:   integration step of Fixed-Interval Filon's Integration Method
             :param    safilonTol:    precision of Self-Adaptive Filon's Integration Method
@@ -520,7 +524,7 @@ class PyModel1D:
 
         pygrnLst, pygrnLst_uiz, pygrnLst_uir = self._get_grn_spectra(
             distarr, nt, dt, upsampling_n, freqband, zeta, keepAllFreq, 
-            vmin_ref, keps, ampk, k0, Length, filonLength, safilonTol, filonCut, converg_method,
+            vmin_ref, keps, ampk, k0, fixed_k0, Length, filonLength, safilonTol, filonCut, converg_method,
             delayT0, delayV0, calc_upar,
             statsfile, statsidxs, print_runtime
         )
@@ -540,7 +544,8 @@ class PyModel1D:
         yarr:Union[np.ndarray,List[float],float,None]=None, 
         distarr:Union[np.ndarray,List[float],float,None]=None, 
         keps:float=-1.0,  
-        k0:float=5.0, 
+        k0:float=50.0, 
+        fixed_k0:bool=False,
         Length:float=15.0, 
         filonLength:float=0.0,
         safilonTol:float=0.0,
@@ -560,7 +565,8 @@ class PyModel1D:
             :param    distarr:          equal to "xarr=[0.0], yarr=distarr"
             :param       keps:          automatic convergence condition, see (Yao and Harkrider (1983) for more details.
                                         negative value denotes not use.
-            :param       k0:            k0 used to define the upper limit :math:`\tilde{k_{max}}=(k_{0}*\pi/hs)^2`, hs=max(abs(depsrc-deprcv),1.0)
+            :param       k0:            k0 used to define the maximum offset of upper bound :math:`\tilde{k_{max}}=(k_{0}*\pi/hs)^2`, hs=max(abs(depsrc-deprcv),1.0)
+            :param       fixed_k0:      directly use k0, rather than choosing a proper offset in [0, k0]
             :param       Length:        integration step `dk=2\pi / (L*rmax)`, default L=15
             :param       filonLength:   integration step of Fixed-Interval Filon's Integration Method
             :param       safilonTol:    precision of Self-Adaptive Filon's Integration Method
@@ -646,16 +652,14 @@ class PyModel1D:
 
         # ====================================================================
         KPROC = c_K_INTEG_PROCESS()
-
         hs = max(abs(depsrc - deprcv), 1.0)
         KPROC.k0 = k0 * np.pi / hs
+        KPROC.fixed_k0 = fixed_k0
         KPROC.keps = keps if converg_method.upper() != 'AUTO' else 0.0
 
         # 最大震中距
         rmax = np.max(rs)
-
         KPROC.kcut = filonCut / rmax
-        
         KPROC.dk = 2.0*np.pi / (Length * rmax)
         
         KPROC.applyFIM = filonLength > 0.0

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -177,7 +177,7 @@ class PyModel1D:
         keps:float=-1.0,  
         ampk:float=1.15,
         k0:float=50.0, 
-        fixed_k0:bool=False,
+        k0_is_fixed:bool=False,
         Length:float=0.0, 
         filonLength:float=0.0,
         safilonTol:float=0.0,
@@ -320,7 +320,7 @@ class PyModel1D:
         KPROC = c_K_INTEG_PROCESS()
         hs = max(abs(depsrc - deprcv), 1.0)
         KPROC.k0 = k0 * np.pi / hs
-        KPROC.fixed_k0 = fixed_k0
+        KPROC.k0_is_fixed = k0_is_fixed
         KPROC.ampk = ampk
         KPROC.keps = keps if converg_method.upper() != 'AUTO' else 0.0
         KPROC.vmin = vmin_ref
@@ -464,7 +464,7 @@ class PyModel1D:
         keps:float=-1.0,  
         ampk:float=1.15,
         k0:float=50.0, 
-        fixed_k0:bool=False,
+        k0_is_fixed:bool=False,
         Length:float=0.0, 
         filonLength:float=0.0,
         safilonTol:float=0.0,
@@ -497,7 +497,7 @@ class PyModel1D:
                                      negative value denotes not use.
             :param    ampk:          The factor that affect the upper bound of the k integral, see below.
             :param    k0:            k0 used to define the maximum offset of upper bound :math:`\tilde{k_{max}}=\sqrt{(k_{0}*\pi/hs)^2 + (ampk*w/vmin_{ref})^2}` , hs=max(abs(depsrc-deprcv),1.0)
-            :param    fixed_k0:      directly use k0, rather than choosing a proper offset in [0, k0]
+            :param    k0_is_fixed:      directly use k0, rather than choosing a proper offset in [0, k0]
             :param    Length:        integration step `dk=2\pi / (L*rmax)`, see Bouchon (1981) and 张海明 (2021) for the criterion, default set automatically.
             :param    filonLength:   integration step of Fixed-Interval Filon's Integration Method
             :param    safilonTol:    precision of Self-Adaptive Filon's Integration Method
@@ -524,7 +524,7 @@ class PyModel1D:
 
         pygrnLst, pygrnLst_uiz, pygrnLst_uir = self._get_grn_spectra(
             distarr, nt, dt, upsampling_n, freqband, zeta, keepAllFreq, 
-            vmin_ref, keps, ampk, k0, fixed_k0, Length, filonLength, safilonTol, filonCut, converg_method,
+            vmin_ref, keps, ampk, k0, k0_is_fixed, Length, filonLength, safilonTol, filonCut, converg_method,
             delayT0, delayV0, calc_upar,
             statsfile, statsidxs, print_runtime
         )
@@ -545,7 +545,7 @@ class PyModel1D:
         distarr:Union[np.ndarray,List[float],float,None]=None, 
         keps:float=-1.0,  
         k0:float=50.0, 
-        fixed_k0:bool=False,
+        k0_is_fixed:bool=False,
         Length:float=15.0, 
         filonLength:float=0.0,
         safilonTol:float=0.0,
@@ -566,7 +566,7 @@ class PyModel1D:
             :param       keps:          automatic convergence condition, see (Yao and Harkrider (1983) for more details.
                                         negative value denotes not use.
             :param       k0:            k0 used to define the maximum offset of upper bound :math:`\tilde{k_{max}}=(k_{0}*\pi/hs)^2`, hs=max(abs(depsrc-deprcv),1.0)
-            :param       fixed_k0:      directly use k0, rather than choosing a proper offset in [0, k0]
+            :param       k0_is_fixed:      directly use k0, rather than choosing a proper offset in [0, k0]
             :param       Length:        integration step `dk=2\pi / (L*rmax)`, default L=15
             :param       filonLength:   integration step of Fixed-Interval Filon's Integration Method
             :param       safilonTol:    precision of Self-Adaptive Filon's Integration Method
@@ -654,7 +654,7 @@ class PyModel1D:
         KPROC = c_K_INTEG_PROCESS()
         hs = max(abs(depsrc - deprcv), 1.0)
         KPROC.k0 = k0 * np.pi / hs
-        KPROC.fixed_k0 = fixed_k0
+        KPROC.k0_is_fixed = k0_is_fixed
         KPROC.keps = keps if converg_method.upper() != 'AUTO' else 0.0
 
         # 最大震中距

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -181,7 +181,7 @@ class PyModel1D:
         filonLength:float=0.0,
         safilonTol:float=0.0,
         filonCut:float=0.0,
-        converg_method:Union[str,None]=None,
+        converg_method:Literal['AUTO', 'NONE', 'DCM', 'PTAM']='AUTO',
         delayT0:float=0.0,
         delayV0:float=0.0,
         calc_upar:bool=False,
@@ -218,10 +218,6 @@ class PyModel1D:
         # 只能设置一种filon积分方法
         if safilonTol > 0.0 and filonLength > 0.0:
             raise ValueError(f"You should only set one of filonLength and safilonTol.")
-        
-        # 只能设置规定的收敛方法
-        if converg_method is not None and converg_method not in ['DCM', 'PTAM', 'none']:
-            raise ValueError(f'Wrong converg_method ({converg_method})')
         
         nf = nt//2+1 
         df = 1/(nt*dt)
@@ -267,10 +263,6 @@ class PyModel1D:
         # 参考最小速度
         if vmin_ref == 0.0:
             vmin_ref = max(self.vmin, 0.1)
-
-        # 若不指定显式收敛方法，则根据情况自动使用PTAM
-        if converg_method is None and abs(depsrc - deprcv) <= 1.0:
-            converg_method = 'DCM'
 
         # 时窗长度
         winT = nt*dt 
@@ -323,41 +315,12 @@ class PyModel1D:
             nstatsidxs = 0
 
 
-        # ===========================================
-        # 打印参数设置 
-        if print_runtime:
-            print(f"k0={k0}")
-            print(f"ampk={ampk}")
-            print(f"keps={keps}")
-            print(f"vmin={vmin_ref}")
-            print(f"Length={Length}")
-            print(f"kcut={filonCut}")
-            print(f"filonLength={filonLength}")
-            print(f"safilonTol={safilonTol}")
-            print(f'converg_method={converg_method}')
-            
-            print(f"nt={nt}")
-            print(f"dt={dt}")
-            print(f"winT={winT}")
-            print(f"zeta={zeta}")
-            print(f"delayT0={delayT0}")
-            print(f"delayV0={delayV0}")
-            print(f"tmax={tmax}")
-            
-            print(f"maxfreq(Hz)={freqs[nf-1]}")
-            print(f"f1(Hz)={freqs[nf1]}")
-            print(f"f2(Hz)={freqs[nf2]}")
-            print(f"distances(km)=", distarr)
-            if nstatsidxs > 0:
-                print(f"statsfile_index=", statsidxs)
-
-
         # ====================================================================
         KPROC = c_K_INTEG_PROCESS()
         hs = max(abs(depsrc - deprcv), 1.0)
         KPROC.k0 = k0 * np.pi / hs
         KPROC.ampk = ampk
-        KPROC.keps = keps if converg_method == 'none' else 0.0
+        KPROC.keps = keps if converg_method.upper() != 'AUTO' else 0.0
         KPROC.vmin = vmin_ref
 
         KPROC.kcut = filonCut / rmax
@@ -370,11 +333,10 @@ class PyModel1D:
         KPROC.applySAFIM = safilonTol > 0.0
         KPROC.sa_tol = safilonTol
 
-        KPROC.applyDCM = converg_method == 'DCM'
-        KPROC.applyPTAM = converg_method == 'PTAM'
+        KPROC.cvgmet = K_INTEG_CVGMET_DICT[converg_method.upper()]
         # ====================================================================
 
-        
+
         # ====================================================================
         grn = c_GRNSPEC()
         grn.nf = nf
@@ -401,7 +363,7 @@ class PyModel1D:
         #     爆炸源 EX[ZR]                          1e-20 cm/(dyne*cm)
         #     剪切源 DD[ZR],DS[ZRT],SS[ZRT]          1e-20 cm/(dyne*cm)
         #=================================================================================
-        C_grt_integ_grn_spec(self.c_mod1d, pointer(KMET), pointer(grn), print_runtime)
+        C_grt_integ_grn_spec(self.c_mod1d, pointer(KPROC), pointer(grn), print_runtime)
         #=================================================================================
         #/////////////////////////////////////////////////////////////////////////////////
 
@@ -504,7 +466,7 @@ class PyModel1D:
         filonLength:float=0.0,
         safilonTol:float=0.0,
         filonCut:float=0.0,
-        converg_method:Union[str,None]=None,
+        converg_method:Literal['AUTO', 'NONE', 'DCM', 'PTAM']='AUTO',
         delayT0:float=0.0,
         delayV0:float=0.0,
         skipImagComps:bool=False,
@@ -536,7 +498,7 @@ class PyModel1D:
             :param    filonLength:   integration step of Fixed-Interval Filon's Integration Method
             :param    safilonTol:    precision of Self-Adaptive Filon's Integration Method
             :param    filonCut:      The splitting point of DWM and (SA)FIM, k*=<filonCut>/rmax, default is 0
-            :param    converg_method:   The method of explicit convergence, you can set "DCM", "PTAM" or "none". Default use "DCM" when abs(depsrc-deprcv) <= 1.0 km
+            :param    converg_method:   The method of explicit convergence, you can set "AUTO", "NONE", "DCM" or "PTAM". Default use "AUTO".
             :param    skipImagComps:    skip the amplitude compensation from imaginary frequency.
             :param    calc_upar:     whether calculate the spatial derivatives of displacements.
             :param    gf_source:     The source type to be calculated
@@ -583,7 +545,7 @@ class PyModel1D:
         filonLength:float=0.0,
         safilonTol:float=0.0,
         filonCut:float=0.0,
-        converg_method:Union[str,None]=None,
+        converg_method:Literal['AUTO', 'NONE', 'DCM', 'PTAM']='AUTO',
         calc_upar:bool=False,
         statsfile:Union[str,None]=None):
 
@@ -603,7 +565,7 @@ class PyModel1D:
             :param       filonLength:   integration step of Fixed-Interval Filon's Integration Method
             :param       safilonTol:    precision of Self-Adaptive Filon's Integration Method
             :param       filonCut:      The splitting point of DWM and (SA)FIM, k*=<filonCut>/rmax, default is 0
-            :param    converg_method:   The method of explicit convergence, you can set "DCM", "PTAM" or "none". Default use "DCM" when abs(depsrc-deprcv) <= 1.0 km
+            :param    converg_method:   The method of explicit convergence, you can set "AUTO", "NONE", "DCM" or "PTAM". Default use "AUTO".
             :param       calc_upar:     whether calculate the spatial derivatives of displacements.
             :param       statsfile:     directory path for saving the statsfile during k integral, used to debug or observe the variations of :math:`F(k,\omega)` and :math:`F(k,\omega)J_m(kr)k` 
             
@@ -629,10 +591,6 @@ class PyModel1D:
         # 只能设置一种filon积分方法
         if safilonTol > 0.0 and filonLength > 0.0:
             raise ValueError(f"You should only set one of filonLength and safilonTol.")
-        
-        # 只能设置规定的收敛方法
-        if converg_method is not None and converg_method not in ['DCM', 'PTAM', 'none']:
-            raise ValueError(f'Wrong converg_method ({converg_method})')
 
         depsrc = self.depsrc
         deprcv = self.deprcv
@@ -671,10 +629,6 @@ class PyModel1D:
         if Length == 0.0:
             Length = 15.0
 
-        # 若不指定显式收敛方法，则根据情况自动使用PTAM
-        if converg_method is None and abs(depsrc - deprcv) <= 1.0:
-            converg_method = 'DCM'
-
         # 积分状态文件
         c_statsfile = None 
         if statsfile is not None:
@@ -690,11 +644,12 @@ class PyModel1D:
             c_pygrn_uiz = c_pygrn_uir = None
         
 
+        # ====================================================================
         KPROC = c_K_INTEG_PROCESS()
 
         hs = max(abs(depsrc - deprcv), 1.0)
         KPROC.k0 = k0 * np.pi / hs
-        KPROC.keps = keps if converg_method == 'none' else 0.0
+        KPROC.keps = keps if converg_method.upper() != 'AUTO' else 0.0
 
         # 最大震中距
         rmax = np.max(rs)
@@ -709,8 +664,10 @@ class PyModel1D:
         KPROC.applySAFIM = safilonTol > 0.0
         KPROC.sa_tol = safilonTol
 
-        KPROC.applyDCM = converg_method == 'DCM'
-        KPROC.applyPTAM = converg_method == 'PTAM'
+        KPROC.cvgmet = K_INTEG_CVGMET_DICT[converg_method.upper()]
+        # ====================================================================
+
+
 
         # 运行C库函数
         #/////////////////////////////////////////////////////////////////////////////////
@@ -720,7 +677,7 @@ class PyModel1D:
         #     剪切源 DD[ZR],DS[ZRT],SS[ZRT]          1e-20 cm/(dyne*cm)
         #=================================================================================
         C_grt_integ_static_grn(
-            self.c_mod1d, nr, c_rs, pointer(KMET),
+            self.c_mod1d, nr, c_rs, pointer(KPROC),
             calc_upar, c_pygrn, c_pygrn_uiz, c_pygrn_uir,
             c_statsfile
         )


### PR DESCRIPTION
This is a relatively large PR. Due to some reasons, it can't be split into several small PRs. The following are the tasks completed in this PR:

+ rename struct `K_INTEG_METHOD` to `K_INTEG_PROCESS`
+ rename variables `KMET/Kmet` to `KPROC/Kproc`
+ use one enum vaiable to define the convergence method, rename "integ_method.h/c" to "integ_process.h/c"
+ optimize the Bessel functions for the small epicentral distance
+ automatically set the proper upper bound of k-integral
+ update the DCM's formula for the z-directives, and fix some typos