### PR TITLE
FIX: forward grt diagnostics in Python wrappers

### DIFF
--- a/pygrt/cli.py
+++ b/pygrt/cli.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 from typing import Iterable, Optional, Sequence, Union
 
 
@@ -43,8 +44,9 @@ def run_grt(
     :param    args:      Arguments passed to the ``grt`` command.
     :param    cwd:       Working directory used to run the command.
     :param    print_log: If true, stream ``grt`` stdout/stderr to the terminal.
-                         If false, capture them and attach any output to the
-                         raised error on failure.
+                         If false, suppress regular stdout logs but still print
+                         warnings and diagnostics. On failure, both output
+                         streams are printed and included in the raised error.
     """
     command = [find_grt(), *(str(arg) for arg in args)]
     if print_log:
@@ -54,12 +56,43 @@ def run_grt(
         return
 
     completed = subprocess.run(command, cwd=cwd, check=False, text=True, capture_output=True)
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
     if completed.returncode != 0:
-        detail = completed.stderr.strip() or completed.stdout.strip()
+        _write_output(stdout, sys.stdout)
+        _write_output(stderr, sys.stderr)
         message = f"grt command failed with exit code {completed.returncode}: {' '.join(command)}"
+        detail = _format_output(stdout, stderr)
         if detail:
             message += f"\n{detail}"
         raise RuntimeError(message)
+
+    _write_warnings(stdout)
+    _write_output(stderr, sys.stderr)
+
+
+def _write_output(output: str, stream) -> None:
+    """Write captured process output without changing its formatting."""
+    if output:
+        stream.write(output)
+        stream.flush()
+
+
+def _write_warnings(stdout: str) -> None:
+    """Forward warning lines from captured ``grt`` stdout."""
+    for line in stdout.splitlines(keepends=True):
+        if "[WARNING]" in line:
+            _write_output(line, sys.stdout)
+
+
+def _format_output(stdout: str, stderr: str) -> str:
+    """Format captured process output for a Python exception."""
+    details = []
+    if stdout.strip():
+        details.append(f"stdout:\n{stdout.rstrip()}")
+    if stderr.strip():
+        details.append(f"stderr:\n{stderr.rstrip()}")
+    return "\n".join(details)
 
 
 def format_float(value: float) -> str:

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -296,7 +296,8 @@ class PyModel1D:
         :param    statsidxs:         Frequency indexes for optional statistics output.
                                      ``None`` means no statistics files. An empty list means
                                      all frequency indexes (CLI bare ``-S``).
-        :param    print_log:         Whether to print calculation logs.
+        :param    print_log:         Whether to print calculation logs. Warnings
+                                     and diagnostics from ``grt`` are always printed.
 
         :return: ``None``. Results are written to disk.
         """
@@ -389,8 +390,6 @@ class PyModel1D:
         # Build the derivative and logging options.
         if calc_upar:
             command["e"] = "-e"
-        if not print_log:
-            command["s"] = "-s"
 
         run_grt(list(command.values()), print_log=print_log)
 

--- a/test/_compare_c_py/test_cli_args.py
+++ b/test/_compare_c_py/test_cli_args.py
@@ -6,8 +6,11 @@
 
 from __future__ import annotations
 
+import io
+import subprocess
 import sys
 import warnings
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 import pygrt
@@ -89,9 +92,56 @@ def test_print_log_forwarded_to_run_grt():
 
         model.greenfn(depsrc=1.0, deprcv=0.0, dists=1.0, nt=8, dt=0.1, print_log=False)
         assert runner.kwargs[-1].get("print_log") is False
-        assert "-s" in runner.commands[-1]
+        assert "-s" not in runner.commands[-1]
     finally:
         _restore_run_grt(pygrt.pymod, original)
+
+
+def test_run_grt_forwards_warnings_and_errors():
+    import pygrt.cli as cli
+
+    original_find_grt = cli.find_grt
+    original_run = cli.subprocess.run
+    responses = [
+        (0, "[INFO] regular log\n[WARNING] warning from grt\n", "stderr diagnostic\n"),
+        (1, "[INFO] partial output\n", "[ERROR] error from grt\n"),
+    ]
+
+    def fake_find_grt():
+        return "grt"
+
+    def fake_run(command, **kwargs):
+        returncode, stdout, stderr = responses.pop(0)
+        return subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr=stderr)
+
+    cli.find_grt = fake_find_grt
+    cli.subprocess.run = fake_run
+    try:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            cli.run_grt(["warning"], print_log=False)
+        assert "[WARNING] warning from grt" in stdout.getvalue()
+        assert "[INFO] regular log" not in stdout.getvalue()
+        assert "stderr diagnostic" in stderr.getvalue()
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        try:
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                cli.run_grt(["failure"], print_log=False)
+        except RuntimeError as exc:
+            message = str(exc)
+            assert "exit code 1" in message
+            assert "[INFO] partial output" in message
+            assert "[ERROR] error from grt" in message
+        else:
+            raise AssertionError("failed grt command should raise RuntimeError")
+        assert "[INFO] partial output" in stdout.getvalue()
+        assert "[ERROR] error from grt" in stderr.getvalue()
+    finally:
+        cli.find_grt = original_find_grt
+        cli.subprocess.run = original_run
 
 
 def test_greenfn_default_and_optional_flags():
@@ -166,7 +216,6 @@ def test_greenfn_default_and_optional_flags():
             "-Gesh",
             "-S0,3,7",
             "-e",
-            "-s",
         )
 
         # ref_first_p 对应 -Ep
@@ -617,6 +666,7 @@ def main():
         test_format_helpers,
         test_invalid_gf_source_and_freqband_and_dists,
         test_print_log_forwarded_to_run_grt,
+        test_run_grt_forwards_warnings_and_errors,
         test_greenfn_default_and_optional_flags,
         test_static_greenfn_xy_and_dists,
         test_syn_source_and_time_function_options,


### PR DESCRIPTION
Improve Python-side handling of `grt` diagnostics. The shared `run_grt` wrapper now forwards warnings and diagnostic output even when regular logs are suppressed, and preserves both stdout and stderr when `grt` exits with an error before raising `RuntimeError`. The `greenfn` Python wrapper no longer adds the C-side `-s` flag, preventing warnings from being suppressed at the source.