### PR TITLE
BREAKING: replace `read_static_nc` with generic NetCDF readers

### DIFF
--- a/docs/source/Gallery/ex15/plot.py
+++ b/docs/source/Gallery/ex15/plot.py
@@ -26,7 +26,7 @@ stgrnLst = [dist2st[float(d)] for d in dists]
 
 # 静态解
 pymod.static_greenfn(depsrc=depsrc, deprcv=deprcv, dists=dists.tolist())
-static_grn = pygrt.utils.read_static_nc("stgrn.nc")
+static_grn = pygrt.utils.read_nc_variables("stgrn.nc")
 
 # 绘制
 coef = 1e-20 * 1e25  # 1e25 为地震矩
@@ -43,8 +43,8 @@ for i, st in enumerate(stgrnLst):
 ax.plot(dists, dynamic_Z, 'k', label='Dynamic Z')
 ax.plot(dists, dynamic_R, 'k', label='Dynamic R')
 
-ax.plot(dists, static_grn['variables']['EXZ']['data'][0, 0, 0] * coef, 'ro', ms=4, label='Static Z')
-ax.plot(dists, static_grn['variables']['EXR']['data'][0, 0, 0] * coef, 'bo', ms=4, label='Static R')
+ax.plot(dists, static_grn['EXZ'][0, 0, 0] * coef, 'ro', ms=4, label='Static Z')
+ax.plot(dists, static_grn['EXR'][0, 0, 0] * coef, 'bo', ms=4, label='Static R')
 
 ax.set_xlim(0, 50)
 ax.set_xlabel('Distance (km)')

--- a/docs/source/Gallery/ex15/plot_all.py
+++ b/docs/source/Gallery/ex15/plot_all.py
@@ -26,7 +26,7 @@ stgrnLst = [dist2st[float(d)] for d in dists]
 
 # 静态解
 pymod.static_greenfn(depsrc=depsrc, deprcv=deprcv, dists=dists.tolist())
-static_grn = pygrt.utils.read_static_nc("stgrn.nc")
+static_grn = pygrt.utils.read_nc_variables("stgrn.nc")
 
 # 绘制零频结果
 fig, axs = plt.subplots(2, 3, figsize=(12, 8), gridspec_kw=dict(hspace=0.3, wspace=0.3)) # 
@@ -55,12 +55,12 @@ for isrc, (src, src2) in enumerate(zip(srctypes,
     ms = 2
     lw = 0.8
     ax.plot(dists, dynamic_Z, 'k', lw=lw, label='Dynamic Z')
-    ax.plot(dists, static_grn['variables'][f'{src}Z']['data'][0, 0, 0] * coef, 'ro', ms=ms, label='Static Z')
+    ax.plot(dists, static_grn[f'{src}Z'][0, 0, 0] * coef, 'ro', ms=ms, label='Static Z')
     ax.plot(dists, dynamic_R, 'k', lw=lw, label='Dynamic R')
-    ax.plot(dists, static_grn['variables'][f'{src}R']['data'][0, 0, 0] * coef, 'bo', ms=ms, label='Static R')
+    ax.plot(dists, static_grn[f'{src}R'][0, 0, 0] * coef, 'bo', ms=ms, label='Static R')
     if src not in ['EX', 'VF', 'DD']:
         ax.plot(dists, dynamic_T, 'k', lw=lw, label='Dynamic T')
-        ax.plot(dists, static_grn['variables'][f'{src}T']['data'][0, 0, 0] * coef, 'go', ms=ms, label='Static T')
+        ax.plot(dists, static_grn[f'{src}T'][0, 0, 0] * coef, 'go', ms=ms, label='Static T')
 
     ax.set_xlim(0, 50)
     ax.set_xlabel('Distance (km)')

--- a/docs/source/Gallery/ex16/plot.py
+++ b/docs/source/Gallery/ex16/plot.py
@@ -40,7 +40,7 @@ pymod1.greenfn(depsrc=depsrc, deprcv=deprcv, dists=rs, nt=nt, dt=dt, keepAllFreq
 st1 = read("GRN1/*/*.sac")
 pygrt.utils.stream_integral(st1)
 pymod1.static_greenfn(depsrc=depsrc, deprcv=deprcv, norths=norths_rng, easts=easts_rng)
-static1 = pygrt.utils.read_static_nc("stgrn1.nc")
+static1 = pygrt.utils.read_nc_variables("stgrn1.nc")
 
 # =============================================================
 # 设置上下翻转模型
@@ -66,7 +66,7 @@ pymod2 = pygrt.PyModel1D(grn="GRN2", stgrn="stgrn2.nc", modelpath=modfile2, topb
 pymod2.greenfn(depsrc=depsrc2, deprcv=deprcv2, dists=rs, nt=nt, dt=dt, keepAllFreq=True)
 st2 = read("GRN2/*/*.sac")
 pymod2.static_greenfn(depsrc=depsrc2, deprcv=deprcv2, norths=norths_rng, easts=easts_rng)
-static2 = pygrt.utils.read_static_nc("stgrn2.nc")
+static2 = pygrt.utils.read_nc_variables("stgrn2.nc")
 pygrt.utils.stream_integral(st2)
 
 
@@ -98,8 +98,8 @@ for i in range(5):
     ax.set_ymargin(0.3)
 
     ax = axs2[i]
-    ax.plot(easts, static1['variables'][chLst[i]]['data'][0, 0, 0], **prop1)
-    ax.plot(easts, static2['variables'][chLst[i]]['data'][0, 0, 0] * sgn, **prop2)
+    ax.plot(easts, static1[chLst[i]][0, 0, 0], **prop1)
+    ax.plot(easts, static2[chLst[i]][0, 0, 0] * sgn, **prop2)
     ax.text(0.96, 0.9, chLst[i], transform=ax.transAxes,  ha='right', va='top', bbox=dict(fc='w'))
     ax.ticklabel_format(axis='y', style='sci', scilimits=(0,0))
     ax.grid()

--- a/docs/source/Tutorial/static/run/plot_points.py
+++ b/docs/source/Tutorial/static/run/plot_points.py
@@ -5,12 +5,11 @@ from matplotlib.colors import Normalize
 
 
 def plot_static_points(static_syn, output_path):
-    variables = static_syn["variables"]
-    north = variables["north"]["data"]
-    east = variables["east"]["data"]
-    z = variables["Z"]["data"]
-    n = variables["N"]["data"]
-    e = variables["E"]["data"]
+    north = static_syn["north"]
+    east = static_syn["east"]
+    z = static_syn["Z"]
+    n = static_syn["N"]
+    e = static_syn["E"]
 
     zmax = max(float(np.max(np.abs(z))), np.finfo(float).eps)
 
@@ -45,5 +44,5 @@ def plot_static_points(static_syn, output_path):
     plt.close(fig)
 
 
-static_syn = pygrt.utils.read_static_nc("stsyn_points.nc")
+static_syn = pygrt.utils.read_nc_variables("stsyn_points.nc")
 plot_static_points(static_syn, "syn_points.svg")

--- a/docs/source/Tutorial/static/run_upar/run.py
+++ b/docs/source/Tutorial/static/run_upar/run.py
@@ -3,24 +3,23 @@ import numpy as np
 import pygrt
 
 def plot6(data:dict, title:str, out:str|None=None):
-    vars_ = data["variables"]
-    norths = vars_["north"]["data"]
-    easts = vars_["east"]["data"]
-    chs = sorted([k for k in vars_ if k.startswith(title.lower() + "_")], reverse=True)
+    norths = data["north"]
+    easts = data["east"]
+    chs = sorted([k for k in data if k.startswith(title.lower() + "_")], reverse=True)
     fig, axs = plt.subplots(len(chs)//3, 3, figsize=(10, len(chs)))
     axs = axs.ravel()
 
     MAX = 0
     for i in range(len(chs)):
         ch = chs[i]
-        m = np.max(np.abs(vars_[ch]["data"]))
+        m = np.max(np.abs(data[ch]))
         if m > MAX:
             MAX = m
 
     for i in range(len(chs)):
         ax = axs[i]
         ch = chs[i]
-        arr = vars_[ch]["data"]
+        arr = data[ch]
         vmin = vmax = None
         if np.max(np.abs(arr))/MAX < 1e-5:
             vmin = -1
@@ -68,7 +67,7 @@ pygrt.utils.static_stress("stsyn_dc_zne.nc")
 # ---------------------------------------------------------------
 
 
-static_tensor = pygrt.utils.read_static_nc("stsyn_dc_zne.nc")
+static_tensor = pygrt.utils.read_nc_variables("stsyn_dc_zne.nc")
 plot6(static_tensor, "Strain", 'static_strain.svg')
 plot6(static_tensor, "Rotation", 'static_rotation.svg')
 plot6(static_tensor, "Stress", 'static_stress.svg')

--- a/docs/source/Tutorial/static/static_gfunc.rst
+++ b/docs/source/Tutorial/static/static_gfunc.rst
@@ -43,5 +43,5 @@ Python中计算静态格林函数的主函数为 :meth:`static_greenfn() <pygrt.
             :end-before: END GRN
 
         结果写入构造 :class:`~pygrt.pymod.PyModel1D` 时 ``stgrn=`` 指定的 NetCDF 文件。需要读回时调用
-        :func:`pygrt.utils.read_static_nc`，返回字典包含
-        ``dimensions``、 ``variables`` 与 ``attributes``。
+        :func:`pygrt.utils.read_nc_variables`，返回 ``{变量名: 数组}`` 字典。
+        如需完整的维度与属性信息，可使用 :func:`pygrt.utils.read_nc`。

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -21,7 +21,7 @@ from obspy import read
 
 from .cli import format_float, format_range, run_grt
 from .c_interfaces import C_grt_compute_travt1d_from_file, C_grt_free, PREAL
-from .utils import read_static_nc
+from .utils import read_nc_variables
 
 
 PathLike = Union[str, os.PathLike]
@@ -900,7 +900,7 @@ class PyModel1D:
                                      ``z``/``n``/``e`` (ZNE). Set this when strain,
                                      stress or rotation will be computed later.
         :param    return_result:     If true, read the generated NetCDF file with
-                                     :func:`pygrt.utils.read_static_nc`.
+                                     :func:`pygrt.utils.read_nc_variables`.
 
         :return: The synthesized NetCDF data when ``return_result`` is true;
                  otherwise ``None``.
@@ -992,7 +992,7 @@ class PyModel1D:
 
         run_grt(list(command.values()))
         if return_result:
-            return read_static_nc(output)
+            return read_nc_variables(output)
         return None
 
     def compute_static_syn(self, *args, **kwargs):

--- a/pygrt/utils.py
+++ b/pygrt/utils.py
@@ -3,7 +3,7 @@
     :author:   Zhu Dengda (zhudengda@mail.iggcas.ac.cn)  
     :date:     2024-07-24  
 
-    该文件包含一些数据处理操作上的补充:   
+    该文件包含一些数据处理操作上的补充 
 
 """
 
@@ -35,8 +35,8 @@ from .c_interfaces import (
 
 
 __all__ = [
-    "read_static_nc",
-    "read_static_grn",
+    "read_nc",
+    "read_nc_variables",
     "okada",
     "strain",
     "rotation",
@@ -83,18 +83,9 @@ NPCT_REAL_TYPE = "f8"
 NPCT_CMPLX_TYPE = "c16"
 
 
-def _attribute_value(value):
-    """Convert a NetCDF attribute to a convenient Python value."""
-    if isinstance(value, np.ndarray) and value.ndim == 0:
-        return value.item()
-    if isinstance(value, bytes):
-        return value.decode("utf-8")
-    return value
-
-
-def read_static_nc(path: PathLike) -> dict:
+def read_nc(path: PathLike) -> dict:
     """
-    Read a static NetCDF grid produced by ``grt static`` modules.
+    Read a NetCDF file into a nested dictionary.
 
     The returned dictionary contains three top-level entries:
 
@@ -105,17 +96,25 @@ def read_static_nc(path: PathLike) -> dict:
 
     Variable arrays are available at ``variables[name]["data"]``.
 
-    :param    path:               Path to the static NetCDF file.
+    :param    path:               Path to the NetCDF file.
 
     :return: A dictionary containing the NetCDF data and metadata.
     """
+    def attribute_value(value):
+        # 将 NetCDF 属性转为更方便使用的 Python 值
+        if isinstance(value, np.ndarray) and value.ndim == 0:
+            return value.item()
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return value
+
     path = str(path)
     if not Path(path).is_file():
         raise FileNotFoundError(f"NetCDF file does not exist: {path}")
 
     with netcdf_file(path, mode="r", mmap=False) as dataset:
         dimensions = {name: int(length) for name, length in dataset.dimensions.items()}
-        attributes = {name: _attribute_value(getattr(dataset, name)) for name in dataset._attributes}
+        attributes = {name: attribute_value(getattr(dataset, name)) for name in dataset._attributes}
         variables = {}
         result = {
             "dimensions": dimensions,
@@ -124,7 +123,7 @@ def read_static_nc(path: PathLike) -> dict:
         }
         for name, variable in dataset.variables.items():
             data = np.array(variable[:], copy=True)
-            variable_attributes = {key: _attribute_value(value) for key, value in variable._attributes.items()}
+            variable_attributes = {key: attribute_value(value) for key, value in variable._attributes.items()}
             variables[name] = {
                 "dimensions": tuple(variable.dimensions),
                 "data": data,
@@ -133,17 +132,18 @@ def read_static_nc(path: PathLike) -> dict:
     return result
 
 
-def read_static_grn(path: PathLike) -> dict:
+def read_nc_variables(path: PathLike) -> dict:
     """
-    Read a static Green's function NetCDF file.
+    Read NetCDF variables as a name-to-array mapping.
 
-    This is an alias of :func:`read_static_nc`.
+    This is a simplified form of :func:`read_nc`. Global attributes and
+    dimension metadata are omitted.
 
-    :param    path:               Path to the static Green's function file.
+    :param    path:               Path to the NetCDF file.
 
-    :return: A dictionary containing the NetCDF data and metadata.
+    :return: A dictionary mapping each variable name to a ``numpy.ndarray``.
     """
-    return read_static_nc(path)
+    return {name: info["data"] for name, info in read_nc(path)["variables"].items()}
 
 
 def okada(
@@ -228,7 +228,7 @@ def okada(
     :param    calc_upar:        If true, also output spatial displacement derivatives
     :param    return_result:    If true, read and return the generated NetCDF data
 
-    :return: The result from :func:`read_static_nc` when ``return_result`` is true;
+    :return: The result from :func:`read_nc_variables` when ``return_result`` is true;
              otherwise ``None``
     """
 
@@ -328,7 +328,7 @@ def okada(
 
     run_grt(command)
     if return_result:
-        return read_static_nc(output)
+        return read_nc_variables(output)
     return None
 
 
@@ -351,7 +351,7 @@ def _run_static_file_module(
         raise FileNotFoundError(f"Synthesis result does not exist: {path}")
 
     run_grt([module, f"-G{path}", *options])
-    return read_static_nc(path) if return_result else None
+    return read_nc_variables(path) if return_result else None
 
 
 def _run_coordinate_transform(
@@ -477,7 +477,7 @@ def static_sproj(
     :param    force_rake:   If true, append ``+f`` and force the manual rake for all finite points.
     :param    return_result: If true, return the processed NetCDF data.
 
-    :return: The result from :func:`read_static_nc` when ``return_result`` is true;
+    :return: The result from :func:`read_nc_variables` when ``return_result`` is true;
              otherwise ``None``
     """
     options = []
@@ -514,7 +514,7 @@ def static_coulomb(
     :param    friction:      Nonnegative dimensionless effective friction coefficient.
     :param    return_result: If true, return the processed NetCDF data.
 
-    :return: The result from :func:`read_static_nc` when ``return_result`` is true;
+    :return: The result from :func:`read_nc_variables` when ``return_result`` is true;
              otherwise ``None``
     """
     return _run_static_file_module(path, "static_coulomb", [f"-F{format_float(friction)}"], return_result)
@@ -546,7 +546,7 @@ def _run_static_tensor_module(path: PathLike, module: str, return_result: bool):
         raise FileNotFoundError(f"Synthesis result does not exist: {path}")
 
     run_grt([module, path])
-    return read_static_nc(path) if return_result else None
+    return read_nc_variables(path) if return_result else None
 
 
 def strain(


### PR DESCRIPTION
- Rename `read_static_nc` to `read_nc` so the helper is not limited to static grids.
- Replace `read_static_grn` with `read_nc_variables`, which returns `{name: ndarray}`.
- Update `PyModel1D`, gallery examples, and the static tutorial to the new return shape.
