### PR TITLE
FEAT: validate Green's function output directories

### DIFF
--- a/pygrt/C_extension/include/grt/common/util.h
+++ b/pygrt/C_extension/include/grt/common/util.h
@@ -79,6 +79,14 @@ int grt_string_ncols(const char *string, const char* delim);
  */
 const char* grt_get_basename(const char* path);
 
+/**
+ * 检查动态格林函数输出根目录中的文件和目录
+ *
+ * @param[in]    output_dir    输出根目录
+ * @param[in]    modelname     当前模型文件名
+ */
+void grt_check_greenfn_output_dir(const char *output_dir, const char *modelname);
+
 
 /**
  * 去除字符串首尾空白

--- a/pygrt/C_extension/src/common/util.c
+++ b/pygrt/C_extension/src/common/util.c
@@ -297,7 +297,7 @@ void grt_check_greenfn_output_dir(const char *output_dir, const char *modelname)
 
         if(!allowed){
             closedir(dir);
-            GRTRaiseError("Entry \"%s\" should not be in Green's function output directory \"%s\".\n", entry_path, output_dir);
+            GRTRaiseError("The current model is \"%s\", but the output directory contains \"%s\". This is not allowed.\n", modelname, entry_path);
         }
 
         GRT_SAFE_FREE_PTR(entry_path);

--- a/pygrt/C_extension/src/common/util.c
+++ b/pygrt/C_extension/src/common/util.c
@@ -174,6 +174,101 @@ const char* grt_get_basename(const char* path) {
 }
 
 
+static bool grt_is_numeric_field(const char *begin, const char *end)
+{
+    while(begin < end && isspace((unsigned char)*begin)) ++begin;
+    while(end > begin && isspace((unsigned char)end[-1])) --end;
+    if(begin == end) return false;
+
+    size_t length = (size_t)(end - begin);
+    char *value = (char *)calloc(length + 1, sizeof(char));
+    memcpy(value, begin, length);
+
+    errno = 0;
+    char *value_end = NULL;
+    real_t number = strtod(value, &value_end);
+    bool valid = (value_end != value) && (*value_end == '\0')
+        && (errno != ERANGE) && isfinite(number);
+
+    GRT_SAFE_FREE_PTR(value);
+    return valid;
+}
+
+
+static bool grt_is_greenfn_subdir_name(const char *name, const char *modelname)
+{
+    size_t model_length = strlen(modelname);
+    size_t name_length = strlen(name);
+    if(name_length <= model_length || strncmp(name, modelname, model_length) != 0 || name[model_length] != '_'){
+        return false;
+    }
+
+    const char *suffix = name + model_length + 1;
+    size_t suffix_length = name_length - model_length - 1;
+    const char *separator2_ptr = strrchr(suffix, '_');
+    if(separator2_ptr == NULL) return false;
+
+    size_t separator2 = (size_t)(separator2_ptr - suffix);
+    size_t separator1 = separator2;
+    while(separator1 > 0 && suffix[separator1 - 1] != '_') --separator1;
+    if(separator1 == 0) return false;
+    --separator1;
+
+    return grt_is_numeric_field(suffix, suffix + separator1)
+        && grt_is_numeric_field(suffix + separator1 + 1, suffix + separator2)
+        && grt_is_numeric_field(suffix + separator2 + 1, suffix + suffix_length);
+}
+
+
+void grt_check_greenfn_output_dir(const char *output_dir, const char *modelname)
+{
+    DIR *dir = opendir(output_dir);
+    if(dir == NULL){
+        GRTRaiseError("Cannot open Green's function output directory \"%s\". Error code: %d\n", output_dir, errno);
+    }
+
+    errno = 0;
+    struct dirent *entry;
+    while((entry = readdir(dir)) != NULL){
+        if(strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0){
+            continue;
+        }
+
+        char *entry_path = NULL;
+        GRT_SAFE_ASPRINTF(&entry_path, "%s/%s", output_dir, entry->d_name);
+
+        struct stat entry_stat;
+        if(stat(entry_path, &entry_stat) != 0){
+            int error_code = errno;
+            closedir(dir);
+            GRTRaiseError("Cannot inspect Green's function output entry \"%s\". Error code: %d\n", entry_path, error_code);
+        }
+
+        bool allowed = false;
+        if(strcmp(entry->d_name, "command") == 0 || strcmp(entry->d_name, modelname) == 0){
+            allowed = S_ISREG(entry_stat.st_mode);
+        } else if(S_ISDIR(entry_stat.st_mode)){
+            allowed = grt_is_greenfn_subdir_name(entry->d_name, modelname);
+        }
+
+        if(!allowed){
+            closedir(dir);
+            GRTRaiseError("Entry \"%s\" should not be in Green's function output directory \"%s\".\n", entry_path, output_dir);
+        }
+
+        GRT_SAFE_FREE_PTR(entry_path);
+    }
+
+    if(errno != 0){
+        int error_code = errno;
+        closedir(dir);
+        GRTRaiseError("Cannot read Green's function output directory \"%s\". Error code: %d\n", output_dir, error_code);
+    }
+
+    closedir(dir);
+}
+
+
 void grt_trim_whitespace(char* str) {
     char* end;
     

--- a/pygrt/C_extension/src/common/util.c
+++ b/pygrt/C_extension/src/common/util.c
@@ -174,19 +174,34 @@ const char* grt_get_basename(const char* path) {
 }
 
 
+/**
+ * 判断指定字符串区间是否表示一个有限实数
+ *
+ * 字符串区间左闭右开，调用方无需为区间补充字符串结束符
+ *
+ * @param[in]    begin    字符串区间的起始位置，包含该位置
+ * @param[in]    end      字符串区间的结束位置，不包含该位置
+ *
+ * @return   如果区间是一个有限实数则返回 true，否则返回 false
+ */
 static bool grt_is_numeric_field(const char *begin, const char *end)
 {
+    // 忽略数值字段两端的空白字符
     while(begin < end && isspace((unsigned char)*begin)) ++begin;
     while(end > begin && isspace((unsigned char)end[-1])) --end;
     if(begin == end) return false;
 
+    // strtod 需要以字符串结束符结尾，因此复制指定的字符串区间
     size_t length = (size_t)(end - begin);
     char *value = (char *)calloc(length + 1, sizeof(char));
     memcpy(value, begin, length);
 
+    // strtod 支持小数、科学计数法以及正负号
     errno = 0;
     char *value_end = NULL;
     real_t number = strtod(value, &value_end);
+
+    // 要求完整解析字段，并排除溢出、下溢、无穷大和非数值
     bool valid = (value_end != value) && (*value_end == '\0')
         && (errno != ERANGE) && isfinite(number);
 
@@ -195,21 +210,37 @@ static bool grt_is_numeric_field(const char *begin, const char *end)
 }
 
 
+/**
+ * 判断格林函数子目录名是否符合当前模型的命名格式
+ *
+ * 子目录名格式为 modelname_depsrc_deprcv_dist
+ * 数值字段从右侧分隔，避免模型名中的下划线参与解析
+ *
+ * @param[in]    name       待检查的子目录名
+ * @param[in]    modelname  当前模型文件名
+ *
+ * @return   如果名称符合当前模型的格林函数目录格式则返回 true，否则返回 false
+ */
 static bool grt_is_greenfn_subdir_name(const char *name, const char *modelname)
 {
     size_t model_length = strlen(modelname);
     size_t name_length = strlen(name);
+
+    // 先精确匹配模型名，并要求模型名后紧跟一个下划线
     if(name_length <= model_length || strncmp(name, modelname, model_length) != 0 || name[model_length] != '_'){
         return false;
     }
 
     const char *suffix = name + model_length + 1;
     size_t suffix_length = name_length - model_length - 1;
+
+    // 从右侧寻找震中距和接收器深度之间的分隔符
     const char *separator2_ptr = strrchr(suffix, '_');
     if(separator2_ptr == NULL) return false;
 
     size_t separator2 = (size_t)(separator2_ptr - suffix);
     size_t separator1 = separator2;
+    // 继续向左寻找震源深度和接收器深度之间的分隔符
     while(separator1 > 0 && suffix[separator1 - 1] != '_') --separator1;
     if(separator1 == 0) return false;
     --separator1;
@@ -220,8 +251,18 @@ static bool grt_is_greenfn_subdir_name(const char *name, const char *modelname)
 }
 
 
+/**
+ * 检查动态和模态格林函数输出根目录中的文件和目录
+ *
+ * 根目录允许包含 command、当前模型副本，以及当前模型对应的格林函数子目录
+ * 调用方应在执行本函数前创建 output_dir
+ *
+ * @param[in]    output_dir  格林函数输出根目录
+ * @param[in]    modelname   当前模型文件名
+ */
 void grt_check_greenfn_output_dir(const char *output_dir, const char *modelname)
 {
+    // 目录应已由调用方创建，这里打开目录并检查其中的已有条目
     DIR *dir = opendir(output_dir);
     if(dir == NULL){
         GRTRaiseError("Cannot open Green's function output directory \"%s\". Error code: %d\n", output_dir, errno);
@@ -230,10 +271,12 @@ void grt_check_greenfn_output_dir(const char *output_dir, const char *modelname)
     errno = 0;
     struct dirent *entry;
     while((entry = readdir(dir)) != NULL){
+        // 跳过目录自身和父目录项
         if(strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0){
             continue;
         }
 
+        // 使用完整路径检查条目类型
         char *entry_path = NULL;
         GRT_SAFE_ASPRINTF(&entry_path, "%s/%s", output_dir, entry->d_name);
 
@@ -244,6 +287,7 @@ void grt_check_greenfn_output_dir(const char *output_dir, const char *modelname)
             GRTRaiseError("Cannot inspect Green's function output entry \"%s\". Error code: %d\n", entry_path, error_code);
         }
 
+        // 根目录只允许 command、模型副本和当前模型的格林函数子目录
         bool allowed = false;
         if(strcmp(entry->d_name, "command") == 0 || strcmp(entry->d_name, modelname) == 0){
             allowed = S_ISREG(entry_stat.st_mode);
@@ -259,6 +303,7 @@ void grt_check_greenfn_output_dir(const char *output_dir, const char *modelname)
         GRT_SAFE_FREE_PTR(entry_path);
     }
 
+    // readdir 返回 NULL 时，通过 errno 区分正常结束和读取失败
     if(errno != 0){
         int error_code = errno;
         closedir(dir);

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -804,6 +804,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
     // 建立保存目录
     GRTCheckMakeDir(Ctrl->O.s_output_dir);
+    grt_check_greenfn_output_dir(Ctrl->O.s_output_dir, Ctrl->M.s_modelname);
 
     // 在目录中保留模型文件副本（basename），便于后续流程取用
     {

--- a/pygrt/C_extension/src/modal/grt_modsum.c
+++ b/pygrt/C_extension/src/modal/grt_modsum.c
@@ -449,21 +449,6 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
         Ctrl->N.modes[0] = 0;
     }
     
-    // 建立保存目录
-    GRTCheckMakeDir(Ctrl->O.s_output_dir);
-
-    // 在目录中保留命令
-    char *dummy = NULL;
-    GRT_SAFE_ASPRINTF(&dummy, "%s/command", Ctrl->O.s_output_dir);
-    FILE *fp = GRTCheckOpenFile(dummy, "a");
-    fprintf(fp, GRT_MAIN_COMMAND " ");  // 主程序名
-    for(int i=0; i<argc; ++i){
-        fprintf(fp, "%s ", argv[i]);
-    }
-    fprintf(fp, "\n");
-    fclose(fp);
-    GRT_SAFE_FREE_PTR(dummy);
-
 }
 
 
@@ -642,6 +627,10 @@ int modsum_main(int argc, char **argv){
         exit(EXIT_FAILURE);
     }
 
+    // 建立保存目录并检查已有内容
+    GRTCheckMakeDir(Ctrl->O.s_output_dir);
+    grt_check_greenfn_output_dir(Ctrl->O.s_output_dir, grt_get_basename(modelpath));
+
     // 在输出根目录保留模型文件副本（basename），便于后续流程取用
     {
         char *model_copy = NULL;
@@ -649,6 +638,18 @@ int modsum_main(int argc, char **argv){
         grt_copy_file(modelpath, model_copy);
         GRT_SAFE_FREE_PTR(model_copy);
     }
+
+    // 在目录中保留命令
+    char *dummy = NULL;
+    GRT_SAFE_ASPRINTF(&dummy, "%s/command", Ctrl->O.s_output_dir);
+    FILE *fp = GRTCheckOpenFile(dummy, "a");
+    fprintf(fp, GRT_MAIN_COMMAND " ");  // 主程序名
+    for(int i=0; i<argc; ++i){
+        fprintf(fp, "%s ", argv[i]);
+    }
+    fprintf(fp, "\n");
+    fclose(fp);
+    GRT_SAFE_FREE_PTR(dummy);
 
     bool doEX = Ctrl->G.doEX;
     bool doVF = Ctrl->G.doVF;

--- a/test/greenfn/test_greenfn.sh
+++ b/test/greenfn/test_greenfn.sh
@@ -63,6 +63,22 @@ printf '6\n8\n10' > dists_no_newline
 grt greenfn -M../milrow -D2/0 -N600/0.02 -Rdists_no_newline -OGRN
 rm -f dists_no_newline
 
+# output directory validation
+mkdir -p GRN_BAD/other_model_2_0_5
+expect_fail "output directory contains another model" \
+    grt greenfn -M../milrow -D2/0 -N8/0.02 -R5 -OGRN_BAD
+test ! -e GRN_BAD/command
+mkdir -p GRN_BAD_FILE
+touch GRN_BAD_FILE/README
+expect_fail "output directory contains an unexpected file" \
+    grt greenfn -M../milrow -D2/0 -N8/0.02 -R5 -OGRN_BAD_FILE
+test ! -e GRN_BAD_FILE/command
+
+cp ../milrow ../mil_row
+grt greenfn -M../mil_row -D2/0 -N8/0.02 -R5 -OGRN_UNDERSCORE
+test -f GRN_UNDERSCORE/mil_row_2_0_5/EXZ.sac
+rm -f ../mil_row
+
 # multi source/receiver depths
 grt greenfn -M../milrow -Ds1,2 -Dr0,1 -N80/0.02 -R5 -OGRN_MULTI -s
 test -f GRN_MULTI/milrow_1_0_5/EXZ.sac
@@ -83,3 +99,4 @@ python -u test_greenfn.py
 rm -rf GRN
 rm -rf GRN_MULTI
 rm -rf GRN_grtstats
+rm -rf GRN_BAD GRN_BAD_FILE GRN_UNDERSCORE

--- a/test/modsum/test_modsum.sh
+++ b/test/modsum/test_modsum.sh
@@ -41,6 +41,17 @@ grt modsum -Cphase_R.nc -Ds1,2 -Dr0,1 -R100 -N0 -OGRN_NM_MULTI -W2 -e
 test -f GRN_NM_MULTI/milrow_1_0_100/EXZ.sac
 test -f GRN_NM_MULTI/milrow_2_1_100/EXZ.sac
 
+# output directory validation
+mkdir -p GRN_NM_BAD/other_model_2_0_100
+expect_fail "output directory contains another model" \
+    grt modsum -Cphase_R.nc -D2/1 -R100 -N0 -OGRN_NM_BAD
+test ! -e GRN_NM_BAD/command
+mkdir -p GRN_NM_BAD_FILE
+touch GRN_NM_BAD_FILE/README
+expect_fail "output directory contains an unexpected file" \
+    grt modsum -Cphase_R.nc -D2/1 -R100 -N0 -OGRN_NM_BAD_FILE
+test ! -e GRN_NM_BAD_FILE/command
+
 expect_fail "-Ds without -Dr" \
     grt modsum -Cphase_R.nc -Ds1,2 -R100 -N0 -OGRN_bad
 


### PR DESCRIPTION
The output directory of dynamic GFs can only exist:
+ `command` (*file*)
+ `{model}` (*file*)
+ `{model}_{depsrc}_{deprcv}_{dist}/` (*directory*)