### PR TITLE
DOC: document Python APIs for modal eigenv, eigenfn and modsum

### DIFF
--- a/docs/source/Tutorial/dynamic/index.rst
+++ b/docs/source/Tutorial/dynamic/index.rst
@@ -35,7 +35,7 @@
         classDef cmdcls fill:#f9f2d9,stroke:#e8d174,stroke-width:2px,color:#333;
         class GG,SS,EE,RR,TT cmdcls
 
-+ C (module name)
++ CLI (module name)
 
 .. mermaid::
 

--- a/docs/source/Tutorial/modal/eigenfunction.rst
+++ b/docs/source/Tutorial/modal/eigenfunction.rst
@@ -6,7 +6,7 @@
 
 本征值对应的位移应力解被称为本征函数，再基于变分理论计算出能量积分后可计算出群速度和频散敏感核 (|aki2009|; |yao2026|)。
 
-C 模块为 :doc:`/Module/eigenfn` （Python函数将于后续版本增加），
+C 模块为 :doc:`/Module/eigenfn`，Python 中对应 :meth:`PyModel1D.eigenfn() <pygrt.pymod.PyModel1D.eigenfn>`，
 计算将基于 :doc:`/Module/eigenv` 模块的频散结果及其内嵌的模型。
 
 以下示例基于 :doc:`eigenvalue` 部分计算的相速度频散结果。
@@ -16,14 +16,26 @@ C 模块为 :doc:`/Module/eigenfn` （Python函数将于后续版本增加），
 
 计算频率 1 Hz 时不同阶的本征函数，深度范围 [0, 50] km，间隔 0.1 km :
 
-.. literalinclude:: run/run.sh
-    :language: bash
-    :start-after: BEGIN EIGENFN
-    :end-before: END EIGENFN
+.. tabs::
 
-Python 提供了 :func:`read_eigenfunction() <pygrt.utils.read_eigenfunction>`
-将结果读入字典（``eigfn`` 等按阶号分组），以及 :func:`plot_eigenfunction() <pygrt.utils.plot_eigenfunction>`
-进行简易绘图。
+    .. group-tab:: CLI
+
+        .. literalinclude:: run/run.sh
+            :language: bash
+            :start-after: BEGIN EIGENFN
+            :end-before: END EIGENFN
+
+    .. group-tab:: Python
+
+        .. literalinclude:: run/run.py
+            :language: python
+            :start-after: BEGIN EIGENFN
+            :end-before: END EIGENFN
+
+        Python 提供了 :func:`read_eigenfunction() <pygrt.utils.read_eigenfunction>`
+        将结果读入字典（``eigfn`` 等按阶号分组），以及 :func:`plot_eigenfunction() <pygrt.utils.plot_eigenfunction>`
+        进行简易绘图。
+
 
 :download:`plot_eigenfunction.py <run/plot_eigenfunction.py>`
 
@@ -34,15 +46,28 @@ Python 提供了 :func:`read_eigenfunction() <pygrt.utils.read_eigenfunction>`
 
 计算所有阶的相速度对应的群速度 :
 
-.. literalinclude:: run/run.sh
-    :language: bash
-    :start-after: BEGIN GROUP
-    :end-before: END GROUP
+.. tabs::
 
-与 :doc:`eigenvalue` 中介绍的一致，可使用
-:func:`read_dispersion() <pygrt.utils.read_dispersion>` 和
-:func:`plot_dispersion() <pygrt.utils.plot_dispersion>` 读取并绘制；
-:doc:`/Module/disp2asc` 模块也可将 |NetCDF| 格式的频散转为文本格式。
+    .. group-tab:: CLI
+
+        .. literalinclude:: run/run.sh
+            :language: bash
+            :start-after: BEGIN GROUP
+            :end-before: END GROUP
+
+        :doc:`/Module/disp2asc` 模块也可将 |NetCDF| 格式的群速度频散转为文本格式。
+
+    .. group-tab:: Python
+
+        .. literalinclude:: run/run.py
+            :language: python
+            :start-after: BEGIN GROUP
+            :end-before: END GROUP
+
+        与 :doc:`eigenvalue` 中介绍的一致，可使用
+        :func:`read_dispersion() <pygrt.utils.read_dispersion>` 和
+        :func:`plot_dispersion() <pygrt.utils.plot_dispersion>` 读取群速度并绘制；
+
 以下同样提供两种方式的简易绘图脚本。
 
 :download:`plot_dispersion_group.py (基于 Matplotlib) <run/plot_dispersion_group.py>` | 
@@ -56,14 +81,25 @@ Python 提供了 :func:`read_eigenfunction() <pygrt.utils.read_eigenfunction>`
 
 计算不同频率下基阶频散曲线的相/群速度频散敏感核，深度间隔 0.2 km :
 
-.. literalinclude:: run/run.sh
-    :language: bash
-    :start-after: BEGIN SENS
-    :end-before: END SENS
+.. tabs::
 
-Python 提供了 :func:`read_sensitivity() <pygrt.utils.read_sensitivity>`
-将结果读入字典（``csens`` / ``usens`` 等按阶号分组），以及 :func:`plot_sensitivity() <pygrt.utils.plot_sensitivity>`
-进行简易绘图。
+    .. group-tab:: CLI
+
+        .. literalinclude:: run/run.sh
+            :language: bash
+            :start-after: BEGIN SENS
+            :end-before: END SENS
+
+    .. group-tab:: Python
+
+        .. literalinclude:: run/run.py
+            :language: python
+            :start-after: BEGIN SENS
+            :end-before: END SENS
+
+        Python 提供了 :func:`read_sensitivity() <pygrt.utils.read_sensitivity>`
+        将结果读入字典（``csens`` / ``usens`` 等按阶号分组），以及 :func:`plot_sensitivity() <pygrt.utils.plot_sensitivity>`
+        进行简易绘图。
 
 :download:`plot_sensitivity.py <run/plot_sensitivity.py>`
 

--- a/docs/source/Tutorial/modal/eigenvalue.rst
+++ b/docs/source/Tutorial/modal/eigenvalue.rst
@@ -5,7 +5,7 @@
 ====================
 
 频散曲线上每个点对应的相速度被称为面波本征值。具体地，这里我们使用自适应搜根方法 (|ars2026|) 计算面波相速度频散曲线，
-C 模块为 :doc:`/Module/eigenv` （Python函数将于后续版本增加）。
+C 模块为 :doc:`/Module/eigenv`，Python 中对应 :meth:`PyModel1D.eigenv() <pygrt.pymod.PyModel1D.eigenv>`。
 
 以下示例使用如下层状模型，文件命名为 :file:`mod2` :
 
@@ -18,17 +18,30 @@ C 模块为 :doc:`/Module/eigenv` （Python函数将于后续版本增加）。
 
 计算 :file:`mod2` 模型中的 Rayleigh 波和 Love 波的所有阶频散曲线，频率 5 Hz 以下，间隔 0.01 Hz。
 
-.. literalinclude:: run/run.sh
-    :language: bash
-    :start-after: BEGIN DISPERSION
-    :end-before: END DISPERSION
+.. tabs::
+
+    .. group-tab:: CLI
+
+        .. literalinclude:: run/run.sh
+            :language: bash
+            :start-after: BEGIN DISPERSION
+            :end-before: END DISPERSION
+
+        如果仅想要快速浏览，可使用 :doc:`/Module/disp2asc` 模块将 |NetCDF|
+        格式的频散转为文本格式，方便简单阅读结果以及使用 |GMT| 绘制。
+
+    .. group-tab:: Python
+
+        .. literalinclude:: run/run.py
+            :language: python
+            :start-after: BEGIN DISPERSION
+            :end-before: END DISPERSION
+
+        Python 提供了 :func:`read_dispersion() <pygrt.utils.read_dispersion>`
+        将结果读入字典（``freq``、``c`` 等按阶号分组），以及 :func:`plot_dispersion() <pygrt.utils.plot_dispersion>` 进行简易绘图。
+
 
 计算结果分别导出为 |NetCDF| 经典格式，其中具体变量详见 :doc:`/Module/eigenv` 模块文档。
-
-Python 提供了 :func:`read_dispersion() <pygrt.utils.read_dispersion>`
-将结果读入字典（``freq``、``c`` 等按阶号分组），以及 :func:`plot_dispersion() <pygrt.utils.plot_dispersion>` 进行简易绘图。
-如果仅想要快速浏览，也可使用 :doc:`/Module/disp2asc` 模块将 |NetCDF|
-格式的频散转为文本格式，方便简单阅读结果以及使用 |GMT| 绘制。
 
 以下提供这两种方式的简易绘图脚本。
 
@@ -44,14 +57,25 @@ Python 提供了 :func:`read_dispersion() <pygrt.utils.read_dispersion>`
 如果感兴趣，可以使用 :doc:`/Module/eigenv` 模块导出搜根过程中对应久期函数幅值。
 例如，以上述程序为例，导出频率 1 Hz 处 Rayleigh 波和 Love 波的久期函数，相速度范围在 [3.0, 5.5] km/s :
 
-.. literalinclude:: run/run.sh
-    :language: bash
-    :start-after: BEGIN SECFUNC
-    :end-before: END SECFUNC
+.. tabs::
 
-Python 提供了 :func:`read_secfunc() <pygrt.utils.read_secfunc>`
-将结果读入字典列表（每一条对应一层的久期函数），以及
-:func:`plot_secfunc() <pygrt.utils.plot_secfunc>` 绘制其中一条（也可传入 ``{标题: 字典}`` 分栏绘制）。
+    .. group-tab:: CLI
+
+        .. literalinclude:: run/run.sh
+            :language: bash
+            :start-after: BEGIN SECFUNC
+            :end-before: END SECFUNC
+
+    .. group-tab:: Python
+
+        .. literalinclude:: run/run.py
+            :language: python
+            :start-after: BEGIN SECFUNC
+            :end-before: END SECFUNC
+
+        Python 提供了 :func:`read_secfunc() <pygrt.utils.read_secfunc>`
+        将结果读入字典列表（每一条对应一层的久期函数），以及
+        :func:`plot_secfunc() <pygrt.utils.plot_secfunc>` 绘制其中一条（也可传入 ``{标题: 字典}`` 分栏绘制）。
 
 :download:`plot_secfunc.py <run/plot_secfunc.py>`
 

--- a/docs/source/Tutorial/modal/index.rst
+++ b/docs/source/Tutorial/modal/index.rst
@@ -4,11 +4,45 @@
 计算动态解（面波解）
 =====================
 
-计算 **动态面波解** 的主要计算流程如下（目前仅支持 C 模块）。其中值得注意的是，
+计算 **动态面波解** 的主要计算流程如下。其中值得注意的是，
 在经过 **modsum** 模块计算得到不同震源的面波格林函数后，
 后续的合成位移/应力等流程完全和 :doc:`/Tutorial/dynamic/index` 是一样的，共享计算模块。
 
 关于面波计算的基本理论详见 |yao2026p| ，这里不再做过多介绍。
+
++ Python
+
+.. mermaid::
+
+    flowchart TB 
+
+        VV(["pygrt.PyModel1D.eigenv()"])
+        FN(["pygrt.PyModel1D.eigenfn()"])
+        MS(["pygrt.PyModel1D.modsum()"])
+        SS(["pygrt.PyModel1D.syn()"])
+        EE(["pygrt.utils.strain()"])
+        RR(["pygrt.utils.rotation()"])
+        TT(["pygrt.utils.stress()"])
+
+        V["Compute Dispersion Curves"]
+        F["Compute Eigenfunctions, Energy Integrals,
+           Group Velocity and Dispersion Sensitivity"]
+        M["Compute Surface-wave Green's Functions (and its Spatial Derivatives)"]
+
+        VV --> V
+        V --> FN --> F
+        V --> MS --> M
+        M --> SS
+        SS --> EE
+        SS --> RR
+        SS --> TT
+        
+        classDef cmdcls1 fill:#A1E3F9,stroke:#006BFF,stroke-width:2px,color:#333;
+        classDef cmdcls2 fill:#f9f2d9,stroke:#e8d174,stroke-width:2px,color:#333;
+        class VV,FN,MS cmdcls1 
+        class SS,EE,RR,TT cmdcls2
+
++ CLI (module name)
 
 .. mermaid::
 

--- a/docs/source/Tutorial/modal/modlib.rst
+++ b/docs/source/Tutorial/modal/modlib.rst
@@ -8,7 +8,8 @@
 再由 :doc:`/Module/modsum` 使用模态叠加法计算格林函数。由于 :doc:`/Module/modsum` 的输出目录格式与
 :doc:`/Module/greenfn` **完全相同**，因此建库和合成时的深度、震中距选择方式也相同，这里只进行简单介绍。
 
-面波建库目前使用 C 模块。Python 接口尚未提供对应的面波计算函数。
+面波建库可以直接使用 :class:`~pygrt.pymod.PyModel1D` 的
+:meth:`~pygrt.pymod.PyModel1D.eigenv` 和 :meth:`~pygrt.pymod.PyModel1D.modsum`。
 
 快速上手
 ---------
@@ -16,14 +17,26 @@
 先用 :doc:`/Module/eigenv` 模块计算 Rayleigh 波和 Love 波的频散结果，再分别调用 :doc:`/Module/modsum`。两次调用可以写入同一个输出根目录：
 Rayleigh 波提供 Z、R 分量，Love 波提供 T 分量，最后得到完整的面波格林函数。
 
-.. literalinclude:: run_library/run.sh
-    :language: bash
-    :start-after: BEGIN LIBRARY
-    :end-before: END LIBRARY
+.. tabs::
+
+    .. group-tab:: CLI
+
+        .. literalinclude:: run_library/run.sh
+            :language: bash
+            :start-after: BEGIN LIBRARY
+            :end-before: END LIBRARY
+
+        ``-N0`` 表示只计算基阶面波；需要更多阶数时可改为 ``-N`` 或指定阶数范围。
+
+    .. group-tab:: Python
+
+        .. literalinclude:: run_library/run.py
+            :language: python
+            :start-after: BEGIN LIBRARY
+            :end-before: END LIBRARY
 
 这里计算了 2、4 km 两个震源深度，0、2 km 两个台站深度，以及 80、100、120 km 三个震中距。
-程序会遍历所有组合，目录例如 ``GRN/milrow_4_2_100/``。``-N0`` 表示只计算基阶面波；
-需要更多阶数时可改为 ``-N`` 或指定阶数范围。
+程序会遍历所有组合，目录例如 ``GRN/milrow_4_2_100/``。
 
 .. warning::
 
@@ -37,10 +50,21 @@ Rayleigh 波提供 Z、R 分量，Love 波提供 T 分量，最后得到完整�
 对多深度、多距离库必须明确设置 **-Ds**、**-Dr** 和 **-R**；下例选择震源深度 4 km、台站深度 2 km、
 震中距 100 km：
 
-.. literalinclude:: run_library/run.sh
-    :language: bash
-    :start-after: BEGIN SYN
-    :end-before: END SYN
+.. tabs::
+
+    .. group-tab:: CLI
+
+        .. literalinclude:: run_library/run.sh
+            :language: bash
+            :start-after: BEGIN SYN
+            :end-before: END SYN
+
+    .. group-tab:: Python
+
+        .. literalinclude:: run_library/run.py
+            :language: python
+            :start-after: BEGIN SYN
+            :end-before: END SYN
 
 选择规则是精确匹配，程序不会在相邻深度或距离之间插值。如果只想固定使用一个已经确定的库节点，
 也可以直接把 **-G** 指向 ``GRN/milrow_4_2_100``，此时不再设置三个选择选项。

--- a/docs/source/Tutorial/modal/run/run.py
+++ b/docs/source/Tutorial/modal/run/run.py
@@ -1,0 +1,62 @@
+import pygrt
+
+# BEGIN DISPERSION
+pymod = pygrt.PyModel1D(modelpath="mod2")
+pymod.eigenv(wtype="R", freqs=(0.0, 5.0, 0.01), phase_path="phase_R.nc", all_modes=True)
+pymod.eigenv(wtype="L", freqs=(0.0, 5.0, 0.01), phase_path="phase_L.nc", all_modes=True)
+# END DISPERSION
+
+
+# BEGIN SECFUNC
+from contextlib import redirect_stdout
+
+# 将输出重定向到文件中
+with open("secfunc_R", "w") as f, redirect_stdout(f):
+    pymod.eigenv(wtype="R", secular_freq=1.0, cmin=3.0, cmax=5.5, iref=0)
+with open("secfunc_L", "w") as f, redirect_stdout(f):
+    pymod.eigenv(wtype="L", secular_freq=1.0, cmin=3.0, cmax=5.5, iref=0)
+# END SECFUNC
+
+
+# BEGIN EIGENFN
+pymod.eigenfn(
+    phase_path="phase_R.nc",
+    freqs=1.0,
+    all_modes=True,
+    eigenfn_path="egn_R.nc",
+    depths=(0.0, 50.0, 0.1),
+)
+pymod.eigenfn(
+    phase_path="phase_L.nc",
+    freqs=1.0,
+    all_modes=True,
+    eigenfn_path="egn_L.nc",
+    depths=(0.0, 50.0, 0.1),
+)
+# END EIGENFN
+
+
+# BEGIN GROUP
+pymod.eigenfn(phase_path="phase_R.nc", all_modes=True, group_path="group_R.nc")
+pymod.eigenfn(phase_path="phase_L.nc", all_modes=True, group_path="group_L.nc")
+# END GROUP
+
+
+# BEGIN SENS
+pymod.eigenfn(
+    phase_path="phase_R.nc",
+    freqs=(0.0, 0.5, 0.1),
+    modes=0,
+    csens_path="csens_R.nc",
+    usens_path="usens_R.nc",
+    sensitivity_dz=0.2,
+)
+pymod.eigenfn(
+    phase_path="phase_L.nc",
+    freqs=(0.0, 0.5, 0.1),
+    modes=0,
+    csens_path="csens_L.nc",
+    usens_path="usens_L.nc",
+    sensitivity_dz=0.2,
+)
+# END SENS

--- a/docs/source/Tutorial/modal/run/run.sh
+++ b/docs/source/Tutorial/modal/run/run.sh
@@ -50,5 +50,6 @@ grt eigenfn -Cphase_L.nc -F0/0.5/0.1 -N0 -K+ccsens_L.nc+uusens_L.nc+z0.2
 
 python plot_sensitivity.py
 
+python run.py
 
 rm -rf *.nc secfunc_*

--- a/docs/source/Tutorial/modal/run_library/run.py
+++ b/docs/source/Tutorial/modal/run_library/run.py
@@ -1,0 +1,34 @@
+import pygrt
+
+# BEGIN LIBRARY
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
+# eigenv 使用等间隔频率，供 modsum 进行逆傅里叶变换
+pymod.eigenv(wtype="R", freqs=(0.0, 1.0, 0.02), phase_path="phase_R.nc", all_modes=True)
+pymod.eigenv(wtype="L", freqs=(0.0, 1.0, 0.02), phase_path="phase_L.nc", all_modes=True)
+
+# depsrc/deprcv 和 dists 传入列表，modsum 在内部遍历全部组合
+# 加上 calc_upar=True 表示计算位移格林函数的空间偏导
+for wave in ("R", "L"):
+    pymod.modsum(
+        phase_path=f"phase_{wave}.nc",
+        depsrc=[2.0, 4.0],
+        deprcv=[0.0, 2.0],
+        dists=[80.0, 100.0, 120.0],
+        modes=0,
+        upsampling_n=4,
+        calc_upar=True,
+    )
+# END LIBRARY
+
+
+# BEGIN SYN
+pymod = pygrt.PyModel1D(grn="GRN")
+# syn 从面波格林函数库根目录精确选择一个深度和距离
+# 加上 calc_upar=True 表示合成位移的空间偏导
+pymod.syn(
+    depsrc=4.0, deprcv=2.0, dist=100.0,
+    azimuth=30.0, scale=1e24,
+    strike=33.0, dip=50.0, rake=120.0,
+    output_path="syn", calc_upar=True,
+)
+# END SYN

--- a/docs/source/Tutorial/modal/run_library/run.sh
+++ b/docs/source/Tutorial/modal/run_library/run.sh
@@ -23,4 +23,6 @@ grt modsum -Cphase_L.nc -Ds2,4 -Dr0,2 -R80,100,120 -N0 -OGRN -W4 -e
 grt syn -GGRN -Ds4 -Dr2 -R100 -S1e24 -A30 -M33/50/120 -Osyn -e
 # END SYN
 
+python run.py
+
 rm -rf GRN *.nc syn

--- a/docs/source/Tutorial/modal/run_modsum/run.py
+++ b/docs/source/Tutorial/modal/run_modsum/run.py
@@ -1,0 +1,25 @@
+import pygrt
+
+# BEGIN
+pymod = pygrt.PyModel1D(grn="GRN", modelpath="milrow")
+
+# Calculate Full-wave
+pymod.greenfn(depsrc=2.0, deprcv=0.0, dists=100.0, nt=200, dt=0.5, upsampling_n=5, calc_upar=True)
+
+# Calculate Surface-wave
+pymod.eigenv(wtype="R", freqs=(0.0, 1.0, 0.01), phase_path="phase_R.nc", all_modes=True)
+pymod.eigenv(wtype="L", freqs=(0.0, 1.0, 0.01), phase_path="phase_L.nc", all_modes=True)
+
+# 0th order
+pymod.modsum(phase_path="phase_R.nc", depsrc=2.0, deprcv=0.0, dists=100.0, modes=0, output_path="GRN_NM_0", upsampling_n=5, calc_upar=True)
+pymod.modsum(phase_path="phase_L.nc", depsrc=2.0, deprcv=0.0, dists=100.0, modes=0, output_path="GRN_NM_0", upsampling_n=5, calc_upar=True)
+# 1st order
+pymod.modsum(phase_path="phase_R.nc", depsrc=2.0, deprcv=0.0, dists=100.0, modes=1, output_path="GRN_NM_1", upsampling_n=5, calc_upar=True)
+pymod.modsum(phase_path="phase_L.nc", depsrc=2.0, deprcv=0.0, dists=100.0, modes=1, output_path="GRN_NM_1", upsampling_n=5, calc_upar=True)
+# 2nd order
+pymod.modsum(phase_path="phase_R.nc", depsrc=2.0, deprcv=0.0, dists=100.0, modes=2, output_path="GRN_NM_2", upsampling_n=5, calc_upar=True)
+pymod.modsum(phase_path="phase_L.nc", depsrc=2.0, deprcv=0.0, dists=100.0, modes=2, output_path="GRN_NM_2", upsampling_n=5, calc_upar=True)
+# all
+pymod.modsum(phase_path="phase_R.nc", depsrc=2.0, deprcv=0.0, dists=100.0, all_modes=True, output_path="GRN_NM_all", upsampling_n=5, calc_upar=True)
+pymod.modsum(phase_path="phase_L.nc", depsrc=2.0, deprcv=0.0, dists=100.0, all_modes=True, output_path="GRN_NM_all", upsampling_n=5, calc_upar=True)
+# END

--- a/docs/source/Tutorial/modal/run_modsum/run.sh
+++ b/docs/source/Tutorial/modal/run_modsum/run.sh
@@ -37,4 +37,6 @@ python compare_wave.py 1
 python compare_wave.py 2
 python compare_wave.py all
 
+python run.py
+
 rm -rf GRN* *.nc

--- a/docs/source/Tutorial/modal/surface_wave.rst
+++ b/docs/source/Tutorial/modal/surface_wave.rst
@@ -7,7 +7,7 @@
 根据留数定理，本征值处对波数积分的贡献可以解析地表达。将多个本征值得到的贡献叠加起来就得到面波格林函数，
 这个方法也被称为 **模态叠加法（Modal Summation Method）** 。 |yao2026p| 给出了推导过程和具体公式，这里不再重复。
 
-C 模块为 :doc:`/Module/modsum` （Python函数将于后续版本增加），
+C 模块为 :doc:`/Module/modsum`，Python 中对应 :meth:`PyModel1D.modsum() <pygrt.pymod.PyModel1D.modsum>`，
 计算将基于 :doc:`/Module/eigenv` 模块的频散结果及其内嵌的模型。
 :doc:`/Module/modsum` 模块保存的波形格式与 :doc:`/Module/greenfn` 模块一致。
 
@@ -19,10 +19,25 @@ C 模块为 :doc:`/Module/modsum` （Python函数将于后续版本增加），
 其中面波波形的时域长度和间隔通过 :doc:`/Module/eigenv` 模块中频域的设置间接确定，
 即 *T = 1 / df* , *dt = 1 / (2\*fmax)* 。
 
-.. literalinclude:: run_modsum/run.sh
-    :language: bash
-    :start-after: BEGIN
-    :end-before: END
+.. tabs::
+
+    .. group-tab:: CLI
+
+        .. literalinclude:: run_modsum/run.sh
+            :language: bash
+            :start-after: BEGIN
+            :end-before: END
+
+    .. group-tab:: Python
+
+        **modsum** 未显式传入 *output_path* 时，会将结果写入构造
+        :class:`~pygrt.pymod.PyModel1D` 时指定的 *grn* 根目录。
+        下例与 CLI 一样为不同阶数指定了各自的输出目录。
+
+        .. literalinclude:: run_modsum/run.py
+            :language: python
+            :start-after: BEGIN
+            :end-before: END
 
 :download:`compare_wave.py <run_modsum/compare_wave.py>` （虚线为全波解，实线为面波解）
 

--- a/docs/source/Tutorial/static/index.rst
+++ b/docs/source/Tutorial/static/index.rst
@@ -41,7 +41,7 @@
         classDef cmdcls fill:#FBE8CE,stroke:#BFA28C,stroke-width:2px,color:#333;
         class GG,SS,EE,RR,TT,SP,CO cmdcls
 
-+ C (module name)
++ CLI (module name)
 
 .. mermaid::
 


### PR DESCRIPTION
- Add Python tutorial tabs and example scripts for `eigenv`, `eigenfn`, `modsum`, and surface-wave library construction.
- Update the modal workflow diagrams to show both Python methods and CLI modules.
- Align a few remaining "C (module name)" headings with the existing CLI wording. Documentation only.
