### PR TITLE
BREAKING: PyModel1D keyword paths (grn/stgrn) 

### DIFF
--- a/docs/source/Advanced/boundary/boundary.rst
+++ b/docs/source/Advanced/boundary/boundary.rst
@@ -23,7 +23,7 @@
          
     .. group-tab:: Python
 
-        :func:`PyModel1D() <pygrt.pymod.PyModel1D>` 创建模型时可设置边界条件：
+        :func:`PyModel1D() <pygrt.pymod.PyModel1D>` 创建时可设置边界条件（与 ``grn`` / ``stgrn`` / ``modelpath`` 同为关键字参数）：
 
         + ``topbound:Literal['free', 'rigid', 'halfspace']`` 顶层边界条件
         + ``botbound:Literal['free', 'rigid', 'halfspace']`` 底层边界条件

--- a/docs/source/Advanced/integ_converg/integ_converg.rst
+++ b/docs/source/Advanced/integ_converg/integ_converg.rst
@@ -29,8 +29,7 @@
             :start-after: BEGIN DGRN
             :end-before: END DGRN
 
-        输出的核函数文件会在 :rst:dir:`GRN_grtstats/milrow_{depsrc}_{deprcv}/` 路径下
-        （与 C 一致，根目录名由 ``set_dynamic_grn_path`` 的输出目录决定）。
+        输出的核函数文件会在 :rst:dir:`GRN_grtstats/milrow_{depsrc}_{deprcv}/` 路径下。
 
 
 C和Python导出的核函数文件是一致的，底层调用的是相同的函数。文件名称格式为 ``K_{iw}_{freq}``，其中 ``{iw}`` 表示频率索引值， ``{freq}`` 表示对应频率(Hz)。文件为自定义的二进制文件， **强烈建议使用Python进行读取及后续处理**。这里还是给出两种读取方法。

--- a/docs/source/Advanced/integ_converg/ptam.rst
+++ b/docs/source/Advanced/integ_converg/ptam.rst
@@ -40,8 +40,7 @@
             :start-after: BEGIN DEPSRC 0.0 DGRN
             :end-before: END DEPSRC 0.0 DGRN
 
-        输出的核函数文件会在 :rst:dir:`GRN_grtstats/milrow_{depsrc}_{deprcv}/` 路径下
-        （与 C 一致）。
+        输出的核函数文件会在 :rst:dir:`GRN_grtstats/milrow_{depsrc}_{deprcv}/` 路径下。
 
 在 ``K_{iw}_{freq}`` 文件同级目录下，程序把 **PTAM过程中的核函数以及积分峰谷位置分为两个文件** 
 保存在 ``PTAM_{ir}_{dist}/`` 目录下（ ``{ir}`` 为震中距索引， ``{dist}`` 为震中距），

--- a/docs/source/Advanced/integ_converg/run/run.py
+++ b/docs/source/Advanced/integ_converg/run/run.py
@@ -7,8 +7,7 @@ from pygrt.cli import format_float
 depsrc = 2.0
 deprcv = 0.0
 
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
 
 # statsidxs 指定频率索引，核函数写入 GRN_grtstats/{model}_{depsrc}_{deprcv}/
 distarr = [5,8,10]
@@ -61,8 +60,7 @@ fig.savefig(f"{srctype}_{ptype}_RI.svg", bbox_inches='tight')
 # BEGIN DEPSRC 0.0 DGRN
 depsrc = 0.0
 deprcv = 0.0
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
 
 pymod.compute_grn(
     depsrc=depsrc, deprcv=deprcv,

--- a/docs/source/Advanced/integ_converg/run_ptam/run.py
+++ b/docs/source/Advanced/integ_converg/run_ptam/run.py
@@ -6,8 +6,7 @@ from pygrt.cli import format_float
 
 depsrc = 0.0
 deprcv = 0.0
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
 
 distarr = [5,8,10]
 # 设置 converg_method='PTAM' 进行收敛
@@ -44,8 +43,7 @@ from pygrt.cli import format_float
 
 depsrc = 0.05
 deprcv = 0.0
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath="milrow")
 
 norths = [2.0, 2.0, 1.0]
 easts = [2.0, 2.0, 1.0]

--- a/docs/source/Advanced/k_integ/drift/run/run.py
+++ b/docs/source/Advanced/k_integ/drift/run/run.py
@@ -4,8 +4,7 @@ import pygrt
 from obspy import read
 from pygrt.cli import format_float
 
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
 
 depsrc = 10.0
 deprcv = 0.0

--- a/docs/source/Advanced/k_integ/safim/run/run.py
+++ b/docs/source/Advanced/k_integ/safim/run/run.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pygrt 
 
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
 
 pymod.compute_grn(
     depsrc=5.0,

--- a/docs/source/Advanced/kernel_old/run/run.py
+++ b/docs/source/Advanced/kernel_old/run/run.py
@@ -6,8 +6,7 @@ from typing import Union
 import pygrt 
 from pygrt.cli import format_float
 
-pymod = pygrt.PyModel1D("mod1")
-pymod.set_dynamic_grn_path("KERNEL")
+pymod = pygrt.PyModel1D(grn="KERNEL", modelpath="mod1")
 
 depsrc = 0.03
 deprcv = 0.0

--- a/docs/source/Gallery/ex01/run.py
+++ b/docs/source/Gallery/ex01/run.py
@@ -4,8 +4,7 @@ import matplotlib.pyplot as plt
 from typing import Union
 import pygrt
 
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
 pymod.compute_grn(depsrc=5.0, deprcv=0.0, distarr=[180], nt=1400, dt=0.1)
 # ?.sac 匹配位移三分量文件名（Z/R/T）
 # integrate_order=1 对应 CLI -I1，得到阶跃型位移

--- a/docs/source/Gallery/ex03/plot_cps_pygrt.py
+++ b/docs/source/Gallery/ex03/plot_cps_pygrt.py
@@ -6,8 +6,7 @@ from obspy import *
 
 depsrc = 2.0   
 deprcv = 0     
-pymod = pygrt.PyModel1D("./milrow")
-pymod.set_dynamic_grn_path("GRN_pygrt")
+pymod = pygrt.PyModel1D(grn="GRN_pygrt", modelpath="./milrow")
 
 rs = np.array([10]) 
 

--- a/docs/source/Gallery/ex05/run.py
+++ b/docs/source/Gallery/ex05/run.py
@@ -13,8 +13,7 @@ dt=0.01
 
 modname="milrow"
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modname)
 
 # compute green functions
 pymod.compute_grn(

--- a/docs/source/Gallery/ex14/plot.py
+++ b/docs/source/Gallery/ex14/plot.py
@@ -32,8 +32,7 @@ t = np.arange(0, nt)*dt * Vs/r
 
 modfile = "_halfspace_mod"
 np.savetxt(modfile, modarr)
-pymod = pygrt.PyModel1D(modfile)
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modfile)
 # 计算格林函数（仅一个震中距，可用通配符读回）
 pymod.compute_grn(
     depsrc=depsrc, deprcv=deprcv, distarr=rs, nt=nt, dt=dt,

--- a/docs/source/Gallery/ex15/plot.py
+++ b/docs/source/Gallery/ex15/plot.py
@@ -11,9 +11,7 @@ deprcv = 0.0
 depsrc = 5.0
 distarr = np.arange(0.1, 50, 1)
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_dynamic_grn_path("GRN")
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(grn="GRN", stgrn="stgrn.nc", modelpath=modname)
 
 # 零频频谱: nt=1 时只算 ω=0
 # C 反变换写 SAC 时乘了 df=1/(nt*dt)，故时域首点 * dt 即还原频域幅值

--- a/docs/source/Gallery/ex15/plot_all.py
+++ b/docs/source/Gallery/ex15/plot_all.py
@@ -11,9 +11,7 @@ deprcv = 0.0
 depsrc = 5.0
 distarr = np.arange(0.1, 50, 0.5)
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_dynamic_grn_path("GRN")
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(grn="GRN", stgrn="stgrn.nc", modelpath=modname)
 
 # 零频频谱: nt=1 时只算 ω=0
 # C 反变换写 SAC 时乘了 df=1/(nt*dt)，故时域首点 * dt 即还原频域幅值

--- a/docs/source/Gallery/ex16/plot.py
+++ b/docs/source/Gallery/ex16/plot.py
@@ -35,9 +35,7 @@ else:
     ])
 modfile1 = f"mod_{bound1}_{bound2}"
 np.savetxt(modfile1, modarr)
-pymod1 = pygrt.PyModel1D(modfile1, topbound=bound1, botbound=bound2)
-pymod1.set_dynamic_grn_path("GRN1")
-pymod1.set_static_grn_path("stgrn1.nc")
+pymod1 = pygrt.PyModel1D(grn="GRN1", stgrn="stgrn1.nc", modelpath=modfile1, topbound=bound1, botbound=bound2)
 pymod1.compute_grn(
     depsrc=depsrc, deprcv=deprcv, distarr=rs, nt=nt, dt=dt,
     keepAllFreq=True,
@@ -70,9 +68,7 @@ print(modarr2.shape, depsrc2, deprcv2)
 
 modfile2 = f"mod_{bound2}_{bound1}"
 np.savetxt(modfile2, modarr2)
-pymod2 = pygrt.PyModel1D(modfile2, topbound=bound2, botbound=bound1)
-pymod2.set_dynamic_grn_path("GRN2")
-pymod2.set_static_grn_path("stgrn2.nc")
+pymod2 = pygrt.PyModel1D(grn="GRN2", stgrn="stgrn2.nc", modelpath=modfile2, topbound=bound2, botbound=bound1)
 pymod2.compute_grn(
     depsrc=depsrc2, deprcv=deprcv2, distarr=rs, nt=nt, dt=dt,
     keepAllFreq=True,

--- a/docs/source/Lamb_problem/run/lamb1_plot_freq_time.py
+++ b/docs/source/Lamb_problem/run/lamb1_plot_freq_time.py
@@ -40,8 +40,7 @@ t = np.arange(0, nt)*dt * Vs/r
 
 modfile = "_halfspace_mod"
 np.savetxt(modfile, modarr)
-pymod = pygrt.PyModel1D(modfile)
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modfile)
 # 计算格林函数（仅一个震中距，可用通配符读回）
 pymod.compute_grn(
     depsrc=depsrc, deprcv=deprcv, distarr=rs, nt=nt, dt=dt,

--- a/docs/source/Module/greenfn.rst
+++ b/docs/source/Module/greenfn.rst
@@ -38,7 +38,8 @@ greenfn
 **greenfn** 模块计算每个震中距 *r* 的格林函数波形保存路径为 
 ``{outdir}/{model}_{depsrc}_{deprcv}_{r}/{stype}.sac`` ，
 其中支持的格林函数类型 ``stype`` 详见 :ref:`grn_types` 。
-执行 **greenfn** 模块的原始命令会附加式地保存到 ``{outdir}/command`` 文件。
+同时会在 *outdir* 根目录保留一份模型文件副本（文件名为 ``-M`` 路径的 basename），
+执行命令也会附加式地写入 ``{outdir}/command`` 。
 
 不同震源的格林函数单位为：
 

--- a/docs/source/Tutorial/dynamic/gfunc.rst
+++ b/docs/source/Tutorial/dynamic/gfunc.rst
@@ -34,7 +34,8 @@ Python中计算动态格林函数的主函数为 :meth:`compute_grn() <pygrt.pym
             :start-after: BEGIN GRN
             :end-before: END GRN
 
-        不同震源深度、接收点深度和震中距的格林函数会在 :rst:dir:`GRN/milrow_{depsrc}_{deprcv}_{dist}/` 路径下，使用SAC格式保存。 
+        不同震源深度、接收点深度和震中距的格林函数会在 :rst:dir:`GRN/milrow_{depsrc}_{deprcv}_{dist}/` 路径下，使用SAC格式保存。
+        输出根目录下还会保留模型文件副本（basename）以及 ``command`` 记录。
 
         一些基本信息（包括源点和场点的物性参数）保存在SAC头段变量中，其中 :c:var:`t0` 和 :c:var:`t1` 分别代表初至P波和初至S波的到时。在不设定其它参数时，程序中使用0（发震时刻）作为参考时间，故其等价于走时。
 
@@ -69,8 +70,9 @@ Python中计算动态格林函数的主函数为 :meth:`compute_grn() <pygrt.pym
             :start-after: BEGIN GRN
             :end-before: END GRN
 
-        格林函数写入 :meth:`set_dynamic_grn_path() <pygrt.pymod.PyModel1D.set_dynamic_grn_path>`
-        指定的根目录。需要读回时使用 ObsPy 的 ``read`` 。 :class:`Trace.stats.sac`
+        格林函数写入构造 :class:`~pygrt.pymod.PyModel1D` 时 ``grn=`` 指定的根目录。
+        该根目录下还会保留一份模型文件副本（与 ``-M`` 的 basename 相同），便于后续取用。
+        需要读回时使用 ObsPy 的 ``read`` 。 :class:`Trace.stats.sac`
         中保存了 SAC 头段变量，与 C 程序输出保持一致。
 
 当时窗长度 nt\*dt 太小“包不住”有效信号，或时窗长度足够但时延不合适，输出的波形会发生混叠，

--- a/docs/source/Tutorial/dynamic/run/run.py
+++ b/docs/source/Tutorial/dynamic/run/run.py
@@ -4,7 +4,7 @@ import numpy as np
 import pygrt
 
 # 直接使用模型文件路径
-pymod = pygrt.PyModel1D("milrow")
+pymod = pygrt.PyModel1D(modelpath="milrow")
 
 # END BUILD MODEL
 # -----------------------------------------------------------------------------------
@@ -15,8 +15,7 @@ pymod = pygrt.PyModel1D("milrow")
 # BEGIN GRN
 from obspy import read
 
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
 
 # 结果写入 GRN/milrow_{depsrc}_{deprcv}_{dist}/
 pymod.compute_grn(
@@ -118,6 +117,14 @@ def plot_int_dif(stsyn:Stream, stsyn_int:Stream, stsyn_dif:Stream, chnl:str, out
             fig.savefig(out, bbox_inches='tight')
 
 # END plot func
+# -----------------------------------------------------------------------------------
+
+
+# -----------------------------------------------------------------------------------
+# BEGIN REUSE GRN
+# 若仅使用已算好的格林函数做合成，构造时只需指定 grn，无需 modelpath
+pymod = pygrt.PyModel1D(grn="GRN")
+# END REUSE GRN
 # -----------------------------------------------------------------------------------
 
 

--- a/docs/source/Tutorial/dynamic/run_upar/run.py
+++ b/docs/source/Tutorial/dynamic/run_upar/run.py
@@ -4,8 +4,7 @@ import numpy as np
 import pygrt
 from obspy import read
 
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
 
 # 传入 calc_upar=True 计算空间导数
 pymod.compute_grn(

--- a/docs/source/Tutorial/dynamic/syn.rst
+++ b/docs/source/Tutorial/dynamic/syn.rst
@@ -12,6 +12,12 @@
 Python中合成动态位移的主函数为 :meth:`compute_syn() <pygrt.pymod.PyModel1D.compute_syn>` ，C模块为 :doc:`/Module/syn`。
 
 使用上节计算的格林函数，合成动态位移（理论地震图）。方便起见，这里统一使用milrow模型，震源深度2km，场点位于地表，震中距10km的格林函数，方位角30°。
+若仅使用已算好的格林函数，构造 :class:`~pygrt.pymod.PyModel1D` 时只需指定 ``grn``，无需再传 ``modelpath``：
+
+.. literalinclude:: run/run.py
+    :language: python
+    :start-after: BEGIN REUSE GRN
+    :end-before: END REUSE GRN
 
 在已知三分量格林函数 :math:`W_m(t), Q_m(t), V_m(t)` 后，合成三分量位移 :math:`u_z(t), u_r(t), u_\theta (t)` 的公式为
 

--- a/docs/source/Tutorial/prepare.rst
+++ b/docs/source/Tutorial/prepare.rst
@@ -50,7 +50,8 @@ Python 接口主要负责组织模型与输出路径，并调用 :command:`grt` 
 
     .. tab:: Python
 
-        模型格式与 C 一致，Python 端直接传入模型文件路径。
+        模型格式与 C 一致。Python 端通过 ``modelpath=`` 传入模型文件路径
+        （计算格林函数时还需同时指定 ``grn=`` 或 ``stgrn=``）。
 
         .. literalinclude:: dynamic/run/run.py
             :language: python

--- a/docs/source/Tutorial/static/run/run.py
+++ b/docs/source/Tutorial/static/run/run.py
@@ -3,8 +3,7 @@
 import numpy as np
 import pygrt
 
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath="milrow")
 
 # norths/easts 各为三个元素: start/stop/step (km)
 norths = [-3.0, 3.0, 0.15]
@@ -55,6 +54,14 @@ def plot_static(static_syn:dict, out:Union[str,None]=None):
     if out is not None:
         fig.savefig(out, bbox_inches='tight')
 # END plot func
+# ---------------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------------
+# BEGIN REUSE STGRN
+# 若仅使用已算好的静态格林函数做合成，构造时只需指定 stgrn，无需 modelpath
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc")
+# END REUSE STGRN
 # ---------------------------------------------------------------------------------
 
 

--- a/docs/source/Tutorial/static/run_upar/run.py
+++ b/docs/source/Tutorial/static/run_upar/run.py
@@ -42,8 +42,7 @@ def plot6(data:dict, title:str, out:str|None=None):
         fig.savefig(out, bbox_inches='tight')
 
 
-pymod = pygrt.PyModel1D("milrow")
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath="milrow")
 
 # norths/easts 各为三个元素: start/stop/step (km)
 # 传入 calc_upar=True 可计算空间导数

--- a/docs/source/Tutorial/static/static_gfunc.rst
+++ b/docs/source/Tutorial/static/static_gfunc.rst
@@ -15,7 +15,7 @@ Python中计算静态格林函数的主函数为 :meth:`compute_static_grn() <py
 + 指定二维的 XY 网格。坐标 (0,0) 为源点的水平投影，每个节点的震中距为 :math:`r_{ij} = \sqrt{x_i^2 + y_j^2}` 。实际计算中会对震中距自动去重以减少计算量。
 + 指定一维的震中距序列。在计算和结果保存上等同于指定从原点 (X=0.0) 沿东向 (Y/km) 指定对应的采样点。
 
-结果会写入用户通过 :meth:`set_static_grn_path() <pygrt.pymod.PyModel1D.set_static_grn_path>` 指定的
+结果会写入用户在构造 :class:`~pygrt.pymod.PyModel1D` 时通过 ``stgrn=`` 指定的
 NetCDF 文件。在 :doc:`static_syn` 阶段，可以指定新的 XY 网格，此时每个节点的格林函数会近似为最近震中距的格林函数。
 
 示例程序
@@ -46,7 +46,6 @@ NetCDF 文件。在 :doc:`static_syn` 阶段，可以指定新的 XY 网格，�
             :start-after: BEGIN GRN
             :end-before: END GRN
 
-        结果写入 :meth:`set_static_grn_path() <pygrt.pymod.PyModel1D.set_static_grn_path>`
-        指定的 NetCDF 文件。需要读回时调用
+        结果写入构造 :class:`~pygrt.pymod.PyModel1D` 时 ``stgrn=`` 指定的 NetCDF 文件。需要读回时调用
         :func:`pygrt.utils.read_static_nc`，返回字典包含
         ``dimensions``、 ``variables`` 与 ``attributes``。

--- a/docs/source/Tutorial/static/static_syn.rst
+++ b/docs/source/Tutorial/static/static_syn.rst
@@ -8,6 +8,12 @@ Python中合成静态位移的主函数为 :meth:`compute_static_syn() <pygrt.py
 C模块为 :doc:`/Module/static_syn`。
 
 使用上节计算的格林函数，合成静态位移。为方便画图，以下结果都使用ZNE分量。
+若仅使用已算好的静态格林函数，构造 :class:`~pygrt.pymod.PyModel1D` 时只需指定 ``stgrn``，无需再传 ``modelpath``：
+
+.. literalinclude:: run/run.py
+    :language: python
+    :start-after: BEGIN REUSE STGRN
+    :end-before: END REUSE STGRN
 
 不同震源
 -------------

--- a/pygrt/C_extension/include/grt/common/util.h
+++ b/pygrt/C_extension/include/grt/common/util.h
@@ -85,6 +85,14 @@ bool grt_is_comment_or_empty(const char* line);
 
 
 /**
+ * 将源文件复制到目标路径（覆盖已存在文件）
+ *
+ * @param[in]    src     源文件路径
+ * @param[in]    dst     目标文件路径
+ */
+void grt_copy_file(const char *src, const char *dst);
+
+/**
  * 由于 Windows MSYS2 环境没有 getline 函数（即使定义了 _GNU_SOURCE）
  * 所以这里需要使用自定义的 getline 函数，参数与 POSIX 定义相同
  */

--- a/pygrt/C_extension/src/common/util.c
+++ b/pygrt/C_extension/src/common/util.c
@@ -141,12 +141,22 @@ void grt_copy_file(const char *src, const char *dst)
 {
     // 源与目标为同一路径时跳过，避免截断自身
     {
+#if _TEST_WHETHER_WIN32_
+        char src_full[_MAX_PATH];
+        char dst_full[_MAX_PATH];
+        if(_fullpath(src_full, src, _MAX_PATH) != NULL
+           && _fullpath(dst_full, dst, _MAX_PATH) != NULL
+           && strcmp(src_full, dst_full) == 0){
+            return;
+        }
+#else
         char src_real[PATH_MAX];
         char dst_real[PATH_MAX];
         if(realpath(src, src_real) != NULL && realpath(dst, dst_real) != NULL
            && strcmp(src_real, dst_real) == 0){
             return;
         }
+#endif
     }
 
     FILE *fin = GRTCheckOpenFile(src, "rb");

--- a/pygrt/C_extension/src/common/util.c
+++ b/pygrt/C_extension/src/common/util.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 
 #include "grt/common/util.h"
 #include "grt/common/model.h"
@@ -133,6 +134,41 @@ bool grt_is_comment_or_empty(const char* line) {
     
     // 检查是否为空行或注释行
     return (*line == '\0' || *line == GRT_COMMENT_HEAD);
+}
+
+
+void grt_copy_file(const char *src, const char *dst)
+{
+    // 源与目标为同一路径时跳过，避免截断自身
+    {
+        char src_real[PATH_MAX];
+        char dst_real[PATH_MAX];
+        if(realpath(src, src_real) != NULL && realpath(dst, dst_real) != NULL
+           && strcmp(src_real, dst_real) == 0){
+            return;
+        }
+    }
+
+    FILE *fin = GRTCheckOpenFile(src, "rb");
+    FILE *fout = GRTCheckOpenFile(dst, "wb");
+
+    char buf[8192];
+    size_t n;
+    while((n = fread(buf, 1, sizeof(buf), fin)) > 0){
+        if(fwrite(buf, 1, n, fout) != n){
+            fclose(fin);
+            fclose(fout);
+            GRTRaiseError("Failed to write copy of \"%s\" to \"%s\".\n", src, dst);
+        }
+    }
+    if(ferror(fin)){
+        fclose(fin);
+        fclose(fout);
+        GRTRaiseError("Failed to read \"%s\" while copying to \"%s\".\n", src, dst);
+    }
+
+    fclose(fin);
+    fclose(fout);
 }
 
 

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -270,6 +270,7 @@ printf("\n"
 "                 + <file>: each line contains a distance value.\n"
 "\n"
 "    -O<outdir>   Directorypath of output for saving.\n"
+"                 The model file is also copied into <outdir>.\n"
 "\n"
 "    -H<f1>/<f2>  Apply bandpass filer with rectangle window, \n"
 "                 default no filter.\n"
@@ -823,6 +824,14 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
     // 建立保存目录
     GRTCheckMakeDir(Ctrl->O.s_output_dir);
+
+    // 在目录中保留模型文件副本（basename），便于后续流程取用
+    {
+        char *model_copy = NULL;
+        GRT_SAFE_ASPRINTF(&model_copy, "%s/%s", Ctrl->O.s_output_dir, Ctrl->M.s_modelname);
+        grt_copy_file(Ctrl->M.s_modelpath, model_copy);
+        GRT_SAFE_FREE_PTR(model_copy);
+    }
 
     // 在目录中保留命令
     char *dummy = NULL;

--- a/pygrt/C_extension/src/modal/grt_modsum.c
+++ b/pygrt/C_extension/src/modal/grt_modsum.c
@@ -139,6 +139,7 @@ printf("\n"
 "                 <deprcv>: receiver depth (km).\n"
 "\n"
 "    -O<outdir>   Directorypath of output for saving.\n"
+"                 The model file is also copied into <outdir>.\n"
 "\n"
 "    -R<r1>,<r2>[,...]|<r1>/<r2>/<dr>|<file>\n"
 "                 Multiple epicentral distances (km), support three ways:\n"
@@ -505,6 +506,14 @@ int modsum_main(int argc, char **argv){
     MODEL1D *mod1d = NULL;
     if((mod1d = grt_read_mod1d_from_file(modelpath, -1.0, -1.0, true)) ==NULL){
         exit(EXIT_FAILURE);
+    }
+
+    // 在输出根目录保留模型文件副本（basename），便于后续流程取用
+    {
+        char *model_copy = NULL;
+        GRT_SAFE_ASPRINTF(&model_copy, "%s/%s", Ctrl->O.s_output_dir, grt_get_basename(modelpath));
+        grt_copy_file(modelpath, model_copy);
+        GRT_SAFE_FREE_PTR(model_copy);
     }
 
     // 当震源位于液体层中时，仅允许计算爆炸源对应的格林函数

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -79,41 +79,67 @@ class PyModel1D:
 
     Typical workflow:
 
-    1. Create the model from a layered-model file.
-    2. Call :meth:`set_dynamic_grn_path` or :meth:`set_static_grn_path`.
-    3. Compute Green's functions with :meth:`compute_grn` or :meth:`compute_static_grn`.
-    4. Synthesize waveforms or static fields with :meth:`compute_syn` or :meth:`compute_static_syn`.
+    1. Create :class:`PyModel1D` with the Green's function path(s) actually needed
+       (``grn`` and/or ``stgrn``) and optional ``modelpath``.
+    2. Compute Green's functions with :meth:`compute_grn` or :meth:`compute_static_grn`
+       (requires ``modelpath``).
+    3. Synthesize waveforms or static fields with :meth:`compute_syn` or
+       :meth:`compute_static_syn` (only the corresponding GF path is required).
     """
 
     def __init__(
         self,
-        modelpath: PathLike,
+        *,
+        grn: Optional[PathLike] = None,
+        stgrn: Optional[PathLike] = None,
+        modelpath: Optional[PathLike] = None,
         topbound: str = "free",
         botbound: str = "halfspace",
     ):
         """
-        Create a file-based 1D layered model.
+        Create a file-based 1D layered model handle.
 
         The model file is a plain text table. Each row is one layer in the form
         ``thickness(km)  Vp(km/s)  Vs(km/s)  Rho(g/cm^3)  [Qp  Qs]``.
         A zero thickness marks a half-space bottom layer.
 
-        :param    modelpath:          Path to the layered model file.
+        All arguments must be passed by keyword. ``grn`` / ``stgrn`` / ``modelpath``
+        are optional at construction; methods that need them raise if missing.
+
+        :param    grn:                Root directory for dynamic Green's functions.
+        :param    stgrn:              NetCDF file path for static Green's functions.
+        :param    modelpath:          Path to the layered model file. Required when
+                                      computing Green's functions or travel times
+                                      (unless ``modelpath`` is passed to
+                                      :meth:`compute_travt1d`).
         :param    topbound:           Top boundary condition. One of ``free``, ``rigid`` and ``halfspace``.
         :param    botbound:           Bottom boundary condition. One of ``free``, ``rigid`` and ``halfspace``.
         """
-        self.modelpath = str(Path(modelpath))
-        self.topbound = topbound
-        self.botbound = botbound
-        self.dynamic_grn_path: Optional[str] = None
-        self.static_grn_path: Optional[str] = None
-
-        if not Path(self.modelpath).is_file():
-            raise FileNotFoundError(f"Model file does not exist: {self.modelpath}")
         if topbound not in {"free", "rigid", "halfspace"}:
             raise ValueError(f"Unsupported topbound={topbound}.")
         if botbound not in {"free", "rigid", "halfspace"}:
             raise ValueError(f"Unsupported botbound={botbound}.")
+
+        self.topbound = topbound
+        self.botbound = botbound
+        self.modelpath: Optional[str] = None
+        self.grn: Optional[str] = None
+        self.stgrn: Optional[str] = None
+
+        if modelpath is not None:
+            self.modelpath = str(Path(modelpath))
+            if not Path(self.modelpath).is_file():
+                raise FileNotFoundError(f"Model file does not exist: {self.modelpath}")
+
+        if grn is not None:
+            target = Path(grn)
+            target.mkdir(parents=True, exist_ok=True)
+            self.grn = str(target)
+
+        if stgrn is not None:
+            target = Path(stgrn)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            self.stgrn = str(target)
 
     def compute_travt1d(
         self,
@@ -121,18 +147,22 @@ class PyModel1D:
         depsrc: float,
         deprcv: float,
         distarr: Union[float, Sequence[float]],
+        modelpath: Optional[PathLike] = None,
     ):
         r"""
         Compute first-arrival P- and S-wave travel times.
 
         Calls the C routine ``grt_compute_travt1d_from_file``, which reads the
-        layered model from ``modelpath`` and evaluates travel times at the given
-        source/receiver depths and epicentral distances. All arguments must be
-        passed by keyword.
+        layered model and evaluates travel times at the given source/receiver
+        depths and epicentral distances. All arguments must be passed by keyword.
 
         :param    depsrc:            Source depth in km.
         :param    deprcv:            Receiver depth in km.
         :param    distarr:           Epicentral distance(s) in km. A scalar or a sequence of distances.
+        :param    modelpath:         Model file for this call only. If omitted, uses
+                                     ``self.modelpath``. If both are set and differ,
+                                     a warning is issued and ``self.modelpath`` is not changed.
+                                     Required when ``self.modelpath`` is unset.
 
         :return: ``(travtP, travtS)`` in s. For a scalar distance both are floats;
                  for multiple distances both are NumPy arrays of shape ``(n,)``.
@@ -140,20 +170,36 @@ class PyModel1D:
         if depsrc < 0 or deprcv < 0:
             raise ValueError("Source and receiver depths must be nonnegative.")
 
+        if modelpath is not None:
+            use_model = str(Path(modelpath))
+            if not Path(use_model).is_file():
+                raise FileNotFoundError(f"Model file does not exist: {use_model}")
+            if self.modelpath is not None:
+                warnings.warn(
+                    f"compute_travt1d uses temporary modelpath={use_model!r}; "
+                    f"instance modelpath={self.modelpath!r} is unchanged.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        else:
+            if self.modelpath is None:
+                raise RuntimeError("Pass modelpath= to compute_travt1d() or set it in PyModel1D(...).")
+            use_model = self.modelpath
+
         # 标量震中距返回 float，序列返回长度为 n 的数组
         single, distances = _normalize_distarr(distarr)
         if distances.size == 0 or np.any(distances < 0):
             raise ValueError("distarr must contain nonnegative distances.")
 
         carr = C_grt_compute_travt1d_from_file(
-            self.modelpath.encode("utf-8"),
+            use_model.encode("utf-8"),
             float(depsrc),
             float(deprcv),
             distances.ctypes.data_as(PREAL),
             c_size_t(distances.size),
         )
         if cast(carr, c_void_p).value is None:
-            raise RuntimeError(f"Failed to compute travel times for model {self.modelpath}.")
+            raise RuntimeError(f"Failed to compute travel times for model {use_model}.")
 
         arr = npct.as_array(carr, shape=(distances.size, 2)).copy()
         C_grt_free(carr)
@@ -161,39 +207,6 @@ class PyModel1D:
         if single:
             return float(arr[0, 0]), float(arr[0, 1])
         return arr[:, 0].copy(), arr[:, 1].copy()
-
-    def set_dynamic_grn_path(self, path: PathLike) -> str:
-        """
-        Set and create the root directory for dynamic Green's functions.
-
-        Later calls to :meth:`compute_grn` write SAC files under this directory.
-        Subdirectories are named
-        ``{model}_{depsrc}_{deprcv}_{distance}``.
-
-        :param    path:               Root directory for dynamic Green's functions.
-
-        :return: The configured dynamic Green's function directory.
-        """
-        target = Path(path)
-        target.mkdir(parents=True, exist_ok=True)
-        self.dynamic_grn_path = str(target)
-        return self.dynamic_grn_path
-
-    def set_static_grn_path(self, path: PathLike) -> str:
-        """
-        Set the NetCDF file path for static Green's functions.
-
-        Later calls to :meth:`compute_static_grn` write (and currently overwrite)
-        this file. Parent directories are created if needed.
-
-        :param    path:               NetCDF file path for static Green's functions.
-
-        :return: The configured static Green's function file path.
-        """
-        target = Path(path)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        self.static_grn_path = str(target)
-        return self.static_grn_path
 
     def compute_grn(
         self,
@@ -229,8 +242,9 @@ class PyModel1D:
         r"""
         Compute dynamic Green's functions with the ``grt greenfn`` command.
 
-        Call :meth:`set_dynamic_grn_path` first. Results are written as SAC files
-        under ``{dynamic_grn_path}/{model}_{depsrc}_{deprcv}_{distance}``.
+        Requires ``grn`` and ``modelpath`` in the constructor. Results are written
+        as SAC files under ``{grn}/{model}_{depsrc}_{deprcv}_{distance}``. The
+        model file is also copied into the ``grn`` root directory by the C module.
         All arguments must be passed by keyword.
 
         :param    depsrc:            Source depth in km.
@@ -288,8 +302,10 @@ class PyModel1D:
 
         :return: ``None``. Results are written to disk.
         """
-        if self.dynamic_grn_path is None:
-            raise RuntimeError("Call set_dynamic_grn_path() before compute_grn().")
+        if self.grn is None:
+            raise RuntimeError("Pass grn= to PyModel1D(...) before compute_grn().")
+        if self.modelpath is None:
+            raise RuntimeError("Pass modelpath= to PyModel1D(...) before compute_grn().")
         if nt <= 0 or dt <= 0:
             raise ValueError("nt and dt must be positive.")
         if depsrc < 0 or deprcv < 0:
@@ -310,7 +326,7 @@ class PyModel1D:
             "D": f"-D{format_float(depsrc)}/{format_float(deprcv)}",
             "N": f"-N{nt}/{format_float(dt)}+w{format_float(zeta)}+n{upsampling_n}",
             "R": f"-R{','.join(format_float(distance) for distance in distances)}",
-            "O": f"-O{self.dynamic_grn_path}",
+            "O": f"-O{self.grn}",
             "B": f"-B{self._boundary_option()}",
         }
 
@@ -398,8 +414,8 @@ class PyModel1D:
         r"""
         Compute static Green's functions with the ``grt static greenfn`` command.
 
-        Call :meth:`set_static_grn_path` first. Results are written to the
-        configured NetCDF file (4D STGRNLIB layout
+        Requires ``stgrn`` and ``modelpath`` in the constructor. Results are written
+        to the configured NetCDF file (4D STGRNLIB layout
         ``[depsrc][deprcv][north][east]``) and currently overwrite any existing
         content. All arguments must be passed by keyword.
 
@@ -456,8 +472,10 @@ class PyModel1D:
 
         :return: ``None``. Results are written to the configured NetCDF file.
         """
-        if self.static_grn_path is None:
-            raise RuntimeError("Call set_static_grn_path() before compute_static_grn().")
+        if self.stgrn is None:
+            raise RuntimeError("Pass stgrn= to PyModel1D(...) before compute_static_grn().")
+        if self.modelpath is None:
+            raise RuntimeError("Pass modelpath= to PyModel1D(...) before compute_static_grn().")
 
         depsrcs = _normalize_depths(depsrc, "depsrc")
         deprcvs = _normalize_depths(deprcv, "deprcv")
@@ -496,7 +514,7 @@ class PyModel1D:
             command["Dr"] = f"-Dr{_format_depth_list(deprcvs)}"
         else:
             command["D"] = f"-D{format_float(float(depsrcs[0]))}/{format_float(float(deprcvs[0]))}"
-        command["O"] = f"-O{self.static_grn_path}"
+        command["O"] = f"-O{self.stgrn}"
         command["B"] = f"-B{self._boundary_option()}"
         command.update(command_grid)
 
@@ -567,8 +585,8 @@ class PyModel1D:
         * ``R`` - radial outward
         * ``T`` - clockwise 90° from ``R``
 
-        Call :meth:`set_dynamic_grn_path` and :meth:`compute_grn` first. The
-        Green's function directory is located under ``dynamic_grn_path`` by
+        Call :meth:`compute_grn` first (or point ``grn`` at an existing GF root).
+        The Green's function directory is located under ``grn`` by
         matching ``dist`` in the subdirectory name. All arguments must be
         passed by keyword.
 
@@ -582,8 +600,7 @@ class PyModel1D:
           ``moment_tensor=(Mxx, Mxy, Mxz, Myy, Myz, Mzz)``.
 
         :param    dist:                Epicentral distance in km. Used to locate the
-                                       Green's function directory under
-                                       ``dynamic_grn_path``.
+                                       Green's function directory under ``grn``.
         :param    azimuth:             Azimuth from source to receiver in deg.
                                        North is 0°, clockwise positive.
         :param    scale:               Source scaling factor. For ``EX``, ``DC``,
@@ -699,8 +716,8 @@ class PyModel1D:
         r"""
         Synthesize static three-component displacement with ``grt static syn``.
 
-        Results are written to the NetCDF file ``output_path``. Call
-        :meth:`set_static_grn_path` and :meth:`compute_static_grn` first.
+        Results are written to the NetCDF file ``output_path``. Requires
+        ``stgrn`` (and typically a prior :meth:`compute_static_grn`).
         All arguments must be passed by keyword.
 
         Receivers default to the library north/east grid. Optionally redefine
@@ -791,8 +808,8 @@ class PyModel1D:
         :return: The synthesized NetCDF data when ``return_result`` is true;
                  otherwise ``None``.
         """
-        if self.static_grn_path is None:
-            raise RuntimeError("Call set_static_grn_path() before compute_static_syn().")
+        if self.stgrn is None:
+            raise RuntimeError("Pass stgrn= to PyModel1D(...) before compute_static_syn().")
         output = Path(output_path)
         output.parent.mkdir(parents=True, exist_ok=True)
 
@@ -831,7 +848,7 @@ class PyModel1D:
         command = {
             "module": "static",
             "subcommand": "syn",
-            "G": f"-G{self.static_grn_path}",
+            "G": f"-G{self.stgrn}",
             "O": f"-O{output}",
         }
 
@@ -870,14 +887,14 @@ class PyModel1D:
 
     def _dynamic_grn_dir(self, dist: float) -> str:
         """
-        在 dynamic_grn_path 下按震中距匹配格林函数子目录
+        在 grn 根目录下按震中距匹配格林函数子目录
 
         子目录命名为 ``{model}_{depsrc}_{deprcv}_{dist}``
         当前假设仅有一套震源/台站深度，故只需匹配 dist
         """
-        if self.dynamic_grn_path is None:
-            raise RuntimeError("Call set_dynamic_grn_path() before compute_syn().")
-        root = Path(self.dynamic_grn_path)
+        if self.grn is None:
+            raise RuntimeError("Pass grn= to PyModel1D(...) before compute_syn().")
+        root = Path(self.grn)
         if not root.is_dir():
             raise FileNotFoundError(f"Dynamic Green's function root does not exist: {root}")
 

--- a/test/_compare_c_py/compare.py
+++ b/test/_compare_c_py/compare.py
@@ -111,8 +111,7 @@ def run_c_dynamic(c_root: Path) -> None:
 
 def run_py_dynamic(py_root: Path) -> None:
     """Python API 计算动态结果"""
-    model = pygrt.PyModel1D(MODEL, "free", "halfspace")
-    model.set_dynamic_grn_path(py_root / "GRN")
+    model = pygrt.PyModel1D(grn=py_root / "GRN", modelpath=MODEL, topbound="free", botbound="halfspace")
     model.compute_grn(
         depsrc=DEPSRC,
         deprcv=DEPRCV,
@@ -202,8 +201,7 @@ def run_py_static(py_root: Path) -> None:
     """Python API 计算静态结果"""
     static_dir = py_root / "static"
     static_dir.mkdir(parents=True)
-    model = pygrt.PyModel1D(MODEL)
-    model.set_static_grn_path(static_dir / "stgrn.nc")
+    model = pygrt.PyModel1D(stgrn=static_dir / "stgrn.nc", modelpath=MODEL)
     model.compute_static_grn(
         depsrc=DEPSRC,
         deprcv=DEPRCV,

--- a/test/_compare_c_py/compare_staticXY.py
+++ b/test/_compare_c_py/compare_staticXY.py
@@ -95,8 +95,7 @@ def run_c(c_root: Path) -> None:
 def run_py(py_root: Path) -> None:
     static_dir = py_root / "static"
     static_dir.mkdir(parents=True)
-    model = pygrt.PyModel1D(MODEL)
-    model.set_static_grn_path(static_dir / "stgrn.nc")
+    model = pygrt.PyModel1D(stgrn=static_dir / "stgrn.nc", modelpath=MODEL)
     model.compute_static_grn(
         depsrc=DEPSRC,
         deprcv=DEPRCV,

--- a/test/_compare_c_py/compare_stgrnlib.py
+++ b/test/_compare_c_py/compare_stgrnlib.py
@@ -120,8 +120,7 @@ def extract_slice(lib: dict, isrc: int, ircv: int) -> dict:
 
 
 def py_compute_to_nc(depsrcs, deprcvs, outpath: str):
-    pymod = pygrt.PyModel1D(MODNAME)
-    pymod.set_static_grn_path(outpath)
+    pymod = pygrt.PyModel1D(stgrn=outpath, modelpath=MODNAME)
     pymod.compute_static_grn(
         depsrc=depsrcs, deprcv=deprcvs, norths=NORTHS, easts=EASTS, calc_upar=True,
     )
@@ -169,8 +168,7 @@ def c_static_syn(grn: Path, out: Path, extra: list) -> None:
 
 
 def py_static_syn(grn: Path, out: Path, **kwargs) -> None:
-    model = pygrt.PyModel1D(MODNAME)
-    model.set_static_grn_path(grn)
+    model = pygrt.PyModel1D(stgrn=grn, modelpath=MODNAME)
     model.compute_static_syn(scale=SCALE, output_path=out, calc_upar=True, **kwargs)
 
 

--- a/test/_compare_c_py/test_cli_args.py
+++ b/test/_compare_c_py/test_cli_args.py
@@ -44,8 +44,7 @@ def test_invalid_gf_source_and_freqband_and_distarr():
     runner = CapturedRunner()
     original = _patch_run_grt(pygrt.pymod, runner)
     try:
-        model = pygrt.PyModel1D(MODEL)
-        model.set_dynamic_grn_path(HERE / "_tmp_args_grn")
+        model = pygrt.PyModel1D(grn=HERE / "_tmp_args_grn", modelpath=MODEL)
 
         try:
             model.compute_grn(depsrc=1.0, deprcv=0.0, distarr=1.0, nt=8, dt=0.1, gf_source=["XX"])
@@ -75,8 +74,7 @@ def test_print_log_forwarded_to_run_grt():
     runner = CapturedRunner()
     original = _patch_run_grt(pygrt.pymod, runner)
     try:
-        model = pygrt.PyModel1D(MODEL)
-        model.set_dynamic_grn_path(HERE / "_tmp_args_grn")
+        model = pygrt.PyModel1D(grn=HERE / "_tmp_args_grn", modelpath=MODEL)
 
         model.compute_grn(depsrc=1.0, deprcv=0.0, distarr=1.0, nt=8, dt=0.1, print_log=True)
         assert runner.kwargs[-1].get("print_log") is True
@@ -93,8 +91,7 @@ def test_compute_grn_default_and_optional_flags():
     runner = CapturedRunner()
     original = _patch_run_grt(pygrt.pymod, runner)
     try:
-        model = pygrt.PyModel1D(MODEL, "free", "halfspace")
-        model.set_dynamic_grn_path(HERE / "_tmp_args_grn")
+        model = pygrt.PyModel1D(grn=HERE / "_tmp_args_grn", modelpath=MODEL, topbound="free", botbound="halfspace")
 
         # 默认参数应显式带上 C 侧常用默认片段
         model.compute_grn(
@@ -113,7 +110,7 @@ def test_compute_grn_default_and_optional_flags():
                 "-D2/0",
                 "-N32/0.05+w0.8+n1",
                 "-R1,2.5",
-                f"-O{model.dynamic_grn_path}",
+                f"-O{model.grn}",
                 "-BfH",
                 "-H-1/-1",
                 "-L0",
@@ -158,7 +155,7 @@ def test_compute_grn_default_and_optional_flags():
             "-D3.5/1.25",
             "-N64/0.02+w0.6+n2+a+f",
             "-R10",
-            f"-O{model.dynamic_grn_path}",
+            f"-O{model.grn}",
             "-BfH",
             "-H0.1/5",
             "-L20+l5+o2",
@@ -199,8 +196,7 @@ def test_compute_grn_default_and_optional_flags():
             ("rigid", "free", "-BrF"),
             ("halfspace", "rigid", "-BhR"),
         ]:
-            model2 = pygrt.PyModel1D(MODEL, top, bot)
-            model2.set_dynamic_grn_path(HERE / "_tmp_args_grn2")
+            model2 = pygrt.PyModel1D(grn=HERE / "_tmp_args_grn2", modelpath=MODEL, topbound=top, botbound=bot)
             model2.compute_grn(
                 depsrc=1.0,
                 deprcv=0.0,
@@ -228,8 +224,7 @@ def test_compute_static_grn_xy_and_distarr():
     runner = CapturedRunner()
     original = _patch_run_grt(pygrt.pymod, runner)
     try:
-        model = pygrt.PyModel1D(MODEL)
-        model.set_static_grn_path(HERE / "_tmp_args_static.nc")
+        model = pygrt.PyModel1D(stgrn=HERE / "_tmp_args_static.nc", modelpath=MODEL)
 
         model.compute_static_grn(
             depsrc=2.0,
@@ -254,7 +249,7 @@ def test_compute_static_grn_xy_and_distarr():
                 "greenfn",
                 f"-M{MODEL}",
                 "-D2/3.3",
-                f"-O{model.static_grn_path}",
+                f"-O{model.stgrn}",
                 "-BfH",
                 "-X-3.1/3.1/0.6",
                 "-Y-4.1/4.1/0.8",
@@ -308,9 +303,8 @@ def test_compute_syn_source_and_time_function_options():
     runner = CapturedRunner()
     original = _patch_run_grt(pygrt.pymod, runner)
     try:
-        model = pygrt.PyModel1D(MODEL)
+        model = pygrt.PyModel1D(grn=HERE / "_tmp_args_grn", modelpath=MODEL)
         grn_root = HERE / "_tmp_args_grn"
-        model.set_dynamic_grn_path(grn_root)
         # 按 dist 匹配子目录，测试前需先准备假目录
         grn_dir = grn_root / f"{MODEL.name}_2_3.3_10"
         grn_dir.mkdir(parents=True, exist_ok=True)
@@ -414,8 +408,7 @@ def test_compute_static_syn_and_tensor_postprocess_args():
     original_pymod = _patch_run_grt(pygrt.pymod, runner)
     original_utils = _patch_run_grt(pygrt.utils, runner)
     try:
-        model = pygrt.PyModel1D(MODEL)
-        model.set_static_grn_path(HERE / "_tmp_args_static.nc")
+        model = pygrt.PyModel1D(stgrn=HERE / "_tmp_args_static.nc", modelpath=MODEL)
         out = HERE / "_tmp_args_static_syn.nc"
 
         model.compute_static_syn(
@@ -436,7 +429,7 @@ def test_compute_static_syn_and_tensor_postprocess_args():
             [
                 "static",
                 "syn",
-                f"-G{model.static_grn_path}",
+                f"-G{model.stgrn}",
                 f"-O{out}",
                 "-Su1e+24",
                 "-M33/50/120",
@@ -458,7 +451,7 @@ def test_compute_static_syn_and_tensor_postprocess_args():
         assert_command_has(
             runner.commands[-1],
             "static", "syn",
-            f"-G{model.static_grn_path}",
+            f"-G{model.stgrn}",
             f"-O{out}",
             "-S1e+20",
             "-Ds2",
@@ -494,7 +487,7 @@ def test_compute_static_syn_and_tensor_postprocess_args():
         assert_command_has(
             runner.commands[-1],
             "static", "syn",
-            f"-G{model.static_grn_path}",
+            f"-G{model.stgrn}",
             f"-O{out}",
             f"-C{HERE / 'cfaults.inp'}+i1/2",
             "-e",

--- a/test/greenfn/test_greenfn.py
+++ b/test/greenfn/test_greenfn.py
@@ -10,8 +10,7 @@ nt = 600
 dt = 0.02
 modname = "../milrow"
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modname)
 
 pymod.compute_grn(depsrc=depsrc, deprcv=deprcv, distarr=dist, nt=nt, dt=dt)
 pymod.compute_grn(
@@ -65,16 +64,13 @@ pymod.compute_grn(
 )
 
 # boundary condition
-pymod = pygrt.PyModel1D(modname, topbound="free", botbound="free")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modname, topbound="free", botbound="free")
 pymod.compute_grn(depsrc=depsrc, deprcv=deprcv, distarr=dist, nt=nt, dt=dt)
 
-pymod = pygrt.PyModel1D(modname, topbound="halfspace", botbound="free")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modname, topbound="halfspace", botbound="free")
 pymod.compute_grn(depsrc=depsrc, deprcv=deprcv, distarr=dist, nt=nt, dt=dt)
 
-pymod = pygrt.PyModel1D(modname, topbound="rigid", botbound="rigid")
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modname, topbound="rigid", botbound="rigid")
 pymod.compute_grn(depsrc=depsrc, deprcv=deprcv, distarr=dist, nt=nt, dt=dt)
 
 for name in ["GRN", "GRN_grtstats"]:

--- a/test/greenfn/test_greenfn.sh
+++ b/test/greenfn/test_greenfn.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 grt greenfn -h
 
 grt greenfn -M../milrow -D2/3 -N600/0.02 -R10 -OGRN
+# 输出根目录应保留模型文件副本
+test -f GRN/milrow
 grt greenfn -M../milrow -D2/3 -N600/0.02 -R10 -e -OGRN
 grt greenfn -M../milrow -D2/3 -N600/0.02+w0.6+n10 -R10 -OGRN
 grt greenfn -M../milrow -D2/3 -N600/0.02 -H1/10 -R10 -OGRN

--- a/test/modsum/test_modsum.sh
+++ b/test/modsum/test_modsum.sh
@@ -9,6 +9,8 @@ grt eigenv -M../milrow -F0/1/0.01 -SL -N -Cphase_L.nc
 # 模态叠加得到格林函数
 # 仅 0 阶
 grt modsum -Cphase_R.nc -D2/1 -R100 -N0 -OGRN_NM_0 -W5 -e
+# 输出根目录应保留模型文件副本（路径来自频散文件中记录的模型）
+test -f GRN_NM_0/milrow
 grt modsum -Cphase_L.nc -D2/1 -R100 -N0 -OGRN_NM_0 -W5 -e
 # 仅 1 阶
 grt modsum -Cphase_R.nc -D2/1 -R100 -N1 -OGRN_NM_1 -W5 -e

--- a/test/static_greenfn/test_static_greenfn.py
+++ b/test/static_greenfn/test_static_greenfn.py
@@ -12,8 +12,7 @@ norths = [-3.0, 3.0, 0.2]
 easts = [-2.0, 2.0, 0.2]
 modname = "../milrow"
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath=modname)
 
 pymod.compute_static_grn(depsrc=depsrc, deprcv=deprcv, norths=norths, easts=easts)
 pymod.compute_static_grn(
@@ -50,16 +49,13 @@ with netcdf_file("stgrn.nc", mmap=False) as f:
     assert f.dimensions["deprcv"] == 1
 
 # boundary condition
-pymod = pygrt.PyModel1D(modname, topbound="free", botbound="free")
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath=modname, topbound="free", botbound="free")
 pymod.compute_static_grn(depsrc=depsrc, deprcv=deprcv, norths=norths, easts=easts)
 
-pymod = pygrt.PyModel1D(modname, topbound="halfspace", botbound="free")
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath=modname, topbound="halfspace", botbound="free")
 pymod.compute_static_grn(depsrc=depsrc, deprcv=deprcv, norths=norths, easts=easts)
 
-pymod = pygrt.PyModel1D(modname, topbound="rigid", botbound="rigid")
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath=modname, topbound="rigid", botbound="rigid")
 pymod.compute_static_grn(depsrc=depsrc, deprcv=deprcv, norths=norths, easts=easts)
 
 # -------------------- 多深度功能 --------------------
@@ -68,8 +64,7 @@ easts_c = [-2.0, 2.0, 1.0]
 depsrcs = [1.0, 2.0, 3.0]
 deprcvs = [0.0, 0.5]
 
-pymod_m = pygrt.PyModel1D(modname)
-pymod_m.set_static_grn_path("stgrn_py_multi.nc")
+pymod_m = pygrt.PyModel1D(stgrn="stgrn_py_multi.nc", modelpath=modname)
 pymod_m.compute_static_grn(depsrc=depsrcs, deprcv=deprcvs, norths=norths_c, easts=easts_c)
 assert Path("stgrn_py_multi.nc").is_file()
 with netcdf_file("stgrn_py_multi.nc", mmap=False) as f:
@@ -77,20 +72,17 @@ with netcdf_file("stgrn_py_multi.nc", mmap=False) as f:
     assert f.dimensions["deprcv"] == 2
 
 # 仅多震源深度
-pymod_ms = pygrt.PyModel1D(modname)
-pymod_ms.set_static_grn_path("stgrn_py_ms.nc")
+pymod_ms = pygrt.PyModel1D(stgrn="stgrn_py_ms.nc", modelpath=modname)
 pymod_ms.compute_static_grn(
     depsrc=[1.0, 2.0], deprcv=0.0, norths=norths_c, easts=easts_c, calc_upar=True,
 )
 
 # 仅多台站深度
-pymod_mr = pygrt.PyModel1D(modname)
-pymod_mr.set_static_grn_path("stgrn_py_mr.nc")
+pymod_mr = pygrt.PyModel1D(stgrn="stgrn_py_mr.nc", modelpath=modname)
 pymod_mr.compute_static_grn(depsrc=2.0, deprcv=[0.0, 0.5], norths=norths_c, easts=easts_c)
 
 # -R / distarr 建库
-pymod_r = pygrt.PyModel1D(modname)
-pymod_r.set_static_grn_path("stgrn_py_r.nc")
+pymod_r = pygrt.PyModel1D(stgrn="stgrn_py_r.nc", modelpath=modname)
 pymod_r.compute_static_grn(
     depsrc=2.0, deprcv=0.0, distarr=[0.0, 1.0, 2.0, 4.0],
 )
@@ -126,7 +118,7 @@ except ValueError:
 # 多深度 stats 应警告并忽略
 with warnings.catch_warnings(record=True) as w:
     warnings.simplefilter("always")
-    pymod_m.set_static_grn_path("stgrn_py_multi2.nc")
+    pymod_m = pygrt.PyModel1D(stgrn="stgrn_py_multi2.nc", modelpath=modname)
     pymod_m.compute_static_grn(
         depsrc=depsrcs, deprcv=deprcvs, norths=norths_c, easts=easts_c, stats=True,
     )

--- a/test/static_syn/test_static_syn.py
+++ b/test/static_syn/test_static_syn.py
@@ -10,8 +10,7 @@ norths = [-3.0, 3.0, 0.2]
 easts = [-2.0, 2.0, 0.2]
 modname = "../milrow"
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath=modname)
 pymod.compute_static_grn(
     depsrc=depsrc, deprcv=deprcv, norths=norths, easts=easts, calc_upar=True,
 )
@@ -44,8 +43,7 @@ pymod.compute_static_syn(
 )
 
 # -------------------- -R 建库后合成 --------------------
-pymod_r = pygrt.PyModel1D(modname)
-pymod_r.set_static_grn_path("stgrn_r.nc")
+pymod_r = pygrt.PyModel1D(stgrn="stgrn_r.nc", modelpath=modname)
 pymod_r.compute_static_grn(
     depsrc=depsrc, deprcv=deprcv, distarr=[0.0, 1.0, 2.0, 4.0, 8.0], calc_upar=True,
 )
@@ -56,8 +54,7 @@ pymod_r.compute_static_syn(
 )
 
 # -------------------- 多深度：点源 -Ds、深度插值、-Q、有限断层 --------------------
-pymod_m = pygrt.PyModel1D(modname)
-pymod_m.set_static_grn_path("stgrn_md.nc")
+pymod_m = pygrt.PyModel1D(stgrn="stgrn_md.nc", modelpath=modname)
 pymod_m.compute_static_grn(
     depsrc=[1.0, 2.0, 3.0], deprcv=0.0,
     distarr=[0.0, 1.0, 2.0, 4.0, 8.0], calc_upar=True,
@@ -92,8 +89,7 @@ pymod_m.compute_static_syn(
 )
 
 # 多台站深度必须给 deprcv
-pymod_mr = pygrt.PyModel1D(modname)
-pymod_mr.set_static_grn_path("stgrn_mr.nc")
+pymod_mr = pygrt.PyModel1D(stgrn="stgrn_mr.nc", modelpath=modname)
 pymod_mr.compute_static_grn(
     depsrc=2.0, deprcv=[0.0, 0.5], distarr=[0.0, 5.0], calc_upar=True,
 )

--- a/test/static_tensors/test_static_tensors.py
+++ b/test/static_tensors/test_static_tensors.py
@@ -8,8 +8,7 @@ norths = [-3.0, 3.0, 0.2]
 easts = [-2.0, 2.0, 0.2]
 modname = "../milrow"
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_static_grn_path("stgrn.nc")
+pymod = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath=modname)
 pymod.compute_static_grn(
     depsrc=depsrc, deprcv=deprcv, norths=norths, easts=easts, calc_upar=True,
 )

--- a/test/syn/test_syn.py
+++ b/test/syn/test_syn.py
@@ -11,8 +11,7 @@ dt = 0.02
 modname = "../milrow"
 az = 22.0
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modname)
 pymod.compute_grn(
     depsrc=depsrc, deprcv=deprcv, distarr=dist, nt=nt, dt=dt, calc_upar=True,
 )

--- a/test/tensors/test_tensors.py
+++ b/test/tensors/test_tensors.py
@@ -11,8 +11,7 @@ dt = 0.02
 modname = "../milrow"
 az = 22.0
 
-pymod = pygrt.PyModel1D(modname)
-pymod.set_dynamic_grn_path("GRN")
+pymod = pygrt.PyModel1D(grn="GRN", modelpath=modname)
 pymod.compute_grn(
     depsrc=depsrc, deprcv=deprcv, distarr=dist, nt=nt, dt=dt, calc_upar=True,
 )
@@ -34,8 +33,7 @@ pygrt.utils.compute_stress("syn_zne")
 pygrt.utils.compute_rotation("syn_zne")
 
 # -------------------- 静态应变 / 应力 / 旋转 --------------------
-pymod_s = pygrt.PyModel1D(modname)
-pymod_s.set_static_grn_path("stgrn.nc")
+pymod_s = pygrt.PyModel1D(stgrn="stgrn.nc", modelpath=modname)
 pymod_s.compute_static_grn(
     depsrc=2.0, deprcv=0.0, norths=[-3.0, 3.0, 1.0], easts=[-2.0, 2.0, 1.0],
     calc_upar=True,

--- a/test/travt/test_travt.py
+++ b/test/travt/test_travt.py
@@ -4,7 +4,7 @@ depsrc = 2.0
 deprcv = 0.0
 modname = "../milrow"
 
-pymod = pygrt.PyModel1D(modname)
+pymod = pygrt.PyModel1D(modelpath=modname)
 
 for dist in [2, 3, 4, 5]:
     tp, ts = pymod.compute_travt1d(depsrc=depsrc, deprcv=deprcv, distarr=dist)


### PR DESCRIPTION
- Make `PyModel1D` keyword-only: pass `grn=` / `stgrn=` / `modelpath=` / boundary options as needed; remove `set_dynamic_grn_path` and `set_static_grn_path`. Synthesis can use only the GF path without a model file.
- Copy the model file into the `-O` output root in `grt greenfn` and `grt modsum` for later reuse.
- Update tests, tutorials, and gallery examples; document synthesis-only construction and the model-copy behavior.
