### PR TITLE
BREAKING: make lamb1 keyword-only and validate dimensionless time

### DIFF
--- a/docs/source/Lamb_problem/index.rst
+++ b/docs/source/Lamb_problem/index.rst
@@ -8,20 +8,29 @@ Lamb 问题
 并分别在上下两册中给出了频域解和时域解，过程之详细令人叹为观止。这里不再对 Lamb 问题及其解法做过多介绍，
 详见张海明老师的书 (|zhang2021|; |zhang2024|)（强烈推荐！！）
 
-**PyGRT** 程序包实现的是在频域求解，这里我对照下册书也编程实现了 Lamb 问题的时域解
-（目前包括第一/二类 Lamb 问题，后续会再扩展），方便进行对比验证。以下简单示范用法以及绘图。
-
-.. note::
-
-    程序输入的时间为无量纲时间，输出的位移为和阶跃函数卷积后的无量纲位移。
-
-    + 无量纲时间 :math:`\bar{t} = \dfrac{t}{T_S}` ，其中 :math:`T_S = \dfrac{r}{\beta}`
-    + 无量纲位移 :math:`\bar{\mathbf{G}}^H = \pi^2 \mu r \mathbf{G}^H` ，上标 :math:`H` 表示已和阶跃函数卷积，下同。
-    + 无量纲空间导数 :math:`\bar{\mathbf{G}}^H_{,k}=\pi^2\mu r^2\mathbf{G}^H_{,k}`
-
+得益于书中详细的推导过程，这里我对照下册书 **编程实现了第一、二类 Lamb 问题在时域的广义闭合解** 。
+以下简单示范用法以及绘图，其中复现了书中的一些结果，并和频域解进行了对比。
 
 .. toctree::
    :maxdepth: 1
 
    lamb1
    lamb2
+
+.. note::
+
+    **程序输入的时间为无量纲时间，输出的位移为和阶跃函数卷积后的无量纲位移。**
+
+    + **无量纲时间** :math:`\bar{t} = \dfrac{t}{T_S} = \dfrac{t}{r/\beta} = \dfrac{\beta t}{r}`，
+      其中 :math:`T_S = \dfrac{r}{\beta}` 是 S 波传播时间尺度，
+      :math:`r` 为源点和接收点的两点直线距离，不是水平震中距
+    + **无量纲位移** 均为 :math:`\bar{\mathbf{G}}^H = \pi^2 \mu r \mathbf{G}^H`，
+      上标 :math:`H` 表示已和阶跃函数卷积，下同
+    + **无量纲空间导数** 均为 :math:`\bar{\mathbf{G}}^H_{,k}=\pi^2\mu r^2\mathbf{G}^H_{,k}`
+
+.. note::
+
+    **如果使用了相关功能，您还需引用：**
+
+    + Feng, X., Zhang, H., 2018. Exact closed-form solutions for lamb’s problem. Geophys. J. Int. 214, 444–459. https://doi.org/10.1093/gji/ggy131
+    + 张海明，冯禧，2024. 地震学中的Lamb问题（下）[M]. 北京：科学出版社.

--- a/docs/source/Lamb_problem/run/lamb1_plot_freq_time.py
+++ b/docs/source/Lamb_problem/run/lamb1_plot_freq_time.py
@@ -19,7 +19,7 @@ nu = 0.5 * (1 - 2*(Vs/Vp)**2) / (1 - (Vs/Vp)**2)
 
 # 模型数组，半无限空间
 modarr = np.array([
-    [0.,  Vp, Vs, Rho, 9e10, 9e10],
+    [0.,  Vp, Vs, Rho],
 ])
 
 # 剪切模量
@@ -36,7 +36,8 @@ dt = 0.005    # 采样时间间隔(s)
 idx = 0      # 震中距索引
 r = rs[idx]
 
-t = np.arange(0, nt)*dt * Vs/r 
+# 将频域解的物理时间转换为无量纲时间
+tbar = np.arange(0, nt)*dt * Vs/r
 
 modfile = "_halfspace_mod"
 np.savetxt(modfile, modarr)
@@ -50,7 +51,7 @@ pygrt.utils.stream_integral(st)
 
 
 # 时域解
-u = pygrt.utils.lamb1(nu, t, 0).reshape(-1, 9)
+u = pygrt.utils.lamb1(nu=nu, tbar=tbar, azimuth=0).reshape(-1, 9)
 u = u[:, [0,2,4,6,8]]
 u.shape
 
@@ -67,17 +68,18 @@ fig, axs = plt.subplots(5, 2, figsize=(10, 10), sharex=True)
 labels = [r"$\bar{{G}}^H_{11}$", r"$\bar{{G}}^H_{13}$", r"$\bar{{G}}^H_{22}$", r"$\bar{{G}}^H_{31}$", r"$\bar{{G}}^H_{33}$"]
 for i in range(5):
     ax = axs[i, 0]
-    ax.plot(t, u[:,i])
+    ax.plot(tbar, u[:,i], c='0.5', lw=1.5)
     ax.set_ylim(-2, 2)
     ax.set_xlim(0, 2)
-    ax.grid()
+    ax.grid(lw=0.4)
     ax.text(0.05, 0.92, labels[i], transform=ax.transAxes, ha='left', va='top', fontsize=12)
 
     ax = axs[i, 1]
-    ax.plot(t, v[:,i])
+    ax.plot(tbar, u[:,i], c='0.5', lw=1.5)
+    ax.plot(tbar, v[:,i], c='b', lw=0.7)
     ax.set_ylim(-2, 2)
     ax.set_xlim(0, 2)
-    ax.grid()
+    ax.grid(lw=0.4)
     ax.text(0.05, 0.92, labels[i], transform=ax.transAxes, ha='left', va='top', fontsize=12)
 
 axs[0,0].set_title("From Time-Domain")

--- a/docs/source/Lamb_problem/run/lamb1_plot_time.py
+++ b/docs/source/Lamb_problem/run/lamb1_plot_time.py
@@ -2,8 +2,8 @@
 import pygrt
 import numpy as np
 
-ts = np.arange(0, 2, 1e-4)
-u = pygrt.utils.lamb1(0.25, ts, 30)
+tbar = np.arange(0, 2, 1e-4)
+u = pygrt.utils.lamb1(nu=0.25, tbar=tbar, azimuth=30)
 # END LAMB1
 
 import matplotlib.pyplot as plt
@@ -12,7 +12,7 @@ fig, axs = plt.subplots(3, 3, figsize=(10, 5), sharex=True)
 for i in range(3):
     for j in range(3):
         ax = axs[i, j]
-        ax.plot(ts, u[:, i, j])
+        ax.plot(tbar, u[:, i, j])
         ax.set_xlim(0, 2)
         ax.set_ylim(-2, 2)
 

--- a/docs/source/Module/lamb1.rst
+++ b/docs/source/Module/lamb1.rst
@@ -22,18 +22,17 @@ lamb1
 描述
 --------
 
-第一类 Lamb1 问题指在半空间中，当源点和场点均位于地表时，求场点记录到的位移。
+第一类 Lamb 问题指在半空间中，当源点和场点均位于地表时，求场点记录到的位移。
 **lamb1** 模块实现的理论基础来源于《地震学中的 Lamb 问题（下）》第 6 章。
-结果为无量纲位移和阶跃函数卷积后的结果，输出到标准输出。实际的物理 Green
-函数需要将输出结果除以 :math:`\pi^2\mu r`，即
+结果为与阶跃函数卷积后的无量纲位移，输出到标准输出，
+第一列为无量纲时间，随后为 9 个 :math:`G_{ij}` 分量，按行优先顺序排列。
+实际的物理 Green 函数需要将输出结果除以 :math:`\pi^2\mu r`，即
 
 .. math::
 
    G^H=\frac{\bar{G}^H}{\pi^2\mu r}
 
-其中 :math:`r` 为震源到接收点的距离，:math:`\mu` 为剪切模量，:math:`\mu` 和
-:math:`r` 应与目标物理量采用一致的单位。恢复实际振幅时，需要在程序外部提供
-:math:`\mu`。
+其中 :math:`r` 为震源到接收点的距离，:math:`\mu` 为剪切模量.
 
 必选选项
 -----------------
@@ -46,13 +45,22 @@ lamb1
 .. _-T:
 
 **-T**\ *t1/t2/dt*
-    无量纲时间序列 :math:`\bar{t}` ，根据起点时刻 *t1*, 终点时刻 *t2* 和间隔 *dt* 定义， 
-    :math:`\bar{t} = \dfrac{t}{T_S}` ，其中 :math:`T_S = \dfrac{r}{\beta}` ，:math:`r` 为震中距，:math:`\beta` 为 S 波速度。
+    无量纲时间序列 :math:`\bar{t}`，其中开始时间 *t1*、结束时间 *t2* 和时间间隔 *dt* 
+    均以 :math:`\bar{t}` 为单位。
+    :math:`\bar{t} = \dfrac{t}{T_S} = \dfrac{t}{r/\beta} = \dfrac{\beta t}{r}`，其中
+    :math:`T_S = \dfrac{r}{\beta}` 是 S 波传播时间尺度，
+    :math:`r` 为震源到接收点的直线距离，:math:`\beta` 为 S 波速度。
 
 .. _-A:
 
 **-A**\ *azimuth*
     方位角，单位为度。
+
+参考文献
+--------------
+
++ Feng, X., Zhang, H., 2018. Exact closed-form solutions for lamb’s problem. Geophys. J. Int. 214, 444–459. https://doi.org/10.1093/gji/ggy131
++ 张海明，冯禧，2024. 地震学中的Lamb问题（下）[M]. 北京：科学出版社.
 
 
 示例

--- a/pygrt/C_extension/include/grt/lamb/lamb1.h
+++ b/pygrt/C_extension/include/grt/lamb/lamb1.h
@@ -18,9 +18,9 @@
  * 使用广义闭合解求解第一类 Lamb 问题
  * 
  * @param[in]    nu        泊松比， (0, 0.5)
- * @param[in]    ts        归一化时间序列
+ * @param[in]    ts        无量纲时间序列 tbar=t/(r/beta)=beta*t/r
  * @param[in]    nt        时间序列点数
- * @param[in]    azimuth   方位角，单位度
+ * @param[in]    azimuth   方位角，单位度，[0, 360]
  * @param[out]   u         记录结果的指针，如果为NULL则输出到标准输出
  * 
  */

--- a/pygrt/C_extension/src/lamb/grt_lamb1.c
+++ b/pygrt/C_extension/src/lamb/grt_lamb1.c
@@ -16,7 +16,7 @@ typedef struct {
         real_t nu;    ///<  泊松比
     } P;
 
-    /** 归一化时间序列 */
+    /** 无量纲时间序列 tbar=t/(r/beta) */
     struct {
         bool active;
         real_t *ts;
@@ -59,7 +59,9 @@ printf("\n"
 "    -P<nu>         Poisson ratio of the halfspace, (0, 0.5).\n"
 "\n"
 "    -T<t1>/<t2>/<dt>\n"
-"                   Dimensionless time.\n"
+"                   Dimensionless time tbar = t/(r/beta) = beta*t/r.\n"
+"                   Here t is physical time, r is the direct source-receiver distance,\n"
+"                   and beta is the S-wave speed.\n"
 "                   <t1>: start time.\n"
 "                   <t2>: end time.\n"
 "                   <dt>: time interval.\n"
@@ -102,7 +104,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                 }
                 break;
 
-            // 归一化时间序列, -Tt1/t2/dt
+            // 无量纲时间序列 tbar, -Tt1/t2/dt
             case 'T':
                 Ctrl->T.active = true;
                 {

--- a/pygrt/C_extension/src/lamb/lamb1.c
+++ b/pygrt/C_extension/src/lamb/lamb1.c
@@ -764,7 +764,21 @@ void grt_solve_lamb1(
 {
     // 检查泊松比范围
     if(nu <= 0.0 || nu >= 0.5){
-        GRTRaiseError("possion ratio (%lf) is out of bound.", nu);
+        GRTRaiseError("poisson ratio (%lf) is out of bound.", nu);
+    }
+    if(ts == NULL || nt <= 0){
+        GRTRaiseError("The time series for lamb1 should not be empty.\n");
+    }
+    if(azimuth < 0.0 || azimuth > 360.0){
+        GRTRaiseError("azimuth should be in [0, 360] degree for lamb1.\n");
+    }
+    for(int i = 0; i < nt; ++i){
+        if(ts[i] < 0.0){
+            GRTRaiseError("The time series for lamb1 should be nonnegative.\n");
+        }
+        if(i > 0 && ts[i] <= ts[i - 1]){
+            GRTRaiseError("The time series for lamb1 should be strictly increasing.\n");
+        }
     }
 
     // 根据情况判断是打印在屏幕还是记录到内存中
@@ -786,7 +800,7 @@ void grt_solve_lamb1(
 
     real_t phi = azimuth * DEG1;
     
-    real_t tbar_eps = GRT_MIN(1e-8, (ts[1]-ts[0]) * 1e-5);
+    real_t tbar_eps = nt > 1 ? GRT_MIN(1e-8, (ts[1]-ts[0]) * 1e-5) : 1e-8;
 
     // 初始化相关变量
     VARS V0 = {0};

--- a/pygrt/utils.py
+++ b/pygrt/utils.py
@@ -1204,34 +1204,35 @@ def plot_statsdata_ptam(statsdata1:np.ndarray, statsdata2:np.ndarray, statsdata_
 
 
 
-def lamb1(nu:float, ts:np.ndarray, azimuth:float):
+def lamb1(*, nu: float, tbar: np.ndarray, azimuth: float):
     r"""
         solve the first-kind Lamb's problem using the generalized closed-form solution, see：
 
             张海明, 冯禧 著. 2024. 地震学中的 Lamb 问题（下）. 科学出版社
 
         :param      nu:         Poisson ratio in (0, 0.5)
-        :param      ts:         dimensionless time :math:`\bar{t}` ，:math:`\bar{t}=\dfrac{t}{r/\beta}`
-        :param      azimuth:    azimuth in degree
+        :param      tbar:       dimensionless time :math:`\bar{t}=\dfrac{t}{T_S}=\dfrac{t}{r/\beta}=\dfrac{\beta t}{r}`,
+                                where :math:`T_S=r/\beta` is the S-wave time scale and :math:`r` is the direct source-receiver distance
+        :param      azimuth:    azimuth in degree, in ``[0, 360]``
 
         :return:    Dimensionless step-force Green function with shape (nt, 3, 3). To get
                     the physical solution, divide by :math:`\pi^2 \mu r`, where
                     :math:`\mu` is the shear modulus. The returned result is dimensionless.
     """
 
-    # 检查数据
-    if np.any(ts < 0.0):
-        raise ValueError("ts should be nonnegative.")
+    nu = _prepare_lamb_scalar(nu, "nu")
+    tbar = _prepare_lamb_time_series(tbar)
+    azimuth = _prepare_lamb_scalar(azimuth, "azimuth")
+    if nu <= 0.0 or nu >= 0.5:
+        raise ValueError("nu should be in (0, 0.5).")
     if azimuth < 0.0 or azimuth > 360.0:
         raise ValueError("azimuth should be in [0, 360].")
-    
-    ts = np.array(ts).astype(NPCT_REAL_TYPE)
-    
+
     # 定义结果数组
-    nt = len(ts)
+    nt = len(tbar)
     u = np.zeros((nt, 3, 3), dtype=NPCT_REAL_TYPE)
 
-    C_grt_solve_lamb1(nu, npct.as_ctypes(ts), nt, azimuth, npct.as_ctypes(u.ravel()))
+    C_grt_solve_lamb1(nu, npct.as_ctypes(tbar), nt, azimuth, npct.as_ctypes(u.ravel()))
 
     return u
 
@@ -1239,6 +1240,46 @@ def lamb1(nu:float, ts:np.ndarray, azimuth:float):
 def solve_lamb1(*args, **kwargs):
     """Legacy interface renamed to :func:`lamb1`; calling it raises an error."""
     raise RuntimeError("solve_lamb1() has been renamed to lamb1(); use lamb1() instead.")
+
+
+def _prepare_lamb_scalar(value, name):
+    try:
+        value = np.asarray(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{name} should be a finite real scalar.") from None
+    if value.ndim != 0:
+        raise ValueError(f"{name} should be a finite real scalar.")
+    try:
+        value = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError(f"{name} should be a finite real scalar.") from None
+    if not np.isfinite(value):
+        raise ValueError(f"{name} should be finite.")
+    return value
+
+
+def _prepare_lamb_time_series(tbar):
+    try:
+        tbar = np.asarray(tbar)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError("tbar should be a one-dimensional sequence of real numbers.") from None
+    if tbar.ndim != 1:
+        raise ValueError("tbar should be a one-dimensional sequence of real numbers.")
+    if np.iscomplexobj(tbar):
+        raise ValueError("tbar should contain real values.")
+    try:
+        tbar = tbar.astype(NPCT_REAL_TYPE, copy=False)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError("tbar should be a one-dimensional sequence of real numbers.") from None
+    if tbar.size == 0:
+        raise ValueError("tbar should not be empty.")
+    if not np.all(np.isfinite(tbar)):
+        raise ValueError("tbar should contain only finite values.")
+    if np.any(tbar < 0.0):
+        raise ValueError("tbar should be nonnegative.")
+    if tbar.size > 1 and np.any(np.diff(tbar) <= 0.0):
+        raise ValueError("tbar should be strictly increasing.")
+    return np.ascontiguousarray(tbar)
 
 
 def _prepare_lamb2_inputs(ts, theta, azimuth):

--- a/test/lamb1/test_lamb1.py
+++ b/test/lamb1/test_lamb1.py
@@ -1,8 +1,28 @@
 import numpy as np
 import pygrt
 
+
+def expect_value_error(desc, **kwargs):
+    try:
+        pygrt.utils.lamb1(**kwargs)
+    except ValueError:
+        return
+    raise ValueError(f"lamb1 should reject {desc}.")
+
+
+expect_value_error("a Poisson ratio outside (0, 0.5)", nu=0.5, tbar=np.asarray([0.0]), azimuth=0.0)
+expect_value_error("an empty time series", nu=0.25, tbar=np.asarray([]), azimuth=0.0)
+expect_value_error("a multidimensional time series", nu=0.25, tbar=np.asarray([[0.0]]), azimuth=0.0)
+expect_value_error("a non-finite time series", nu=0.25, tbar=np.asarray([0.0, np.inf]), azimuth=0.0)
+expect_value_error("a negative time series", nu=0.25, tbar=np.asarray([-1e-8]), azimuth=0.0)
+expect_value_error("a non-increasing time series", nu=0.25, tbar=np.asarray([0.0, 0.0]), azimuth=0.0)
+expect_value_error("a non-finite Poisson ratio", nu=np.nan, tbar=np.asarray([0.0]), azimuth=0.0)
+expect_value_error("a non-finite azimuth", nu=0.25, tbar=np.asarray([0.0]), azimuth=np.nan)
+expect_value_error("an azimuth outside [0, 360]", nu=0.25, tbar=np.asarray([0.0]), azimuth=361.0)
+
+
 ts = np.arange(0, 2+1e-8, 1e-3)
-lamb1 = pygrt.utils.lamb1(0.25, ts, 30)
+lamb1 = pygrt.utils.lamb1(nu=0.25, tbar=ts, azimuth=30)
 
 # check results
 # Since the rounding error of ref_lamb1, the error will not be absolutely zero.


### PR DESCRIPTION
Harden the first-kind Lamb solver before the later geometry rewrite.

The Python `lamb1()` interface is now keyword-only and takes `tbar` instead of `ts`. C and Python both reject empty, non-finite, or non-increasing time series, and azimuths outside [0, 360]. Docs and plot scripts are updated to the same dimensionless-time definition.

This branch keeps the existing lamb2 CLI/Python API (`-D<theta>`) unchanged, so lamb1 and lamb2 tests both pass on their own.