### PR TITLE
REFAC: support complex horizontal wavenumbers

### DIFF
--- a/pygrt/C_extension/include/grt/common/model.h
+++ b/pygrt/C_extension/include/grt/common/model.h
@@ -49,7 +49,7 @@ typedef struct {
     MODEL1D *mod1d;
 
     cplx_t omega;   ///< 圆频率
-    real_t k;   ///< 波数
+    cplx_t k;   ///< 波数
     cplx_t c_phase;   ///< 当前相速度
 
     cplx_t *mu;       ///< mu[n] \f$ V_b^2 * \rho \f$
@@ -231,9 +231,9 @@ void grt_update_mod1d_state_omega(MODEL1D_STATE *mstat, const cplx_t omega, cons
  * 根据记录好的圆频率，给定波数，计算相速度和每层的 xa, xb, caca, cbcb
  * 
  * @param[in,out]      mstat     `MODEL1D_STATE` 结构体指针
- * @param[in]          k        波数
+ * @param[in]          k        复数波数
  */
-void grt_update_mod1d_state_k(MODEL1D_STATE *mstat, const real_t k);
+void grt_update_mod1d_state_k(MODEL1D_STATE *mstat, const cplx_t k);
 
 
 /**
@@ -276,4 +276,3 @@ bool grt_check_vel_in_mod(const MODEL1D *mod1d, const real_t vel, const real_t t
  * 
  */
 void grt_get_mod1d_vmin_vmax(const MODEL1D *mod1d, real_t *vmin, real_t *vmax);
-

--- a/pygrt/C_extension/include/grt/integral/kernel.h
+++ b/pygrt/C_extension/include/grt/integral/kernel.h
@@ -15,7 +15,7 @@
 /**
  * 计算核函数的函数指针，动态与静态的接口一致
  */
-typedef void (*GRT_KernelFunc) (MODEL1D_STATE *mstat, const real_t k, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz);
+typedef void (*GRT_KernelFunc) (MODEL1D_STATE *mstat, const cplx_t k, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz);
 
 
 /**
@@ -80,25 +80,25 @@ typedef void (*GRT_KernelFunc) (MODEL1D_STATE *mstat, const real_t k, cplxChnlGr
  *  计算相应的矩阵。  
  *
  *  @param[in,out]     mstat       `MODEL1D_STATE` 结构体指针
- *  @param[in]     k               波数
+ *  @param[in]     k               复数波数
  *  @param[out]    QWV             不同震源，不同阶数的核函数 \f$ q_m, w_m, v_m \f$
  *  @param[in]     calc_uiz        是否计算ui_z（位移u对坐标z的偏导）
  *  @param[out]    QWV_uiz         不同震源，不同阶数的核函数对z的偏导 \f$ \frac{\partial q_m}{\partial z}, \frac{\partial w_m}{\partial z}, \frac{\partial v_m}{\partial z} \f$
  * 
  */
-void grt_kernel(MODEL1D_STATE *mstat, const real_t k, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz);
+void grt_kernel(MODEL1D_STATE *mstat, const cplx_t k, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz);
 
 /** 构建广义反射透射系数矩阵。作为 kernel 函数中的第一部分 */
-void grt_GRT_matrix(MODEL1D_STATE *mstat, const real_t k);
+void grt_GRT_matrix(MODEL1D_STATE *mstat, const cplx_t k);
 
 /** 从广义 R/T 矩阵出发，计算每个震源对应的核函数 QWV。 作为 kernel 函数中的第二部分 */
 void grt_GRT_build_QWV(MODEL1D_STATE *mstat, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz);
 
 /** 静态解的核函数 */
-void grt_static_kernel(MODEL1D_STATE *mstat, const real_t k, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz);
+void grt_static_kernel(MODEL1D_STATE *mstat, const cplx_t k, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz);
 
 /** 静态广义反射透射系数矩阵 */
-void grt_static_GRT_matrix(MODEL1D_STATE *mstat, const real_t k);
+void grt_static_GRT_matrix(MODEL1D_STATE *mstat, const cplx_t k);
 
 /** 静态 QWV */
 void grt_static_GRT_build_QWV(MODEL1D_STATE *mstat, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz);

--- a/pygrt/C_extension/include/grt/modal/secular.h
+++ b/pygrt/C_extension/include/grt/modal/secular.h
@@ -16,26 +16,26 @@
  * 计算所有层位的两个 P-SV 广义矩阵： RD_RL, RU_FR 
  * 
  * @param[in]      mstat        模型结构体指针
- * @param[in]      k            本征波数
+ * @param[in]      k            复数本征波数
  * @param[out]     Mall_RL      所有层的 RD_RL 矩阵
  * @param[out]     Mall_FR      所有层的 RU_FR 矩阵
  */
-void grt_GRT_matrix_allLayer_Rayl(MODEL1D_STATE *mstat, const real_t k, RT_MATRIX *Mall_RL, RT_MATRIX *Mall_FR);
+void grt_GRT_matrix_allLayer_Rayl(MODEL1D_STATE *mstat, const cplx_t k, RT_MATRIX *Mall_RL, RT_MATRIX *Mall_FR);
 
 /** 计算所有层位的两个  P-SV 广义矩阵： RD_RL, RU_FR  */
-void grt_GRT_matrix_allLayer_Love(MODEL1D_STATE *mstat, const real_t k, RT_MATRIX *Mall_RL, RT_MATRIX *Mall_FR);
+void grt_GRT_matrix_allLayer_Love(MODEL1D_STATE *mstat, const cplx_t k, RT_MATRIX *Mall_RL, RT_MATRIX *Mall_FR);
 
 /** 
  * 计算指定层位 iref 处的两个 SH 广义矩阵(标量)： RDL_RL, RUL_FR 
  * 
  * @param[in]      mstat        模型结构体指针
- * @param[in]      k            本征波数
+ * @param[in]      k            复数本征波数
  * @param[in]      iref         当前层位
  */
-void grt_GRT_matrix_Rayl(MODEL1D_STATE *mstat, const real_t k, const size_t iref);
+void grt_GRT_matrix_Rayl(MODEL1D_STATE *mstat, const cplx_t k, const size_t iref);
 
 /** 计算所有层位的两个 SH 广义矩阵(标量)： RDL_RL, RUL_FR   */
-void grt_GRT_matrix_Love(MODEL1D_STATE *mstat, const real_t k, const size_t iref);
+void grt_GRT_matrix_Love(MODEL1D_STATE *mstat, const cplx_t k, const size_t iref);
 
 
 

--- a/pygrt/C_extension/src/common/model.c
+++ b/pygrt/C_extension/src/common/model.c
@@ -43,6 +43,13 @@
     X(caca, cplx_t)\
     X(cbcb, cplx_t)\
 
+
+static cplx_t select_vertical_root(const cplx_t k, const cplx_t root)
+{
+    // 选择使垂向传播因子不增长的根
+    return (creal(k*root) < 0.0) ? -root : root;
+}
+
     
 MODEL1D * grt_init_mod1d(size_t n)
 {
@@ -491,7 +498,7 @@ void grt_update_mod1d_state_omega(MODEL1D_STATE *mstat, const cplx_t omega, cons
 }
 
 
-void grt_update_mod1d_state_k(MODEL1D_STATE *mstat, const real_t k)
+void grt_update_mod1d_state_k(MODEL1D_STATE *mstat, const cplx_t k)
 {
     MODEL1D *mod1d = mstat->mod1d;
     mstat->k = k;
@@ -523,12 +530,12 @@ void grt_update_mod1d_state_k(MODEL1D_STATE *mstat, const real_t k)
         caca = mstat->c_phase / (va*atna); 
         caca *= caca;
         mstat->caca[i] = caca;
-        mstat->xa[i] = sqrt(1.0 - caca);
+        mstat->xa[i] = select_vertical_root(k, sqrt(1.0 - caca));
         
         cbcb = (mod1d->isLiquid[i])? 0.0 : mstat->c_phase / (vb*atnb);  // 考虑液体层
         cbcb *= cbcb;
         mstat->cbcb[i] = cbcb;
-        mstat->xb[i] = sqrt(1.0 - cbcb);
+        mstat->xb[i] = select_vertical_root(k, sqrt(1.0 - cbcb));
     }
 }
 

--- a/pygrt/C_extension/src/dynamic/layer.c
+++ b/pygrt/C_extension/src/dynamic/layer.c
@@ -170,7 +170,7 @@ void grt_botbound_RD_PSV(MODEL1D_STATE *mstat)
     }
 
     // 时延 RD
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     real_t thk = mod1d->Thk[nlay-2];
 
     cplx_t exa, exb, ex2a, ex2b, exab;
@@ -204,7 +204,7 @@ void grt_botbound_RD_SH(MODEL1D_STATE *mstat)
     }
 
     // 时延 RD
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     real_t thk = mod1d->Thk[nlay-2];
 
     cplx_t exb, ex2b;
@@ -222,7 +222,7 @@ void grt_wave2qwv_REV_PSV(MODEL1D_STATE *mstat)
     cplx_t xa = mstat->xa[ircv];
     cplx_t xb = mstat->xb[ircv];
     bool   isLiquid = mod1d->isLiquid[ircv];
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
 
     cplx_t D11[2][2], D12[2][2];
     if( ! isLiquid){
@@ -256,7 +256,7 @@ void grt_wave2qwv_REV_SH(MODEL1D_STATE *mstat)
     MODEL1D *mod1d = mstat->mod1d;
     size_t ircv = mod1d->ircv;
     bool   isLiquid = mod1d->isLiquid[ircv];
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
 
     if( ! isLiquid){
         // 位于固体层
@@ -280,7 +280,7 @@ void grt_wave2qwv_z_REV_PSV(MODEL1D_STATE *mstat)
     cplx_t xa = mstat->xa[ircv];
     cplx_t xb = mstat->xb[ircv];
     bool   isLiquid = mod1d->isLiquid[ircv];
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
 
 
     // 将垂直波函数转为ui,z在(B_m, P_m, C_m)系下的分量
@@ -314,7 +314,7 @@ void grt_wave2qwv_z_REV_SH(MODEL1D_STATE *mstat)
     size_t ircv = mod1d->ircv;
     cplx_t xb = mstat->xb[ircv];
     bool   isLiquid = mod1d->isLiquid[ircv];
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     
     // 将垂直波函数转为ui,z在(B_m, P_m, C_m)系下的分量
     // 新推导的公式
@@ -729,7 +729,7 @@ void grt_delay_RT_matrix(const MODEL1D_STATE *mstat, const size_t iy, RT_MATRIX 
     real_t thk = mod1d->Thk[iy-1];
     cplx_t xa1 = mstat->xa[iy-1];
     cplx_t xb1 = mstat->xb[iy-1];
-    real_t k   = mstat->k;
+    cplx_t k   = mstat->k;
 
     cplx_t exa, exb, ex2a, ex2b, exab;
     exa = exp(- k*thk*xa1);
@@ -760,7 +760,7 @@ void grt_delay_RT_matrix_PSV(const MODEL1D_STATE *mstat, const size_t iy, RT_MAT
     real_t thk = mod1d->Thk[iy-1];
     cplx_t xa1 = mstat->xa[iy-1];
     cplx_t xb1 = mstat->xb[iy-1];
-    real_t k   = mstat->k;
+    cplx_t k   = mstat->k;
 
     cplx_t exa, exb, ex2a, ex2b, exab;
     exa = exp(- k*thk*xa1);
@@ -784,7 +784,7 @@ void grt_delay_RT_matrix_SH(const MODEL1D_STATE *mstat, const size_t iy, RT_MATR
     MODEL1D *mod1d = mstat->mod1d;
     real_t thk = mod1d->Thk[iy-1];
     cplx_t xb1 = mstat->xb[iy-1];
-    real_t k   = mstat->k;
+    cplx_t k   = mstat->k;
 
     cplx_t exb, ex2b;
     exb = exp(- k*thk*xb1);
@@ -803,7 +803,7 @@ void grt_delay_GRT_matrix(const MODEL1D_STATE *mstat, const size_t iy, RT_MATRIX
     real_t thk = mod1d->Thk[iy-1];
     cplx_t xa1 = mstat->xa[iy-1];
     cplx_t xb1 = mstat->xb[iy-1];
-    real_t k   = mstat->k;
+    cplx_t k   = mstat->k;
     
     cplx_t exa, exb, ex2a, ex2b, exab;
     exa = exp(- k*thk*xa1);
@@ -830,8 +830,8 @@ void grt_delay_GRT_matrix(const MODEL1D_STATE *mstat, const size_t iy, RT_MATRIX
 void grt_get_layer_D(const MODEL1D_STATE *mstat, const size_t iy, bool inverse, int liquid_invtype, cplx_t D[4][4])
 {
     // 第iy层物理量
-    real_t k = mstat->k;
-    real_t kk = k*k;
+    cplx_t k = mstat->k;
+    cplx_t kk = k*k;
     cplx_t xa = mstat->xa[iy];
     cplx_t xb = mstat->xb[iy];
     cplx_t mu = mstat->mu[iy];
@@ -900,7 +900,7 @@ void grt_get_layer_D(const MODEL1D_STATE *mstat, const size_t iy, bool inverse, 
 
 void grt_get_layer_D11(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][2])
 {
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     cplx_t xa = mstat->xa[iy];
     cplx_t xb = mstat->xb[iy];
     if(! mstat->mod1d->isLiquid[iy]){
@@ -915,7 +915,7 @@ void grt_get_layer_D11(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][
 
 void grt_get_layer_D12(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][2])
 {
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     cplx_t xa = mstat->xa[iy];
     cplx_t xb = mstat->xb[iy];
     if(! mstat->mod1d->isLiquid[iy]){
@@ -929,7 +929,7 @@ void grt_get_layer_D12(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][
 
 void grt_get_layer_D11_uiz(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][2])
 {
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     cplx_t xa = mstat->xa[iy];
     cplx_t xb = mstat->xb[iy];
     cplx_t a = k*xa;
@@ -946,7 +946,7 @@ void grt_get_layer_D11_uiz(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D
 
 void grt_get_layer_D12_uiz(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][2])
 {
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     cplx_t xa = mstat->xa[iy];
     cplx_t xb = mstat->xb[iy];
     cplx_t a = k*xa;
@@ -963,7 +963,7 @@ void grt_get_layer_D12_uiz(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D
 
 void grt_get_layer_D21(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][2])
 {
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     cplx_t xa = mstat->xa[iy];
     cplx_t xb = mstat->xb[iy];
     cplx_t mu = mstat->mu[iy];
@@ -983,7 +983,7 @@ void grt_get_layer_D21(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][
 
 void grt_get_layer_D22(const MODEL1D_STATE *mstat, const size_t iy, cplx_t D[2][2])
 {
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     cplx_t xa = mstat->xa[iy];
     cplx_t xb = mstat->xb[iy];
     cplx_t mu = mstat->mu[iy];
@@ -1007,7 +1007,7 @@ void grt_get_layer_T(const MODEL1D_STATE *mstat, const size_t iy, bool inverse, 
         GRTRaiseError("Wrong execution.");
     }
 
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
     cplx_t xb = mstat->xb[iy];
     cplx_t mu = mstat->mu[iy];
 

--- a/pygrt/C_extension/src/dynamic/source.c
+++ b/pygrt/C_extension/src/dynamic/source.c
@@ -18,7 +18,7 @@
 
 inline GCC_ALWAYS_INLINE void _source_PSV(
     const cplx_t xa, const cplx_t caca, 
-    const cplx_t xb, const cplx_t cbcb, const real_t k, cplxChnlGrid coefD, cplxChnlGrid coefU)
+    const cplx_t xb, const cplx_t cbcb, const cplx_t k, cplxChnlGrid coefD, cplxChnlGrid coefU)
 {
     cplx_t tmp;
 
@@ -47,7 +47,7 @@ inline GCC_ALWAYS_INLINE void _source_PSV(
 
 }
 
-inline GCC_ALWAYS_INLINE void _source_SH(const cplx_t xb, const cplx_t cbcb, const real_t k, cplxChnlGrid coefD, cplxChnlGrid coefU)
+inline GCC_ALWAYS_INLINE void _source_SH(const cplx_t xb, const cplx_t cbcb, const cplx_t k, cplxChnlGrid coefD, cplxChnlGrid coefU)
 {
     cplx_t tmp;
 
@@ -81,7 +81,7 @@ void grt_source_coef_PSV(const MODEL1D_STATE *mstat, cplxChnlGrid src_coefD, cpl
     cplx_t caca = mstat->caca[isrc];
     cplx_t xb = mstat->xb[isrc];
     cplx_t cbcb = mstat->cbcb[isrc];
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
 
     _source_PSV(xa, caca, xb, cbcb, k, src_coefD, src_coefU);
 }
@@ -92,9 +92,8 @@ void grt_source_coef_SH(const MODEL1D_STATE *mstat, cplxChnlGrid src_coefD, cplx
     size_t isrc = mstat->mod1d->isrc;
     cplx_t xb = mstat->xb[isrc];
     cplx_t cbcb = mstat->cbcb[isrc];
-    real_t k = mstat->k;
+    cplx_t k = mstat->k;
 
     _source_SH(xb, cbcb, k, src_coefD, src_coefU);
 }
-
 

--- a/pygrt/C_extension/src/integral/kernel_template.c_
+++ b/pygrt/C_extension/src/integral/kernel_template.c_
@@ -57,7 +57,7 @@
 #define __grt_wave2qwv_z_REV_SH   CONCAT_PREFIX(wave2qwv_z_REV_SH)
 
 
-void __GRT_MATRIX_FUNC__(MODEL1D_STATE *mstat, const real_t k)
+void __GRT_MATRIX_FUNC__(MODEL1D_STATE *mstat, const cplx_t k)
 {
     mstat->k = k;
     // 为动态解计算xa,xb,caca,cbcb
@@ -288,7 +288,7 @@ void __BUILD_QWV__(MODEL1D_STATE *mstat, cplxChnlGrid QWV, bool calc_uiz, cplxCh
 }
 
 
-void __KERNEL_FUNC__(MODEL1D_STATE *mstat, const real_t k, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz)
+void __KERNEL_FUNC__(MODEL1D_STATE *mstat, const cplx_t k, cplxChnlGrid QWV, bool calc_uiz, cplxChnlGrid QWV_uiz)
 {
     __GRT_MATRIX_FUNC__(mstat, k);
     __BUILD_QWV__(mstat, QWV, calc_uiz, QWV_uiz);

--- a/pygrt/C_extension/src/modal/eigenfn.c
+++ b/pygrt/C_extension/src/modal/eigenfn.c
@@ -48,7 +48,7 @@ static void grt_potential_propagate_UpDown_Rayl(
     cplx_t exa, exb;
     cplx_t E[2][2] = GRT_INIT_ZERO_2x2_MATRIX; 
     
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
     exa = exp(- eigenK*thk0*xa0);
     exb = exp(- eigenK*thk0*xb0);
     E[0][0] = exa;
@@ -89,7 +89,7 @@ static void grt_potential_propagate_UpDown_Love(
 
     grt_RT_matrix_SH(mstat, iy, M);
 
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
     real_t thk0 = mstat->mod1d->Thk[iy-1];
     cplx_t xb0 = mstat->xb[iy-1];
     bool *isLiquid = mstat->mod1d->isLiquid;
@@ -150,7 +150,7 @@ static void grt_potential_propagate_DownUp_Rayl(
     cplx_t exa, exb;
     cplx_t E[2][2] = GRT_INIT_ZERO_2x2_MATRIX; 
     
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
     exa = exp(- eigenK*thk0*xa0);
     exb = exp(- eigenK*thk0*xb0);
     E[0][0] = exa;
@@ -199,7 +199,7 @@ static void grt_potential_propagate_DownUp_Love(
 
     grt_RT_matrix_SH(mstat, iy+1, M);
 
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
     real_t thk0 = mstat->mod1d->Thk[iy];
     cplx_t xb0 = mstat->xb[iy];
 
@@ -235,7 +235,7 @@ void grt_get_mod_potential_Up_Down_Rayl(
     // 计算 RD_RL, RU_FR 矩阵
     RT_MATRIX *Mall_FR = (RT_MATRIX *)calloc(nlay, sizeof(RT_MATRIX));
     RT_MATRIX *Mall_RL = (RT_MATRIX *)calloc(nlay, sizeof(RT_MATRIX));
-    grt_GRT_matrix_allLayer_Rayl(mstat, mstat->k, Mall_RL, Mall_FR);
+    grt_GRT_matrix_allLayer_Rayl(mstat, creal(mstat->k), Mall_RL, Mall_FR);
 
     // 向下传播
     for(size_t iy = iref+1; iy < nlay; ++iy){
@@ -272,7 +272,7 @@ void grt_get_mod_potential_Up_Down_Love(
     // 计算 RDL_RL, RUL_FR 矩阵
     RT_MATRIX *Mall_FR = (RT_MATRIX *)calloc(nlay, sizeof(RT_MATRIX));
     RT_MATRIX *Mall_RL = (RT_MATRIX *)calloc(nlay, sizeof(RT_MATRIX));
-    grt_GRT_matrix_allLayer_Love(mstat, mstat->k, Mall_RL, Mall_FR);
+    grt_GRT_matrix_allLayer_Love(mstat, creal(mstat->k), Mall_RL, Mall_FR);
 
     // 向下传播
     for(size_t iy = iref + 1; iy < nlay; ++iy){
@@ -320,7 +320,7 @@ void grt_get_eigenfn_single_depth_Rayl(
     cplx_t xa=0.0, xb=0.0;
     memset(eigenfn, 0, sizeof(cplx_t)*4);
 
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
     xa = mstat->xa[ziref];
     xb = mstat->xb[ziref];
 
@@ -360,7 +360,7 @@ void grt_get_eigenfn_single_depth_Love(
     cplx_t xb=0.0;
     memset(eigenfn, 0, sizeof(cplx_t)*4);
 
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
     xb = mstat->xb[ziref];
 
     // 直接跳过液体层
@@ -453,4 +453,3 @@ void grt_get_eigenfn_depths(
         GRTRaiseError("Wrong execution.");
     }
 }
-

--- a/pygrt/C_extension/src/modal/energy.c
+++ b/pygrt/C_extension/src/modal/energy.c
@@ -183,7 +183,7 @@ static void energy_integrals_single_layer_Rayl(
     grt_cmatmxn_block_assign(2, 4, D2x4_uiz, 0, 2, 2, 2, D12_uiz);
     grt_cmatmxn_transpose(2, 4, D2x4_uiz, D4x2_uiz);
     
-    real_t k  = mstat->k;
+    real_t k  = creal(mstat->k);
     cplx_t xa = mstat->xa[iy];
     cplx_t xb = mstat->xb[iy];
 
@@ -250,7 +250,7 @@ static void energy_integrals_single_layer_Love(
 {
     cplx_t M[2][2] = {0};
 
-    real_t k  = mstat->k;
+    real_t k  = creal(mstat->k);
     cplx_t xb = mstat->xb[iy];
 
     // 1. (v)^2
@@ -346,7 +346,7 @@ void grt_energy_integrals_Rayl(
     ziref = last_ziref = -1;
     real_t dz=0.0, h=0.0;
 
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
     size_t cpar_nz = eigfnmet->cpar_nz;
     size_t nlay = mstat->mod1d->n;
 
@@ -452,7 +452,7 @@ void grt_energy_integrals_Love(
     ziref = last_ziref = -1;
     real_t dz=0.0, h=0.0;
 
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
     size_t cpar_nz = eigfnmet->cpar_nz;
     size_t nlay = mstat->mod1d->n;
 
@@ -558,5 +558,3 @@ void grt_energy_integrals(
         GRTRaiseError("Wrong execution.");
     }
 }
-
-

--- a/pygrt/C_extension/src/modal/grt_eigenfn.c
+++ b/pygrt/C_extension/src/modal/grt_eigenfn.c
@@ -466,8 +466,9 @@ static void grt_eigenfn_egy_udisp_phaseK_util(
             real_t cphase = eigv->c_roots[ic];
             
             local_mstat->c_phase = cphase;
-            local_mstat->k = creal(omega)/cphase;
-            grt_update_mod1d_state_k(local_mstat, local_mstat->k);
+            real_t k = creal(omega)/cphase;
+            local_mstat->k = k;
+            grt_update_mod1d_state_k(local_mstat, k);
 
             size_t iref = eigv->c_roots_iref[ic];
 
@@ -497,7 +498,7 @@ static void grt_eigenfn_egy_udisp_phaseK_util(
                     local_mstat, eigfnmet->wtype, ncols, 
                     mod_potRaylLove_Down, mod_potRaylLove_Up, eigfnmet, &eigfnmet->eigfn[iw][ic]);
                 // 计算群速度
-                eigfnmet->eigv[iw].u_roots[ic] = grt_get_group_velocity(omega, local_mstat->k, eigfnmet->eigfn[iw][ic].egyint, eigfnmet->wtype);
+                eigfnmet->eigv[iw].u_roots[ic] = grt_get_group_velocity(omega, creal(local_mstat->k), eigfnmet->eigfn[iw][ic].egyint, eigfnmet->wtype);
             }
 
             GRT_SAFE_FREE_PTR(mod_potRaylLove_Down);

--- a/pygrt/C_extension/src/modal/modgrn.c
+++ b/pygrt/C_extension/src/modal/modgrn.c
@@ -24,7 +24,7 @@ void grt_modsum_grn_Rayl(
     size_t isrc = mstat->mod1d->isrc;
     size_t ircv = mstat->mod1d->ircv;
 
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
 
     // 震源层物性参数
     cplx_t src_mu = mstat->mu[isrc];
@@ -67,7 +67,7 @@ void grt_modsum_grn_Rayl(
         cplx_t xa = mstat->xa[ircv];
         cplx_t xb = mstat->xb[ircv];
         bool   isLiquid = mstat->mod1d->isLiquid[ircv];
-        real_t k = mstat->k;
+        real_t k = creal(mstat->k);
 
         cplx_t ak = k*k*xa;
         cplx_t bk = k*k*xb;
@@ -130,7 +130,7 @@ void grt_modsum_grn_Love(
     size_t isrc = mstat->mod1d->isrc;
     size_t ircv = mstat->mod1d->ircv;
 
-    real_t eigenK = mstat->k;
+    real_t eigenK = creal(mstat->k);
 
     // 震源层物性参数
     cplx_t src_mu = mstat->mu[isrc];
@@ -167,7 +167,7 @@ void grt_modsum_grn_Love(
     if(grn->calc_upar){
         cplx_t xb = mstat->xb[ircv];
         bool   isLiquid = mstat->mod1d->isLiquid[ircv];
-        real_t k = mstat->k;
+        real_t k = creal(mstat->k);
 
         cplx_t bk = k*k*xb;
         cplx_t T0_z[GRT_LOVE_DIM][GRT_LOVE_DIM] = {{bk, -bk}};
@@ -267,8 +267,9 @@ void grt_modsum_grn_spec(MODEL1D *mod1d, const DISPER_TYPE wtype, EIGENFN_INFO *
             real_t cphase = eigv->c_roots[ic];
             
             local_mstat->c_phase = cphase;
-            local_mstat->k = creal(omega)/cphase;
-            grt_update_mod1d_state_k(local_mstat, local_mstat->k);
+            real_t k = creal(omega)/cphase;
+            local_mstat->k = k;
+            grt_update_mod1d_state_k(local_mstat, k);
 
             size_t iref = eigv->c_roots_iref[ic];
 

--- a/pygrt/C_extension/src/modal/secular.c
+++ b/pygrt/C_extension/src/modal/secular.c
@@ -22,7 +22,7 @@
 #include "grt/modal/secular.h"
 
 
-void grt_GRT_matrix_allLayer_Rayl(MODEL1D_STATE *mstat, const real_t k, RT_MATRIX *Mall_RL, RT_MATRIX *Mall_FR)
+void grt_GRT_matrix_allLayer_Rayl(MODEL1D_STATE *mstat, const cplx_t k, RT_MATRIX *Mall_RL, RT_MATRIX *Mall_FR)
 {
     mstat->k = k;
     grt_update_mod1d_state_k(mstat, k);
@@ -83,7 +83,7 @@ void grt_GRT_matrix_allLayer_Rayl(MODEL1D_STATE *mstat, const real_t k, RT_MATRI
 }
 
 
-void grt_GRT_matrix_allLayer_Love(MODEL1D_STATE *mstat, const real_t k, RT_MATRIX *Mall_RL, RT_MATRIX *Mall_FR)
+void grt_GRT_matrix_allLayer_Love(MODEL1D_STATE *mstat, const cplx_t k, RT_MATRIX *Mall_RL, RT_MATRIX *Mall_FR)
 {
     mstat->k = k;
     grt_update_mod1d_state_k(mstat, k);
@@ -142,7 +142,7 @@ void grt_GRT_matrix_allLayer_Love(MODEL1D_STATE *mstat, const real_t k, RT_MATRI
     }
 }
 
-void grt_GRT_matrix_Rayl(MODEL1D_STATE *mstat, const real_t k, const size_t iref)
+void grt_GRT_matrix_Rayl(MODEL1D_STATE *mstat, const cplx_t k, const size_t iref)
 {
     mstat->k = k;
     grt_update_mod1d_state_k(mstat, k);
@@ -222,7 +222,7 @@ void grt_GRT_matrix_Rayl(MODEL1D_STATE *mstat, const real_t k, const size_t iref
 }
 
 
-void grt_GRT_matrix_Love(MODEL1D_STATE *mstat, const real_t k, const size_t iref)
+void grt_GRT_matrix_Love(MODEL1D_STATE *mstat, const cplx_t k, const size_t iref)
 {
     mstat->k = k;
     grt_update_mod1d_state_k(mstat, k);
@@ -406,7 +406,7 @@ void grt_secular_function_potential_Rayl(
         cplx_t RU_FA_delay[2][2] = {0};
         if(isLiquid[iref-1]){
             cref = GRT_MIN(Va[iref-1], Vb[iref]);
-            cplx_t ex2a = exp( - 2.0 * mstat->k * Thk[iref-1] * mstat->xa[iref-1]);
+            cplx_t ex2a = exp( - 2.0 * creal(mstat->k) * Thk[iref-1] * mstat->xa[iref-1]);
             R3[0][0] = RU_FA_delay[0][0] = ex2a * mstat->M_FA.RU[0][0];
             R3[1][1] = mstat->M_BL.RD[0][0];
             R3[1][2] = mstat->M_BL.RD[0][1];

--- a/pygrt/C_extension/src/static/static_layer.c
+++ b/pygrt/C_extension/src/static/static_layer.c
@@ -70,7 +70,7 @@ void grt_static_topbound_RU_PSV(MODEL1D_STATE *mstat)
 {
     MODEL1D *mod1d = mstat->mod1d;
     cplx_t delta = mstat->delta[0];
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
     if(mod1d->topbound == GRT_BOUND_FREE){
         mstat->M_top.stats = __freeBound_R_PSV(0.0, k, delta, mstat->M_top.RU);
     }
@@ -112,7 +112,7 @@ void grt_static_botbound_RD_PSV(MODEL1D_STATE *mstat)
     size_t nlay = mod1d->n;
     cplx_t delta = mstat->delta[nlay-2];
     real_t thk = mod1d->Thk[nlay-2];
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
     if(mod1d->botbound == GRT_BOUND_FREE){
         mstat->M_bot.stats = __freeBound_R_PSV(thk, k, delta, mstat->M_bot.RD);
     }
@@ -140,7 +140,7 @@ void grt_static_botbound_RD_SH(MODEL1D_STATE *mstat)
     MODEL1D *mod1d = mstat->mod1d;
     size_t nlay = mod1d->n;
     real_t thk = mod1d->Thk[nlay-2];
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
     if(mod1d->botbound == GRT_BOUND_FREE){
         mstat->M_bot.stats = __freeBound_R_SH(&mstat->M_bot.RDL);
     }
@@ -189,7 +189,7 @@ void grt_static_wave2qwv_REV_SH(MODEL1D_STATE *mstat)
 void grt_static_wave2qwv_z_REV_PSV(MODEL1D_STATE *mstat)
 {
     MODEL1D *mod1d = mstat->mod1d;
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
     size_t ircv = mod1d->ircv;
     cplx_t delta1 = mstat->delta[ircv];
 
@@ -208,7 +208,7 @@ void grt_static_wave2qwv_z_REV_PSV(MODEL1D_STATE *mstat)
 
 void grt_static_wave2qwv_z_REV_SH(MODEL1D_STATE *mstat)
 {
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
     // 新推导公式
     if(mstat->mod1d->ircvup){// 震源更深
         mstat->uiz_R_EVL = (1.0 - mstat->M_FA.RUL)*k;
@@ -223,7 +223,7 @@ void grt_static_RT_matrix_PSV(const MODEL1D_STATE *mstat, const size_t iy, RT_MA
     MODEL_2LAYS_ATTRIB(mstat, cplx_t, mu);
     MODEL_2LAYS_ATTRIB(mstat, cplx_t, delta);
     real_t thk = mstat->mod1d->Thk[iy-1];
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
 
     // 公式(8.4.18)
     cplx_t dmu = mu1 - mu2;
@@ -281,7 +281,7 @@ void grt_static_RT_matrix_SH(const MODEL1D_STATE *mstat, const size_t iy, RT_MAT
 void grt_static_delay_RT_matrix(const MODEL1D_STATE *mstat, const size_t iy, RT_MATRIX *M)
 {
     real_t thk = mstat->mod1d->Thk[iy-1];
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
     
     cplx_t ex, ex2;
     ex = exp(- k*thk);

--- a/pygrt/C_extension/src/static/static_source.c
+++ b/pygrt/C_extension/src/static/static_source.c
@@ -76,7 +76,7 @@ void grt_static_source_coef_PSV(const MODEL1D_STATE *mstat, cplxChnlGrid src_coe
 {
     size_t isrc = mstat->mod1d->isrc;
     cplx_t delta = mstat->delta[isrc];
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
 
     _source_PSV(delta, k, src_coefD, src_coefU);
 }
@@ -84,9 +84,7 @@ void grt_static_source_coef_PSV(const MODEL1D_STATE *mstat, cplxChnlGrid src_coe
 
 void grt_static_source_coef_SH(const MODEL1D_STATE *mstat, cplxChnlGrid src_coefD, cplxChnlGrid src_coefU)
 {
-    real_t k = mstat->k;
+    real_t k = creal(mstat->k);
     
     _source_SH(k, src_coefD, src_coefU);
 }
-
-


### PR DESCRIPTION
Promote the shared model wavenumber state to a complex value and propagate it through dynamic, static, and modal transfer-matrix paths. Preserve real modal eigenvalue calculations while selecting non-growing vertical roots for complex-frequency computations.