### PR TITLE
FEAT: add Python receiver-function wrapper

### DIFF
--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -188,9 +188,10 @@ class PyModel1D:
 
     1. Create :class:`PyModel1D` with the Green's function path(s) actually needed
        (``grn`` and/or ``stgrn``) and optional ``modelpath``.
-    2. Compute modal dispersion and Green's functions with :meth:`eigenv`,
-       :meth:`eigenfn`, :meth:`modsum`, :meth:`greenfn` or
-       :meth:`static_greenfn` (the required paths depend on the method).
+    2. Compute modal dispersion, receiver functions and Green's functions with
+       :meth:`eigenv`, :meth:`eigenfn`, :meth:`modsum`, :meth:`rftn`,
+       :meth:`greenfn` or :meth:`static_greenfn` (the required paths depend on
+       the method).
     3. Synthesize waveforms or static fields with :meth:`syn` or
        :meth:`static_syn` (only the corresponding GF path is required).
     """
@@ -914,6 +915,136 @@ class PyModel1D:
     def compute_grn(self, *args, **kwargs):
         """Legacy interface renamed to :meth:`greenfn`; calling it raises an error."""
         raise RuntimeError("compute_grn() has been renamed to greenfn(); use greenfn() instead.")
+
+    def rftn(
+        self,
+        *,
+        wtype: str,
+        nt: int,
+        dt: float,
+        output_path: PathLike,
+        rayp: Optional[float] = None,
+        inca: Optional[float] = None,
+        idx: Optional[int] = None,
+        zeta: float = 0.8,
+        upsampling_n: int = 1,
+        keepAllFreq: bool = False,
+        skipImagComps: bool = False,
+        alp: float = 1.0,
+        delay: float = 0.0,
+        write_components: bool = False,
+        print_log: bool = True,
+    ):
+        r"""
+        Compute receiver functions for a plane incident P or SV wave.
+
+        This method wraps the ``grt rftn`` command. The incident wave is
+        specified by either a horizontal ray parameter ``rayp`` or an upward
+        incidence angle ``inca`` at the selected reverse-indexed model layer.
+        Results are written as ``P_rftn.sac`` or ``S_rftn.sac`` below
+        ``output_path``; ``write_components=True`` also writes the corresponding
+        ``Z`` and ``R`` response files. All arguments must be passed by keyword.
+
+        :param    wtype:             Incident wave type, ``"P"`` or ``"S"``.
+        :param    nt:                Number of time samples.
+        :param    dt:                Time-sample interval in s.
+        :param    output_path:       Output directory for SAC files.
+        :param    rayp:              Horizontal ray parameter in s/km. Mutually
+                                     exclusive with ``inca``.
+        :param    inca:              Upgoing incidence angle in degrees in the
+                                     selected reverse-indexed layer. Mutually
+                                     exclusive with ``rayp``.
+        :param    idx:               Optional nonnegative reverse layer index
+                                     used with ``inca``; zero denotes the
+                                     halfspace.
+        :param    zeta:              Virtual-frequency coefficient in ``-N``.
+        :param    upsampling_n:      Time-domain upsampling factor in ``-N``.
+        :param    keepAllFreq:       If true, append ``+a`` to ``-N``.
+        :param    skipImagComps:     If true, append ``+f`` to ``-N`` and skip
+                                     virtual-frequency compensation.
+        :param    alp:               Gaussian low-pass filter parameter.
+        :param    delay:             Additional delay before the P arrival in s.
+                                     The program already applies an internal delay;
+                                     set this only when more delay is needed.
+        :param    write_components:  If true, also write absolute Z and R
+                                     response time series.
+        :param    print_log:         If false, suppress regular ``grt`` output
+                                     while preserving warnings and diagnostics.
+
+        :return: ``None``. SAC files are written below ``output_path``.
+        """
+        if self.modelpath is None:
+            raise RuntimeError("Pass modelpath= to PyModel1D(...) before rftn().")
+        if not isinstance(wtype, str) or wtype.upper() not in {"P", "S"}:
+            raise ValueError('wtype must be "P" or "S".')
+        if (rayp is None) == (inca is None):
+            raise ValueError("Set exactly one of rayp and inca.")
+        if idx is not None and inca is None:
+            raise ValueError("idx requires inca.")
+
+        nt = _normalize_integer(nt, "nt", minimum=1)
+        upsampling_n = _normalize_integer(upsampling_n, "upsampling_n", minimum=1)
+
+        def positive_finite(value: float, name: str) -> float:
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                raise TypeError(f"{name} must be a positive number.") from None
+            if not np.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be positive and finite.")
+            return value
+
+        dt = positive_finite(dt, "dt")
+        zeta = positive_finite(zeta, "zeta")
+        alp = positive_finite(alp, "alp")
+
+        try:
+            delay = float(delay)
+        except (TypeError, ValueError):
+            raise TypeError("delay must be finite.") from None
+        if not np.isfinite(delay):
+            raise ValueError("delay must be finite.")
+
+        command = {
+            "subcommand": "rftn",
+            "M": f"-M{self.modelpath}",
+        }
+        if rayp is not None:
+            rayp = positive_finite(rayp, "rayp")
+            command["P"] = f"-P{format_float(rayp)}"
+        else:
+            try:
+                inca = float(inca)
+            except (TypeError, ValueError):
+                raise TypeError("inca must be a finite number.") from None
+            if not np.isfinite(inca) or inca < 0.0 or inca >= 90.0:
+                raise ValueError("inca must be finite and satisfy 0 <= inca < 90.")
+            if idx is not None:
+                idx = _normalize_integer(idx, "idx", minimum=0)
+                inca_option = f"{format_float(inca)}/{idx}"
+            else:
+                inca_option = format_float(inca)
+            command["I"] = f"-I{inca_option}"
+
+        n_option = f"-N{nt}/{format_float(dt)}+w{format_float(zeta)}+n{upsampling_n}"
+        if keepAllFreq:
+            n_option += "+a"
+        if skipImagComps:
+            n_option += "+f"
+
+        command.update({
+            "T": f"-T{wtype.upper()}",
+            "N": n_option,
+            "A": f"-A{format_float(alp)}",
+            "E": f"-E{format_float(delay)}",
+        })
+        if write_components:
+            command["W"] = "-W"
+
+        output = Path(output_path)
+        output.mkdir(parents=True, exist_ok=True)
+        command["O"] = f"-O{output}"
+        run_grt(list(command.values()), print_log=print_log)
 
     def static_greenfn(
         self,

--- a/test/_compare_c_py/test_cli_args.py
+++ b/test/_compare_c_py/test_cli_args.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import io
+import shutil
 import subprocess
 import sys
 import warnings
@@ -485,6 +486,82 @@ def test_modal_cli_argument_mapping():
         _restore_run_grt(pygrt.pymod, original)
 
 
+def test_rftn_cli_argument_mapping():
+    runner = CapturedRunner()
+    original = _patch_run_grt(pygrt.pymod, runner)
+    output = HERE / "_tmp_args_rftn"
+    try:
+        model = pygrt.PyModel1D(modelpath=MODEL)
+
+        model.rftn(
+            wtype="p",
+            rayp=0.12,
+            nt=128,
+            dt=0.05,
+            output_path=output,
+            zeta=0.9,
+            upsampling_n=4,
+            keepAllFreq=True,
+            skipImagComps=True,
+            alp=0.8,
+            delay=-1.2,
+            write_components=True,
+            print_log=False,
+        )
+        assert_command_equals(
+            runner.commands[-1],
+            [
+                "rftn",
+                f"-M{MODEL}",
+                "-P0.12",
+                "-TP",
+                "-N128/0.05+w0.9+n4+a+f",
+                "-A0.8",
+                "-E-1.2",
+                "-W",
+                f"-O{output}",
+            ],
+        )
+        assert runner.kwargs[-1].get("print_log") is False
+
+        model.rftn(
+            wtype="S",
+            inca=30.0,
+            idx=2,
+            nt=8,
+            dt=0.1,
+            output_path=output,
+        )
+        assert_command_equals(
+            runner.commands[-1],
+            [
+                "rftn",
+                f"-M{MODEL}",
+                "-I30/2",
+                "-TS",
+                "-N8/0.1+w0.8+n1",
+                "-A1",
+                "-E0",
+                f"-O{output}",
+            ],
+        )
+
+        for kwargs in (
+            {"rayp": 0.1, "inca": 20.0},
+            {"rayp": None, "inca": None},
+            {"rayp": 0.1, "idx": 1},
+        ):
+            try:
+                model.rftn(wtype="P", nt=8, dt=0.1, output_path=output, **kwargs)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"invalid rayp/inca arguments should fail: {kwargs}")
+    finally:
+        _restore_run_grt(pygrt.pymod, original)
+        shutil.rmtree(output, ignore_errors=True)
+
+
 def test_static_greenfn_xy_and_dists():
     runner = CapturedRunner()
     original = _patch_run_grt(pygrt.pymod, runner)
@@ -916,6 +993,7 @@ def main():
         test_run_grt_forwards_warnings_and_errors,
         test_greenfn_default_and_optional_flags,
         test_modal_cli_argument_mapping,
+        test_rftn_cli_argument_mapping,
         test_static_greenfn_xy_and_dists,
         test_syn_source_and_time_function_options,
         test_source_type_is_inferred_from_source_parameters,

--- a/test/rftn/test_rftn.py
+++ b/test/rftn/test_rftn.py
@@ -1,0 +1,101 @@
+import shutil
+from pathlib import Path
+
+import numpy as np
+from obspy import read
+
+import pygrt
+
+
+MODEL = "../milrow"
+
+
+def compare_sac_dirs(c_dir: Path, py_dir: Path, expected_names: set[str]) -> None:
+    c_names = {path.name for path in c_dir.glob("*.sac")}
+    py_names = {path.name for path in py_dir.glob("*.sac")}
+    assert c_names == expected_names
+    assert py_names == expected_names
+
+    for name in sorted(expected_names):
+        c_trace = read(str(c_dir / name))[0]
+        py_trace = read(str(py_dir / name))[0]
+        assert c_trace.stats.npts == py_trace.stats.npts
+        assert c_trace.stats.delta == py_trace.stats.delta
+        np.testing.assert_array_equal(c_trace.data, py_trace.data)
+
+
+def expect_value_error(callable_obj, message: str) -> None:
+    try:
+        callable_obj()
+    except ValueError:
+        return
+    raise AssertionError(message)
+
+
+model = pygrt.PyModel1D(modelpath=MODEL)
+
+# 与 test_rftn.sh 中的 C 命令对应的 P 波参数
+model.rftn(
+    wtype="P",
+    rayp=0.12,
+    nt=64,
+    dt=0.05,
+    output_path="PY_P",
+    write_components=True,
+    print_log=False,
+)
+compare_sac_dirs(
+    Path("C_P"),
+    Path("PY_P"),
+    {"P_rftn.sac", "P_Z.sac", "P_R.sac"},
+)
+
+# 与 test_rftn.sh 中的 C 命令对应的 SV 波参数
+model.rftn(
+    wtype="S",
+    inca=20.0,
+    idx=2,
+    nt=64,
+    dt=0.05,
+    output_path="PY_S",
+    zeta=0.9,
+    upsampling_n=2,
+    keepAllFreq=True,
+    skipImagComps=True,
+    alp=0.8,
+    delay=0.5,
+    write_components=True,
+    print_log=False,
+)
+compare_sac_dirs(
+    Path("C_S"),
+    Path("PY_S"),
+    {"S_rftn.sac", "S_Z.sac", "S_R.sac"},
+)
+
+# Python 端输入检查
+expect_value_error(
+    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.1, inca=20.0),
+    "rayp and inca should be mutually exclusive",
+)
+expect_value_error(
+    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad"),
+    "one of rayp and inca should be required",
+)
+expect_value_error(
+    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.1, idx=1),
+    "idx should require inca",
+)
+expect_value_error(
+    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad", inca=90.0),
+    "inca should be below 90 degrees",
+)
+expect_value_error(
+    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.0),
+    "rayp should be positive",
+)
+
+for name in ["PY_P", "PY_S", "bad"]:
+    path = Path(name)
+    if path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)

--- a/test/rftn/test_rftn.sh
+++ b/test/rftn/test_rftn.sh
@@ -39,4 +39,6 @@ expect_fail "one of -P and -I is required" \
 expect_fail "incidence angle must be below 90 degrees" \
     grt rftn -M../milrow -I90 -TP -N8/0.1 -OC_BAD
 
+python -u test_rftn.py
+
 rm -rf C_P C_S PY_P PY_S


### PR DESCRIPTION
Expose `grt rftn` through `PyModel1D.rftn` with keyword-only validation and complete CLI option mapping. 