### PR TITLE
FIX: assign rake-only -M values in static_sproj

### DIFF
--- a/pygrt/C_extension/src/static/grt_static_sproj.c
+++ b/pygrt/C_extension/src/static/grt_static_sproj.c
@@ -109,8 +109,8 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                 // 先按 + 拆分主参数和可选的强制标记
                 char *string = strdup(optarg);
                 char *token = strtok(string, "+");
-                real_t strike = 0.0, dip = 0.0, rake = 0.0;
-                int nscan = token == NULL ? 0 : sscanf(token, "%lf/%lf/%lf", &strike, &dip, &rake);
+                real_t a1 = 0.0, a2 = 0.0, a3 = 0.0;
+                int nscan = (token == NULL) ? 0 : sscanf(token, "%lf/%lf/%lf", &a1, &a2, &a3);
                 if((nscan != 1) && (nscan != 3)){
                     GRT_SAFE_FREE_PTR(string);
                     GRTBadOptionError(M, "Expect <rake> or <strike>/<dip>/<rake>.");
@@ -119,21 +119,21 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                 Ctrl->M.active = true;
                 Ctrl->M.has_geometry = nscan == 3;
                 if(nscan == 3){
-                    Ctrl->M.strike = strike;
-                    Ctrl->M.dip = dip;
-                    Ctrl->M.rake = rake;
-                    if(!isfinite(strike) || (strike < 0.0) || (strike > 360.0)){
+                    Ctrl->M.strike = a1;
+                    Ctrl->M.dip = a2;
+                    Ctrl->M.rake = a3;
+                    if(!isfinite(Ctrl->M.strike) || (Ctrl->M.strike < 0.0) || (Ctrl->M.strike > 360.0)){
                         GRT_SAFE_FREE_PTR(string);
                         GRTBadOptionError(M, "Strike must be in [0, 360].");
                     }
-                    if(!isfinite(dip) || (dip < 0.0) || (dip > 90.0)){
+                    if(!isfinite(Ctrl->M.dip) || (Ctrl->M.dip < 0.0) || (Ctrl->M.dip > 90.0)){
                         GRT_SAFE_FREE_PTR(string);
                         GRTBadOptionError(M, "Dip must be in [0, 90].");
                     }
                 } else {
-                    Ctrl->M.rake = rake;
+                    Ctrl->M.rake = a1;
                 }
-                if(!isfinite(rake) || (rake < -180.0) || (rake > 180.0)){
+                if(!isfinite(Ctrl->M.rake) || (Ctrl->M.rake < -180.0) || (Ctrl->M.rake > 180.0)){
                     GRT_SAFE_FREE_PTR(string);
                     GRTBadOptionError(M, "Rake must be in [-180, 180].");
                 }

--- a/test/static_sproj/test_static_sproj.py
+++ b/test/static_sproj/test_static_sproj.py
@@ -139,5 +139,10 @@ assert np.all(np.isfinite(finite_defined["sigma_n"]))
 assert np.all(np.isfinite(finite_defined["tau_s"]))
 assert np.all(np.isfinite(finite_no_rake["sigma_n"]))
 assert np.all(np.isfinite(finite_no_rake["tau_s"]))
+# -M40 只传入 rake，必须按 40° 而不是 0° 投影
+for index in range(finite_no_rake["sigma_n"].size):
+    expected_sigma, expected_tau = project_zne(finite_no_rake, 20.0, 45.0, 40.0, index)
+    np.testing.assert_allclose(finite_no_rake["sigma_n"].flat[index], expected_sigma, rtol=1e-12, atol=1e-8)
+    np.testing.assert_allclose(finite_no_rake["tau_s"].flat[index], expected_tau, rtol=1e-12, atol=1e-8)
 
 print("test_sproj.py: all checks passed")


### PR DESCRIPTION
- `grt static sproj -M<rake>` (and `-M<rake>+f`) stored the angle as strike and left rake at 0, so finite-receiver Coulomb projection used the wrong slip direction.
- Parse `<rake>` vs `<strike>/<dip>/<rake>` from positional slots and assert `-M40` against an independent ZNE projection.
