### PR TITLE
FEAT: add nthreads to Python wrappers and guard PTAM stats files

### DIFF
--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -168,6 +168,13 @@ def _normalize_integer(value: int, name: str, minimum: int = 0) -> int:
     return number
 
 
+def _nthreads_option(nthreads: Optional[int]) -> Optional[str]:
+    """将线程数格式化为 CLI ``-P`` 选项，``None`` 表示使用全部核心"""
+    if nthreads is None:
+        return None
+    return f"-P{_normalize_integer(nthreads, 'nthreads', minimum=1)}"
+
+
 def _ensure_parent(path: PathLike) -> None:
     """确保输出文件的父目录存在"""
     Path(path).parent.mkdir(parents=True, exist_ok=True)
@@ -329,6 +336,7 @@ class PyModel1D:
         cmax: Optional[float] = None,
         iref: Optional[int] = None,
         ctrl_kw: Optional[Dict[str, float]] = None,
+        nthreads: Optional[int] = None,
         print_log: bool = True,
     ):
         r"""
@@ -367,8 +375,11 @@ class PyModel1D:
                                    decimal exponents of the CLI thresholds
                                    (``tol=3`` means :math:`10^{-3}`), while
                                    ``dc`` is a uniform search interval in km/s.
-        :param    print_log:       If false, pass ``-s`` and capture command
-                                   output on failure.
+        :param    nthreads:        Number of OpenMP threads. ``None`` uses all
+                                   cores (CLI ``-P``).
+        :param    print_log:       If false, suppress command output and
+                                   capture it on failure. Warnings and
+                                   diagnostics from ``grt`` are still printed.
 
         :return: ``None``. The dispersion file is written to ``phase_path`` in
                  ordinary mode.
@@ -469,8 +480,9 @@ class PyModel1D:
         if ctrl_option is not None:
             command["T"] = ctrl_option
 
-        if not print_log:
-            command["s"] = "-s"
+        nthreads_option = _nthreads_option(nthreads)
+        if nthreads_option is not None:
+            command["P"] = nthreads_option
 
         run_grt(list(command.values()), print_log=print_log)
 
@@ -587,6 +599,7 @@ class PyModel1D:
         ref_first_p: bool = False,
         gf_source: Optional[Iterable[str]] = None,
         calc_upar: bool = False,
+        nthreads: Optional[int] = None,
         print_log: bool = True,
     ):
         r"""
@@ -624,8 +637,11 @@ class PyModel1D:
                                    ``HF`` and ``DC``. ``None`` means all types.
         :param    calc_upar:       If true, also compute spatial displacement
                                    derivatives.
+        :param    nthreads:        Number of OpenMP threads. ``None`` uses all
+                                   cores (CLI ``-P``).
         :param    print_log:       If false, suppress command output and capture it
-                                   on failure.
+                                   on failure. Warnings and diagnostics from
+                                   ``grt`` are still printed.
 
         :return: ``None``. Green's-function SAC files are written below the output root.
         """
@@ -694,6 +710,9 @@ class PyModel1D:
             command["W"] = f"-W{_normalize_integer(upsampling_n, 'upsampling_n', minimum=1)}"
         if calc_upar:
             command["e"] = "-e"
+        nthreads_option = _nthreads_option(nthreads)
+        if nthreads_option is not None:
+            command["P"] = nthreads_option
         run_grt(list(command.values()), print_log=print_log)
 
     def greenfn(
@@ -725,6 +744,7 @@ class PyModel1D:
         calc_upar: bool = False,
         gf_source: Optional[Iterable[str]] = None,
         statsidxs: Optional[Sequence[int]] = None,
+        nthreads: Optional[int] = None,
         print_log: bool = True,
     ):
         r"""
@@ -789,6 +809,8 @@ class PyModel1D:
         :param    statsidxs:         Frequency indexes for optional statistics output.
                                      ``None`` means no statistics files. An empty list means
                                      all frequency indexes (CLI bare ``-S``).
+        :param    nthreads:          Number of OpenMP threads. ``None`` uses all cores
+                                     (CLI ``-P``).
         :param    print_log:         Whether to print calculation logs. Warnings
                                      and diagnostics from ``grt`` are always printed.
 
@@ -880,9 +902,12 @@ class PyModel1D:
         if statsidxs is not None:
             command["S"] = "-S" + ",".join(str(index) for index in statsidxs)
 
-        # Build the derivative and logging options.
+        # Build the derivative and thread-count options.
         if calc_upar:
             command["e"] = "-e"
+        nthreads_option = _nthreads_option(nthreads)
+        if nthreads_option is not None:
+            command["P"] = nthreads_option
 
         run_grt(list(command.values()), print_log=print_log)
 

--- a/pygrt/utils.py
+++ b/pygrt/utils.py
@@ -911,7 +911,9 @@ def read_statsfile_ptam(statsfile:str):
     '''
         read a statsfile from PTAM process  
 
-        :param    statsfile:       File path (Wildcards can be used to simplify input)
+        :param    statsfile:       PTAM stats file path. The basename must start
+                                   with ``PTAM``. Wildcards can be used to
+                                   simplify input.
 
         :return:
             - **data1** -     `numpy.ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_ custom type array, during DCM or (SA)FIM
@@ -924,11 +926,17 @@ def read_statsfile_ptam(statsfile:str):
         raise OSError(f"{statsfile} should only match one file, but {len(Lst)} matched.")
     statsfile = Lst[0]
 
+    # 必须是 PTAM 开头的统计文件，避免误读 K/C 核函数文件
+    PTAMname = os.path.basename(statsfile)
+    if not PTAMname.startswith("PTAM"):
+        raise ValueError(
+            f"{statsfile} is not a PTAM stats file; the basename must start with 'PTAM'."
+        )
+
     # 获得震中距
     dist = float(os.path.dirname(statsfile).split("_")[-1])
 
     # 从文件路径命名中，获得对应的K文件路径
-    PTAMname = os.path.basename(statsfile)
     if "_" in PTAMname:  # 动态解
         splits = PTAMname.split("_")
         splits[-3] = "K"

--- a/test/_compare_c_py/test_cli_args.py
+++ b/test/_compare_c_py/test_cli_args.py
@@ -93,6 +93,15 @@ def test_print_log_forwarded_to_run_grt():
         model.greenfn(depsrc=1.0, deprcv=0.0, dists=1.0, nt=8, dt=0.1, print_log=False)
         assert runner.kwargs[-1].get("print_log") is False
         assert "-s" not in runner.commands[-1]
+
+        model.eigenv(
+            wtype="R",
+            freqs=(0.0, 1.0, 0.1),
+            phase_path=HERE / "_tmp_args_phase.nc",
+            print_log=False,
+        )
+        assert runner.kwargs[-1].get("print_log") is False
+        assert "-s" not in runner.commands[-1]
     finally:
         _restore_run_grt(pygrt.pymod, original)
 
@@ -196,6 +205,7 @@ def test_greenfn_default_and_optional_flags():
             calc_upar=True,
             gf_source=["EX", "DC", "HF"],
             statsidxs=[0, 3, 7],
+            nthreads=4,
             print_log=False,
         )
         cmd = runner.commands[-1]
@@ -216,6 +226,7 @@ def test_greenfn_default_and_optional_flags():
             "-Gesh",
             "-S0,3,7",
             "-e",
+            "-P4",
         )
 
         # ref_first_p 对应 -Ep
@@ -270,6 +281,7 @@ def test_modal_cli_argument_mapping():
             phase_path=phase,
             all_modes=True,
             ctrl_kw={"tol": 3.0, "cgap": 7.0, "thrd": 4.0, "vgap": 7.0, "dc": 3.0},
+            nthreads=2,
             print_log=False,
         )
         assert_command_equals(
@@ -282,7 +294,7 @@ def test_modal_cli_argument_mapping():
                 f"-C{phase}",
                 "-N",
                 "-T+t3+c7+r4+v7+u3",
-                "-s",
+                "-P2",
             ],
         )
         assert runner.kwargs[-1].get("print_log") is False
@@ -338,6 +350,7 @@ def test_modal_cli_argument_mapping():
             delayV0=3.4,
             gf_source=["EX", "VF", "HF", "DC"],
             calc_upar=True,
+            nthreads=8,
             print_log=False,
         )
         assert_command_equals(
@@ -355,6 +368,7 @@ def test_modal_cli_argument_mapping():
                 "-Gevhs",
                 "-W4",
                 "-e",
+                "-P8",
             ],
         )
         assert runner.kwargs[-1].get("print_log") is False
@@ -368,7 +382,7 @@ def test_modal_cli_argument_mapping():
         )
         assert_command_equals(
             runner.commands[-1],
-            ["eigenv", f"-M{MODEL}", "-SR", "-F1/5/1+p", f"-C{phase}", "-N2", "-s"],
+            ["eigenv", f"-M{MODEL}", "-SR", "-F1/5/1+p", f"-C{phase}", "-N2"],
         )
 
         model.eigenfn(
@@ -460,6 +474,13 @@ def test_modal_cli_argument_mapping():
             assert "depth" in str(exc)
         else:
             raise AssertionError("eigenfn should reject a single nonpositive depth")
+
+        try:
+            model.greenfn(depsrc=1.0, deprcv=0.0, dists=1.0, nt=8, dt=0.1, nthreads=0)
+        except ValueError as exc:
+            assert "nthreads" in str(exc)
+        else:
+            raise AssertionError("greenfn should reject nonpositive nthreads")
     finally:
         _restore_run_grt(pygrt.pymod, original)
 
@@ -874,6 +895,19 @@ def test_format_helpers():
         raise AssertionError("format_range should reject non-3-length input")
 
 
+def test_read_statsfile_ptam_requires_prefix():
+    dummy = HERE / "K_dummy_stats"
+    dummy.write_bytes(b"not-ptam")
+    try:
+        pygrt.utils.read_statsfile_ptam(str(dummy))
+    except ValueError as exc:
+        assert "PTAM" in str(exc)
+    else:
+        raise AssertionError("read_statsfile_ptam should reject non-PTAM filenames")
+    finally:
+        dummy.unlink(missing_ok=True)
+
+
 def main():
     tests = [
         test_format_helpers,
@@ -889,6 +923,7 @@ def main():
         test_static_sproj_and_coulomb_args,
         test_tensor_return_result_reads_prefix_only,
         test_renamed_interfaces_fail_with_migration_message,
+        test_read_statsfile_ptam_requires_prefix,
     ]
     for func in tests:
         print(f"[RUN] {func.__name__}")


### PR DESCRIPTION
- Add optional `nthreads` (`-P`) to `PyModel1D.greenfn`, `eigenv`, and `modsum`. `None` still uses all cores.
- Stop sending CLI `-s` when `print_log=False`, so `run_grt` can still surface `grt` warnings; silence is handled by capturing stdout.
- `read_statsfile_ptam` now requires a `PTAM*` basename before reading companion `K` files.
