### PR TITLE
REFAC: standardize receiver identifiers as "rcv"

### DIFF
--- a/docs/source/Lamb_problem/run_lamb2/lamb2_plot_time.py
+++ b/docs/source/Lamb_problem/run_lamb2/lamb2_plot_time.py
@@ -27,7 +27,7 @@ G, dG_source, dG_receiver = pygrt.utils.lamb2(
 EPICENTRAL_DISTANCE = 10.0
 NU = 0.25
 AZIMUTH = 30.0
-SOURCE_DEPTHS = np.array([0.1, 0.5, 1.0, 2.0, 5.0, 10.0])
+DEPSRCS = np.array([0.1, 0.5, 1.0, 2.0, 5.0, 10.0])
 TMAX = 2.0
 DTBAR = 0.002
 
@@ -52,12 +52,12 @@ def component_label(component: str, derivative_coordinate: int | None = None) ->
 
 def compute_lamb2_results() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     ts = np.arange(int(round(TMAX / DTBAR)) + 1, dtype=float) * DTBAR
-    greens = np.empty((len(SOURCE_DEPTHS), len(ts), 3, 3))
-    source_derivatives = np.empty((len(SOURCE_DEPTHS), len(ts), 3, 3, 3))
+    greens = np.empty((len(DEPSRCS), len(ts), 3, 3))
+    source_derivatives = np.empty((len(DEPSRCS), len(ts), 3, 3, 3))
 
-    for index, source_depth in enumerate(SOURCE_DEPTHS):
+    for index, depsrc in enumerate(DEPSRCS):
         G, dG_source, _ = pygrt.utils.lamb2(
-            nu=NU, tbar=ts, R=EPICENTRAL_DISTANCE, depsrc=source_depth, azimuth=AZIMUTH
+            nu=NU, tbar=ts, R=EPICENTRAL_DISTANCE, depsrc=depsrc, azimuth=AZIMUTH
         )
         greens[index] = G
         source_derivatives[index] = dG_source
@@ -93,11 +93,11 @@ def plot_components(
             fontsize=11,
         )
 
-    for source_depth, offset in zip(SOURCE_DEPTHS, offsets):
+    for depsrc, offset in zip(DEPSRCS, offsets):
         axes[0, 0].text(
             0.03,
             offset,
-            f"{source_depth:g}",
+            f"{depsrc:g}",
             transform=axes[0, 0].get_yaxis_transform(),
             ha="left",
             va="bottom",

--- a/docs/source/Lamb_problem/run_lamb3/lamb3_plot_time.py
+++ b/docs/source/Lamb_problem/run_lamb3/lamb3_plot_time.py
@@ -28,7 +28,7 @@ G, dG_source, dG_receiver = pygrt.utils.lamb3(
 EPICENTRAL_DISTANCE = 10.0
 NU = 0.25
 AZIMUTH = 30.0
-SOURCE_DEPTHS = np.array([0.1, 0.5, 1.0, 2.0, 5.0, 10.0])
+DEPSRCS = np.array([0.1, 0.5, 1.0, 2.0, 5.0, 10.0])
 TMAX = 2.0
 DTBAR = 0.002
 
@@ -51,15 +51,15 @@ def component_label(component: str, derivative_coordinate: int | None = None) ->
     return rf"$\bar{{G}}^H_{{{component}}}$"
 
 
-def compute_lamb3_results(receiver_depth:float) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def compute_lamb3_results(deprcv:float) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     ts = np.arange(int(round(TMAX / DTBAR)) + 1, dtype=float) * DTBAR
-    greens = np.empty((len(SOURCE_DEPTHS), len(ts), 3, 3))
-    source_derivatives = np.empty((len(SOURCE_DEPTHS), len(ts), 3, 3, 3))
+    greens = np.empty((len(DEPSRCS), len(ts), 3, 3))
+    source_derivatives = np.empty((len(DEPSRCS), len(ts), 3, 3, 3))
 
-    for index, source_depth in enumerate(SOURCE_DEPTHS):
+    for index, depsrc in enumerate(DEPSRCS):
         G, dG_source, _ = pygrt.utils.lamb3(
-            nu=NU, tbar=ts, R=EPICENTRAL_DISTANCE, depsrc=source_depth,
-            deprcv=receiver_depth, azimuth=AZIMUTH,
+            nu=NU, tbar=ts, R=EPICENTRAL_DISTANCE, depsrc=depsrc,
+            deprcv=deprcv, azimuth=AZIMUTH,
         )
         greens[index] = G
         source_derivatives[index] = dG_source
@@ -95,11 +95,11 @@ def plot_components(
             fontsize=11,
         )
 
-    for source_depth, offset in zip(SOURCE_DEPTHS, offsets):
+    for depsrc, offset in zip(DEPSRCS, offsets):
         axes[0, 0].text(
             0.03,
             offset,
-            f"{source_depth:g}",
+            f"{depsrc:g}",
             transform=axes[0, 0].get_yaxis_transform(),
             ha="left",
             va="bottom",
@@ -112,9 +112,9 @@ def plot_components(
     plt.close(fig)
 
 
-for receiver_depth in [0.1, 1.0, 5.0]:
-    ts, greens, source_derivatives = compute_lamb3_results(receiver_depth)
-    plot_components(ts, greens, GREEN_SCALE, GREEN_OFFSETS, GREEN_YLIM, f"lamb3_{receiver_depth:.1f}.svg")
+for deprcv in [0.1, 1.0, 5.0]:
+    ts, greens, source_derivatives = compute_lamb3_results(deprcv)
+    plot_components(ts, greens, GREEN_SCALE, GREEN_OFFSETS, GREEN_YLIM, f"lamb3_{deprcv:.1f}.svg")
 
     for coordinate in (1, 2, 3):
         plot_components(
@@ -123,6 +123,6 @@ for receiver_depth in [0.1, 1.0, 5.0]:
             DERIVATIVE_SCALES[coordinate],
             DERIVATIVE_OFFSETS,
             DERIVATIVE_YLIM,
-            f"lamb3_d{coordinate}_{receiver_depth:.1f}.svg",
+            f"lamb3_d{coordinate}_{deprcv:.1f}.svg",
             derivative_coordinate=coordinate,
         )

--- a/docs/source/Tutorial/static/run/run.py
+++ b/docs/source/Tutorial/static/run/run.py
@@ -76,9 +76,9 @@ pymod.static_syn(
 
 # ---------------------------------------------------------------------------------
 # BEGIN SYN POINTS
-# 设置 recv_points 来传入任意点坐标文件
+# 设置 rcv_points 来传入任意点坐标文件
 pymod.static_syn(
-    recv_points="rcv_pts.txt",
+    rcv_points="rcv_pts.txt",
     scale=1e24, strike=33, dip=90, rake=0, output_path="stsyn_points.nc", zne=True,
 )
 # END SYN POINTS

--- a/pygrt/C_extension/include/grt.h
+++ b/pygrt/C_extension/include/grt.h
@@ -57,7 +57,7 @@
 #include "grt/modal/secular.h"
 
 
-#include "grt/static/recv_points.h"
+#include "grt/static/rcv_points.h"
 #include "grt/static/static_grn.h"
 #include "grt/static/stgrnlib.h"
 #include "grt/static/static_layer.h"

--- a/pygrt/C_extension/include/grt/lamb/lamb2.h
+++ b/pygrt/C_extension/include/grt/lamb/lamb2.h
@@ -21,8 +21,8 @@
  * @param[in]    ts             无量纲时间序列 tbar=t/(r/beta)=beta*t/r
  * @param[in]    nt             时间序列点数
  * @param[in]    R              源点到接收点的水平距离，必须为正数
- * @param[in]    source_depth   源点深度，与 receiver_depth 恰好一个大于零
- * @param[in]    receiver_depth 接收点深度，与 source_depth 恰好一个大于零
+ * @param[in]    depsrc         源点深度，与 deprcv 恰好一个大于零
+ * @param[in]    deprcv         接收点深度，与 depsrc 恰好一个大于零
  * @param[in]    azimuth        方位角，单位度，[0, 360]
  * @param[out]   G              无量纲阶跃力位移，G[time][i][j]
  * @param[out]   dG_source      无量纲源点导数，dG_source[time][k'][i][j]
@@ -32,5 +32,5 @@
  */
 void grt_solve_lamb2(
     const real_t nu, const real_t *ts, const int nt,
-    const real_t R, const real_t source_depth, const real_t receiver_depth, const real_t azimuth,
+    const real_t R, const real_t depsrc, const real_t deprcv, const real_t azimuth,
     real_t (*G)[3][3], real_t (*dG_source)[3][3][3], real_t (*dG_receiver)[3][3][3]);

--- a/pygrt/C_extension/include/grt/lamb/lamb3.h
+++ b/pygrt/C_extension/include/grt/lamb/lamb3.h
@@ -20,8 +20,8 @@
  * @param[in]    ts              无量纲时间序列 tbar=t/(r/beta)=beta*t/r
  * @param[in]    nt              时间序列点数
  * @param[in]    R               源点和接收点之间的水平距离，应为正数
- * @param[in]    source_depth    源点深度 x3'，必须大于零
- * @param[in]    receiver_depth  接收点深度 x3，必须大于零
+ * @param[in]    depsrc          源点深度 x3'，必须大于零
+ * @param[in]    deprcv          接收点深度 x3，必须大于零
  * @param[in]    azimuth         水平距离方位角，单位度，[0, 360]
  * @param[out]   G               无量纲阶跃力位移，G[time][i][j]
  * @param[out]   dG_source       无量纲源点导数，dG_source[time][k'][i][j]
@@ -31,6 +31,6 @@
  */
 void grt_solve_lamb3(
     const real_t nu, const real_t *ts, const int nt,
-    const real_t R, const real_t source_depth, const real_t receiver_depth,
+    const real_t R, const real_t depsrc, const real_t deprcv,
     const real_t azimuth, real_t (*G)[3][3], real_t (*dG_source)[3][3][3],
     real_t (*dG_receiver)[3][3][3]);

--- a/pygrt/C_extension/include/grt/static/rcv_points.h
+++ b/pygrt/C_extension/include/grt/static/rcv_points.h
@@ -1,5 +1,5 @@
 /**
- * @file   recv_points.h
+ * @file   rcv_points.h
  * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
  * @date   2026-08
  *
@@ -17,14 +17,14 @@
 #include "grt/common/finite_fault.h"
 
 /** layout 字符串：写入 nc 全局属性，读端据此分支 */
-#define GRT_RECV_LAYOUT_GRID   "grid"
-#define GRT_RECV_LAYOUT_POINTS "points"
+#define GRT_RCV_LAYOUT_GRID   "grid"
+#define GRT_RCV_LAYOUT_POINTS "points"
 
 /** NetCDF 接收点布局 */
 typedef enum {
-    GRT_RECV_NC_LAYOUT_GRID = 0,           ///< 规则网格布局
-    GRT_RECV_NC_LAYOUT_POINTS              ///< 一维接收点布局
-} GRT_RECV_NC_LAYOUT;
+    GRT_RCV_NC_LAYOUT_GRID = 0,           ///< 规则网格布局
+    GRT_RCV_NC_LAYOUT_POINTS              ///< 一维接收点布局
+} GRT_RCV_NC_LAYOUT;
 
 /** 接收点坐标及可选的有限接收断层信息 */
 typedef struct {
@@ -51,17 +51,17 @@ typedef struct {
     real_t *frakes;         ///< 每条有限接收断层的滑动角 (degree)
     size_t *stksizes;       ///< 每条有限接收断层沿走向的子断层数量
     size_t *dipsizes;       ///< 每条有限接收断层沿倾向的子断层数量
-} GRT_RECV_POINTS;
+} GRT_RCV_POINTS;
 
 /** 已打开 NetCDF 文件中的接收坐标及维度信息 */
 typedef struct {
-    GRT_RECV_NC_LAYOUT layout;     ///< 接收点布局类型
+    GRT_RCV_NC_LAYOUT layout;     ///< 接收点布局类型
     size_t npts;                   ///< 展平后的接收点总数
     real_t *norths;                ///< 展平后的北向坐标数组 (km)
     real_t *easts;                 ///< 展平后的东向坐标数组 (km)
 
     int dimids[2];                 ///< 接收坐标对应的 NetCDF 维度 ID
-} GRT_RECV_NC_INFO;
+} GRT_RCV_NC_INFO;
 
 /**
  * 由 north/east 轴与单一深度展开为点列（is_grid=true）
@@ -71,9 +71,9 @@ typedef struct {
  * @param[in]   neast    east 方向点数
  * @param[in]   easts    east 坐标 (km)
  * @param[in]   depth    接收深度 (km)
- * @return      新分配的 GRT_RECV_POINTS*，调用方负责 grt_recv_points_free
+ * @return      新分配的 GRT_RCV_POINTS*，调用方负责 grt_rcv_points_free
  */
-GRT_RECV_POINTS *grt_recv_points_from_grid(
+GRT_RCV_POINTS *grt_rcv_points_from_grid(
     size_t nnorth, const real_t *norths,
     size_t neast,  const real_t *easts,
     real_t depth);
@@ -85,16 +85,16 @@ GRT_RECV_POINTS *grt_recv_points_from_grid(
  * strike dip rake (degree)，# 开头为注释
  *
  * @param[in]   path   文件路径
- * @return      新分配的 GRT_RECV_POINTS*
+ * @return      新分配的 GRT_RCV_POINTS*
  */
-GRT_RECV_POINTS *grt_recv_points_from_file(const char *path);
+GRT_RCV_POINTS *grt_rcv_points_from_file(const char *path);
 
 /**
- * 释放 GRT_RECV_POINTS（含坐标和可选接收断层几何）
+ * 释放 GRT_RCV_POINTS（含坐标和可选接收断层几何）
  *
  * @param[in,out]  pts   可为 NULL
  */
-void grt_recv_points_free(GRT_RECV_POINTS *pts);
+void grt_rcv_points_free(GRT_RCV_POINTS *pts);
 
 /**
  * 从有限断层数组生成接收点列表
@@ -107,9 +107,9 @@ void grt_recv_points_free(GRT_RECV_POINTS *pts);
  * @param[in]   faults   已读取并建立衍生量的有限断层数组
  * @param[in]   dL       沿走向子断层尺寸 (km)
  * @param[in]   dW       沿倾向子断层尺寸 (km)
- * @return      新分配的 GRT_RECV_POINTS*，调用方负责 grt_recv_points_free
+ * @return      新分配的 GRT_RCV_POINTS*，调用方负责 grt_rcv_points_free
  */
-GRT_RECV_POINTS *grt_recv_points_from_faults(
+GRT_RCV_POINTS *grt_rcv_points_from_faults(
     size_t nfault, const FINITE_FAULT *faults, real_t dL, real_t dW);
 
 /**
@@ -118,7 +118,7 @@ GRT_RECV_POINTS *grt_recv_points_from_faults(
  * @param[in]  ncid   已打开的 NetCDF 文件 ID
  * @return            接收布局类型
  */
-GRT_RECV_NC_LAYOUT grt_recv_nc_get_layout(int ncid);
+GRT_RCV_NC_LAYOUT grt_rcv_nc_get_layout(int ncid);
 
 /**
  * 读取已打开 NetCDF 文件中的接收坐标布局
@@ -126,14 +126,14 @@ GRT_RECV_NC_LAYOUT grt_recv_nc_get_layout(int ncid);
  * @param[in]   ncid   已打开的 NetCDF 文件 ID
  * @param[out]  info   接收坐标和维度信息
  */
-void grt_recv_nc_info_load(int ncid, GRT_RECV_NC_INFO *info);
+void grt_rcv_nc_info_load(int ncid, GRT_RCV_NC_INFO *info);
 
 /**
- * 释放 GRT_RECV_NC_INFO
+ * 释放 GRT_RCV_NC_INFO
  *
  * @param[in,out]  info   接收坐标和维度信息
  */
-void grt_recv_nc_info_free(GRT_RECV_NC_INFO *info);
+void grt_rcv_nc_info_free(GRT_RCV_NC_INFO *info);
 
 /**
  * 从已打开的 nc 判断是否为 points 布局
@@ -143,4 +143,4 @@ void grt_recv_nc_info_free(GRT_RECV_NC_INFO *info);
  * @param[in]   ncid   已打开的 nc id
  * @return      true 表示 points，false 表示 grid
  */
-bool grt_recv_nc_is_points(int ncid);
+bool grt_rcv_nc_is_points(int ncid);

--- a/pygrt/C_extension/include/grt/static/static_output.h
+++ b/pygrt/C_extension/include/grt/static/static_output.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "grt/static/recv_points.h"
+#include "grt/static/rcv_points.h"
 
 /**
  * 查询指定深度处的接收介质参数
@@ -37,7 +37,7 @@ typedef struct {
     real_t alpha;                                ///< 均匀半空间 alpha 参数
     real_t lambda;                               ///< 均匀半空间 lambda 参数
     real_t mu;                                   ///< 均匀半空间 mu 参数
-    const GRT_RECV_POINTS *recv;                 ///< 规则网格、任意点或有限接收断层点列表
+    const GRT_RCV_POINTS *rcv;                   ///< 规则网格、任意点或有限接收断层点列表
     GRT_STATIC_MEDIUM_FUNC get_medium;           ///< 接收介质查询回调函数
     void *medium_context;                        ///< 接收介质查询回调上下文
     const real_t (*syn)[GRT_CHANNEL_NUM];        ///< 位移数组

--- a/pygrt/C_extension/src/lamb/grt_lamb2.c
+++ b/pygrt/C_extension/src/lamb/grt_lamb2.c
@@ -33,8 +33,8 @@ typedef struct {
     struct {
         bool s_active;       ///< -Ds
         bool r_active;       ///< -Dr
-        real_t source_depth;
-        real_t receiver_depth;
+        real_t depsrc;
+        real_t deprcv;
     } D;
 
     /** 空间导数输出路径 */
@@ -182,7 +182,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                     Ctrl->D.s_active = true;
                     {
                         char extra;
-                        if (1 != sscanf(optarg + 1, "%lf%c", &Ctrl->D.source_depth, &extra) || Ctrl->D.source_depth <= 0.0) {
+                        if (1 != sscanf(optarg + 1, "%lf%c", &Ctrl->D.depsrc, &extra) || Ctrl->D.depsrc <= 0.0) {
                             GRTBadOptionError(Ds, "source depth should be strictly positive.");
                         }
                     }
@@ -190,7 +190,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                     Ctrl->D.r_active = true;
                     {
                         char extra;
-                        if (1 != sscanf(optarg + 1, "%lf%c", &Ctrl->D.receiver_depth, &extra) || Ctrl->D.receiver_depth <= 0.0) {
+                        if (1 != sscanf(optarg + 1, "%lf%c", &Ctrl->D.deprcv, &extra) || Ctrl->D.deprcv <= 0.0) {
                             GRTBadOptionError(Dr, "receiver depth should be strictly positive.");
                         }
                     }
@@ -262,7 +262,7 @@ static void run_lamb2_with_derivative_outputs(const GRT_MODULE_CTRL *Ctrl)
     }
 
     grt_solve_lamb2(Ctrl->P.nu, Ctrl->T.ts, Ctrl->T.nt, Ctrl->R.distance,
-        Ctrl->D.source_depth, Ctrl->D.receiver_depth, Ctrl->A.azimuth,
+        Ctrl->D.depsrc, Ctrl->D.deprcv, Ctrl->A.azimuth,
         G, dG_source, dG_receiver);
     grt_lamb_print_green_series(stdout, Ctrl->T.ts, Ctrl->T.nt, G);
     if (source_file != NULL) {
@@ -288,7 +288,7 @@ int lamb2_main(int argc, char **argv)
         run_lamb2_with_derivative_outputs(Ctrl);
     } else {
         grt_solve_lamb2(Ctrl->P.nu, Ctrl->T.ts, Ctrl->T.nt, Ctrl->R.distance,
-            Ctrl->D.source_depth, Ctrl->D.receiver_depth, Ctrl->A.azimuth, NULL, NULL, NULL);
+            Ctrl->D.depsrc, Ctrl->D.deprcv, Ctrl->A.azimuth, NULL, NULL, NULL);
     }
     free_Ctrl(Ctrl);
     return EXIT_SUCCESS;

--- a/pygrt/C_extension/src/lamb/grt_lamb3.c
+++ b/pygrt/C_extension/src/lamb/grt_lamb3.c
@@ -29,8 +29,8 @@ typedef struct {
 
     struct {
         bool active;
-        real_t source_depth;
-        real_t receiver_depth;
+        real_t depsrc;
+        real_t deprcv;
     } D;
 
     struct {
@@ -178,11 +178,11 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                 Ctrl->D.active = true;
                 {
                     char extra;
-                    if(2 != sscanf(optarg, "%lf/%lf%c", &Ctrl->D.source_depth, &Ctrl->D.receiver_depth, &extra)){
+                    if(2 != sscanf(optarg, "%lf/%lf%c", &Ctrl->D.depsrc, &Ctrl->D.deprcv, &extra)){
                         GRTBadOptionError(D, "expected source-depth/receiver-depth.");
                     }
                 }
-                if(Ctrl->D.source_depth <= 0.0 || Ctrl->D.receiver_depth <= 0.0){
+                if(Ctrl->D.depsrc <= 0.0 || Ctrl->D.deprcv <= 0.0){
                     GRTBadOptionError(D, "source and receiver depths should be strictly positive.");
                 }
                 break;
@@ -235,8 +235,8 @@ static void run_lamb3_with_derivative_outputs(const GRT_MODULE_CTRL *Ctrl)
         receiver_file = GRTCheckOpenFile(Ctrl->S.receiver_path, "w");
     }
 
-    grt_solve_lamb3(Ctrl->P.nu, Ctrl->T.ts, Ctrl->T.nt, Ctrl->R.distance, Ctrl->D.source_depth,
-        Ctrl->D.receiver_depth, Ctrl->A.azimuth, G, dG_source, dG_receiver);
+    grt_solve_lamb3(Ctrl->P.nu, Ctrl->T.ts, Ctrl->T.nt, Ctrl->R.distance, Ctrl->D.depsrc,
+        Ctrl->D.deprcv, Ctrl->A.azimuth, G, dG_source, dG_receiver);
     grt_lamb_print_green_series(stdout, Ctrl->T.ts, Ctrl->T.nt, G);
     if (source_file != NULL) {
         grt_lamb_print_derivative_series(source_file, Ctrl->T.ts, Ctrl->T.nt, dG_source, true);
@@ -260,8 +260,8 @@ int lamb3_main(int argc, char **argv)
     if (Ctrl->S.active) {
         run_lamb3_with_derivative_outputs(Ctrl);
     } else {
-        grt_solve_lamb3(Ctrl->P.nu, Ctrl->T.ts, Ctrl->T.nt, Ctrl->R.distance, Ctrl->D.source_depth,
-            Ctrl->D.receiver_depth, Ctrl->A.azimuth, NULL, NULL, NULL);
+        grt_solve_lamb3(Ctrl->P.nu, Ctrl->T.ts, Ctrl->T.nt, Ctrl->R.distance, Ctrl->D.depsrc,
+            Ctrl->D.deprcv, Ctrl->A.azimuth, NULL, NULL, NULL);
     }
     free_Ctrl(Ctrl);
     return EXIT_SUCCESS;

--- a/pygrt/C_extension/src/lamb/lamb2.c
+++ b/pygrt/C_extension/src/lamb/lamb2.c
@@ -517,7 +517,7 @@ static real_t shift_lamb2_boundary(const real_t tbar, const LAMB2_VARS *V, const
 }
 
 void grt_solve_lamb2(
-    const real_t nu, const real_t *ts, const int nt, const real_t R, const real_t source_depth, const real_t receiver_depth,
+    const real_t nu, const real_t *ts, const int nt, const real_t R, const real_t depsrc, const real_t deprcv,
     const real_t azimuth, real_t (*G)[3][3], real_t (*dG_source)[3][3][3], real_t (*dG_receiver)[3][3][3])
 {
     if (nu <= 0.0 || nu >= 0.5) {
@@ -532,15 +532,15 @@ void grt_solve_lamb2(
     if (R <= 0.0) {
         GRTRaiseError("The horizontal distance R should be positive in lamb2.\n");
     }
-    if (source_depth < 0.0 || receiver_depth < 0.0) {
+    if (depsrc < 0.0 || deprcv < 0.0) {
         GRTRaiseError("The source and receiver depths should be nonnegative in lamb2.\n");
     }
-    const bool buried_source = source_depth > 0.0 && receiver_depth == 0.0;
-    const bool surface_source = source_depth == 0.0 && receiver_depth > 0.0;
+    const bool buried_source = depsrc > 0.0 && deprcv == 0.0;
+    const bool surface_source = depsrc == 0.0 && deprcv > 0.0;
     if (!buried_source && !surface_source) {
         GRTRaiseError("lamb2 requires exactly one of source and receiver depths to be strictly positive, and the other to be zero.\n");
     }
-    const real_t buried_depth = buried_source ? source_depth : receiver_depth;
+    const real_t buried_depth = buried_source ? depsrc : deprcv;
     real_t solve_azimuth = azimuth;
     if (surface_source) {
         solve_azimuth = azimuth + 180.0;

--- a/pygrt/C_extension/src/lamb/lamb2_coeffs.c_
+++ b/pygrt/C_extension/src/lamb/lamb2_coeffs.c_
@@ -21,7 +21,7 @@ typedef struct {
     real_t k2;            ///< k^2
     real_t kp;            ///< kp=sqrt(1-k^2)
     real_t kp2;           ///< kp^2=1-k^2
-    real_t theta;         ///< 直接波射线角 theta=atan2(R,source_depth)
+    real_t theta;         ///< 直接波射线角 theta=atan2(R,depsrc)
     real_t phi;           ///< 水平面方位角 phi
     real_t st;            ///< sin(theta)
     real_t ct;            ///< cos(theta)

--- a/pygrt/C_extension/src/lamb/lamb3.c
+++ b/pygrt/C_extension/src/lamb/lamb3.c
@@ -306,8 +306,8 @@ static void make_coefficients(const LAMB3_VARS *V, const bool need_P, const bool
         LAMB3_CONVERSION_COEFF_SET *conversion_raw = calloc(1, sizeof(*conversion_raw));
         /* 接收点竖向导数对应交换深度后的 PS/SP 项 */
         LAMB3_VARS reciprocal = *V;
-        reciprocal.source_depth = V->receiver_depth;
-        reciprocal.receiver_depth = V->source_depth;
+        reciprocal.depsrc = V->deprcv;
+        reciprocal.deprcv = V->depsrc;
         if (need_PS) {
             make_lamb3_PS_coefficients(V, 1.0, 1, conversion_raw);
             make_conversion_pf_set(conversion_raw, V->rayleigh_ps, &coefficients->PS);
@@ -417,7 +417,7 @@ static real_t conversion_arrival(const real_t R, const real_t p_depth, const rea
     return (k * rp + rs) / direct_distance;
 }
 
-static void make_vars(const real_t nu, const real_t R, const real_t source_depth, const real_t receiver_depth, const real_t azimuth, LAMB3_VARS *V) {
+static void make_vars(const real_t nu, const real_t R, const real_t depsrc, const real_t deprcv, const real_t azimuth, LAMB3_VARS *V) {
     memset(V, 0, sizeof(*V));
     V->nu = nu;
     V->k2 = 0.5 * (1.0 - 2.0 * nu) / (1.0 - nu);
@@ -425,12 +425,12 @@ static void make_vars(const real_t nu, const real_t R, const real_t source_depth
     V->kp2 = 1.0 - V->k2;
     V->kp = sqrt(V->kp2);
     V->R = R;
-    V->source_depth = source_depth;
-    V->receiver_depth = receiver_depth;
-    V->r = hypot(R, source_depth - receiver_depth);
-    V->rp = hypot(R, source_depth + receiver_depth);
-    V->theta = atan2(R, source_depth - receiver_depth);
-    V->theta_ref = atan2(R, source_depth + receiver_depth);
+    V->depsrc = depsrc;
+    V->deprcv = deprcv;
+    V->r = hypot(R, depsrc - deprcv);
+    V->rp = hypot(R, depsrc + deprcv);
+    V->theta = atan2(R, depsrc - deprcv);
+    V->theta_ref = atan2(R, depsrc + deprcv);
     V->phi = azimuth * DEG1;
     V->st = sin(V->theta);
     V->ct = cos(V->theta);
@@ -452,9 +452,9 @@ static void make_vars(const real_t nu, const real_t R, const real_t source_depth
     V->angle_ratio = V->use_angle_ratio ? V->sf / V->cf : 0.0;
     V->supercritical = V->theta_ref > V->theta_c;
 
-    if (source_depth > 0.0 && receiver_depth > 0.0) {
-        V->tps = conversion_arrival(R, source_depth, receiver_depth, V->k, V->r);
-        V->tsp = conversion_arrival(R, receiver_depth, source_depth, V->k, V->r);
+    if (depsrc > 0.0 && deprcv > 0.0) {
+        V->tps = conversion_arrival(R, depsrc, deprcv, V->k, V->r);
+        V->tsp = conversion_arrival(R, deprcv, depsrc, V->k, V->r);
     } else {
         V->tps = INFINITY;
         V->tsp = INFINITY;
@@ -1185,8 +1185,8 @@ static void evaluate_reflection_wave(const real_t sbar, const real_t sbar2, cons
  */
 static void evaluate_conversion_term(const real_t tbar, const LAMB3_VARS *V, const LAMB3_CONVERSION_PF_SET *coeffs,
                                      const bool swap_depth, real_t F[3][3], real_t Fk_source[3][3][3], real_t Fk_receiver[3][3][3]) {
-    const real_t p_depth = swap_depth ? V->receiver_depth : V->source_depth;
-    const real_t s_depth = swap_depth ? V->source_depth : V->receiver_depth;
+    const real_t p_depth = swap_depth ? V->deprcv : V->depsrc;
+    const real_t s_depth = swap_depth ? V->depsrc : V->deprcv;
     LAMB3_PS_CTX P;
     make_PS_context(tbar, p_depth, s_depth, V, &P);
     LAMB3_PS_BASIS basis;
@@ -1522,7 +1522,7 @@ static void evaluate_time(const real_t tbar, const LAMB3_VARS *V, const LAMB3_RE
 }
 
 void grt_solve_lamb3(
-    const real_t nu, const real_t *ts, const int nt, const real_t R, const real_t source_depth, const real_t receiver_depth,
+    const real_t nu, const real_t *ts, const int nt, const real_t R, const real_t depsrc, const real_t deprcv,
     const real_t azimuth, real_t (*G)[3][3], real_t (*dG_source)[3][3][3], real_t (*dG_receiver)[3][3][3])
 {
     if (nu <= 0.0 || nu >= 0.5) {
@@ -1537,7 +1537,7 @@ void grt_solve_lamb3(
     if (R <= 0.0) {
         GRTRaiseError("The horizontal distance R should be positive in lamb3.\n");
     }
-    if (source_depth <= 0.0 || receiver_depth <= 0.0) {
+    if (depsrc <= 0.0 || deprcv <= 0.0) {
         GRTRaiseError("Source and receiver depths should be strictly positive in lamb3.\n");
     }
     if (azimuth < 0.0 || azimuth > 360.0) {
@@ -1553,18 +1553,18 @@ void grt_solve_lamb3(
     }
 
     LAMB3_VARS V;
-    make_vars(nu, R, source_depth, receiver_depth, azimuth, &V);
+    make_vars(nu, R, depsrc, deprcv, azimuth, &V);
     real_t horizontal_distance_ratio = R / V.rp;
-    real_t source_depth_ratio = source_depth / V.r;
-    real_t receiver_depth_ratio = receiver_depth / V.r;
+    real_t depsrc_ratio = depsrc / V.r;
+    real_t deprcv_ratio = deprcv / V.r;
     if (horizontal_distance_ratio <= LAMB3_SMALL_R_WARNING_RATIO) {
         GRTRaiseWarning(
             "The horizontal distance ratio R/r'=%e is small in lamb3; calculation is very likely to fail.", horizontal_distance_ratio);
     }
-    if (source_depth_ratio <= LAMB_SURFACE_DEPTH_WARNING_RATIO || receiver_depth_ratio <= LAMB_SURFACE_DEPTH_WARNING_RATIO) {
+    if (depsrc_ratio <= LAMB_SURFACE_DEPTH_WARNING_RATIO || deprcv_ratio <= LAMB_SURFACE_DEPTH_WARNING_RATIO) {
         GRTRaiseWarning(
             "Source or receiver depth ratio to direct distance is close to zero (source/r=%e, receiver/r=%e); calculation is very likely to fail.",
-            source_depth_ratio, receiver_depth_ratio);
+            depsrc_ratio, deprcv_ratio);
     }
     const real_t tbar_eps = nt > 1 ? GRT_MIN(1e-8, (ts[1] - ts[0]) * 1e-5) : 1e-8;
     /* 末点若正好落在波前上会被右移，用略大的 tEnd 判断以免漏构造系数 */

--- a/pygrt/C_extension/src/lamb/lamb3_coeffs.c_
+++ b/pygrt/C_extension/src/lamb/lamb3_coeffs.c_
@@ -20,12 +20,12 @@ typedef struct {
     real_t kp;                  ///< kp=sqrt(1-k^2)
     real_t kp2;                 ///< kp^2=1-k^2
     real_t R;                   ///< 源点和接收点的水平距离 R
-    real_t r;                   ///< 直接路径长度 r=sqrt(R^2+(source_depth-receiver_depth)^2)
-    real_t rp;                  ///< 反射路径长度 rp=sqrt(R^2+(source_depth+receiver_depth)^2)
-    real_t source_depth;        ///< 源点深度 x3'
-    real_t receiver_depth;      ///< 接收点深度 x3
-    real_t theta;               ///< 直接波射线角 theta=atan2(R,source_depth-receiver_depth)
-    real_t theta_ref;           ///< 反射波射线角 theta_ref=atan2(R,source_depth+receiver_depth)
+    real_t r;                   ///< 直接路径长度 r=sqrt(R^2+(depsrc-deprcv)^2)
+    real_t rp;                  ///< 反射路径长度 rp=sqrt(R^2+(depsrc+deprcv)^2)
+    real_t depsrc;              ///< 源点深度 x3'
+    real_t deprcv;              ///< 接收点深度 x3
+    real_t theta;               ///< 直接波射线角 theta=atan2(R,depsrc-deprcv)
+    real_t theta_ref;           ///< 反射波射线角 theta_ref=atan2(R,depsrc+deprcv)
     real_t phi;                 ///< 水平面方位角 phi
     real_t st;                  ///< sin(theta)
     real_t ct;                  ///< cos(theta)
@@ -3530,8 +3530,8 @@ static void transform_lamb3_conversion_matrix(LAMB3_POLY_COEFF matrix[3][3]) {
 }
 
 static void make_lamb3_PS_coefficients(const LAMB3_VARS *V, const real_t z_minus_sign, const int make_vertical, LAMB3_CONVERSION_COEFF_SET *coeffs) {
-    const real_t z_plus = (V->source_depth + V->receiver_depth) / V->R;
-    const real_t z_minus = z_minus_sign * (V->receiver_depth - V->source_depth) / V->R;
+    const real_t z_plus = (V->depsrc + V->deprcv) / V->R;
+    const real_t z_minus = z_minus_sign * (V->deprcv - V->depsrc) / V->R;
     const real_t time_scale = V->r / V->R;
     const real_t k_prime = V->kp;
     const real_t k_prime2 = V->kp2;

--- a/pygrt/C_extension/src/static/grt_okada.c
+++ b/pygrt/C_extension/src/static/grt_okada.c
@@ -382,14 +382,14 @@ static void parse_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
  * @param[in]  Ctrl   Okada 命令行控制结构体
  * @return            新分配的接收点结构体
  */
-static GRT_RECV_POINTS *build_receivers(const GRT_MODULE_CTRL *Ctrl)
+static GRT_RCV_POINTS *build_receivers(const GRT_MODULE_CTRL *Ctrl)
 {
-    if(Ctrl->Q.active) return grt_recv_points_from_file(Ctrl->Q.path);
+    if(Ctrl->Q.active) return grt_rcv_points_from_file(Ctrl->Q.path);
     if(Ctrl->R.active){
-        return grt_recv_points_from_faults(
+        return grt_rcv_points_from_faults(
             Ctrl->R.nfault, Ctrl->R.faults, Ctrl->R.dL, Ctrl->R.dW);
     }
-    return grt_recv_points_from_grid(Ctrl->X.n, Ctrl->X.values, Ctrl->Y.n, Ctrl->Y.values, Ctrl->deprcv);
+    return grt_rcv_points_from_grid(Ctrl->X.n, Ctrl->X.values, Ctrl->Y.n, Ctrl->Y.values, Ctrl->deprcv);
 }
 
 /** 将 Okada 局部坐标中的位移和偏导转换到 PyGRT ZNE 坐标
@@ -650,13 +650,13 @@ static void okada_get_medium(
  *
  * @param[in]  Ctrl         Okada 命令行控制结构体
  * @param[in]  medium       均匀半空间介质参数
- * @param[in]  recv         规则网格、任意点或有限接收断层点列表
+ * @param[in]  rcv          规则网格、任意点或有限接收断层点列表
  * @param[in]  syn          位移数组
  * @param[in]  syn_d        位移偏导数组
  */
 static void save_nc(
     const GRT_MODULE_CTRL *Ctrl, const OKADA_MEDIUM_PARAMS *medium,
-    const GRT_RECV_POINTS *recv,
+    const GRT_RCV_POINTS *rcv,
     const real_t (*syn)[3], const real_t (*syn_d)[3][3])
 {
     const char *channels;
@@ -690,7 +690,7 @@ static void save_nc(
         .alpha = medium->alpha,
         .lambda = medium->lambda,
         .mu = medium->mu,
-        .recv = recv,
+        .rcv = rcv,
         .get_medium = okada_get_medium,
         .medium_context = (void *)medium,
         .syn = (const real_t (*)[GRT_CHANNEL_NUM])syn,
@@ -712,11 +712,11 @@ int okada_main(int argc, char **argv)
     medium.alpha = 1.0 - (medium.vs / medium.vp) * (medium.vs / medium.vp);
     medium.mu = medium.rho * medium.vs * medium.vs * 1e10;
     medium.lambda = medium.rho * (medium.vp * medium.vp - 2.0 * medium.vs * medium.vs) * 1e10;
-    GRT_RECV_POINTS *recv = build_receivers(Ctrl);
-    size_t npts = recv->npts;
-    const real_t *norths = recv->norths;
-    const real_t *easts = recv->easts;
-    const real_t *depths = recv->depths;
+    GRT_RCV_POINTS *rcv = build_receivers(Ctrl);
+    size_t npts = rcv->npts;
+    const real_t *norths = rcv->norths;
+    const real_t *easts = rcv->easts;
+    const real_t *depths = rcv->depths;
     real_t (*syn)[3] = (real_t (*)[3])calloc(npts, sizeof(*syn));
     real_t (*syn_d)[3][3] = (real_t (*)[3][3])calloc(npts, sizeof(*syn_d));
     if((syn == NULL) || (syn_d == NULL)) GRTRaiseError("failed to allocate Okada output.");
@@ -739,12 +739,12 @@ int okada_main(int argc, char **argv)
     } else {
         add_point_source(Ctrl, &medium, npts, norths, easts, depths, syn, syn_d);
     }
-    save_nc(Ctrl, &medium, recv, syn, syn_d);
+    save_nc(Ctrl, &medium, rcv, syn, syn_d);
 
     if(!Ctrl->s.active) GRTRaiseInfo("Okada static displacements saved in \"%s\".", Ctrl->O.path);
     GRT_SAFE_FREE_PTR(syn);
     GRT_SAFE_FREE_PTR(syn_d);
-    grt_recv_points_free(recv);
+    grt_rcv_points_free(rcv);
     free_Ctrl(Ctrl);
     return EXIT_SUCCESS;
 }

--- a/pygrt/C_extension/src/static/grt_static_coulomb.c
+++ b/pygrt/C_extension/src/static/grt_static_coulomb.c
@@ -211,13 +211,13 @@ int static_coulomb_main(int argc, char **argv)
     int ncid;
     NC_CHECK(nc_open(Ctrl->G.s_ingrid, NC_WRITE, &ncid));
 
-    GRT_RECV_NC_INFO recv_info;
-    grt_recv_nc_info_load(ncid, &recv_info);
-    int ndims = (recv_info.layout == GRT_RECV_NC_LAYOUT_POINTS) ? 1 : 2;
-    size_t npts = recv_info.npts;
+    GRT_RCV_NC_INFO rcv_info;
+    grt_rcv_nc_info_load(ncid, &rcv_info);
+    int ndims = (rcv_info.layout == GRT_RCV_NC_LAYOUT_POINTS) ? 1 : 2;
+    size_t npts = rcv_info.npts;
 
-    int sigma_n_varid = get_projection_var(ncid, "sigma_n", ndims, recv_info.dimids);
-    int tau_s_varid = get_projection_var(ncid, "tau_s", ndims, recv_info.dimids);
+    int sigma_n_varid = get_projection_var(ncid, "sigma_n", ndims, rcv_info.dimids);
+    int tau_s_varid = get_projection_var(ncid, "tau_s", ndims, rcv_info.dimids);
     real_t *sigma_n = (real_t *)calloc(npts, sizeof(real_t));
     real_t *tau_s = (real_t *)calloc(npts, sizeof(real_t));
     real_t *coulomb = (real_t *)calloc(npts, sizeof(real_t));
@@ -229,10 +229,10 @@ int static_coulomb_main(int argc, char **argv)
         coulomb[i] = tau_s[i] + Ctrl->F.friction * sigma_n[i];
     }
 
-    write_coulomb_variable(ncid, ndims, recv_info.dimids, coulomb);
+    write_coulomb_variable(ncid, ndims, rcv_info.dimids, coulomb);
     NC_CHECK(nc_close(ncid));
 
-    grt_recv_nc_info_free(&recv_info);
+    grt_rcv_nc_info_free(&rcv_info);
     GRT_SAFE_FREE_PTR(sigma_n);
     GRT_SAFE_FREE_PTR(tau_s);
     GRT_SAFE_FREE_PTR(coulomb);

--- a/pygrt/C_extension/src/static/grt_static_rotation.c
+++ b/pygrt/C_extension/src/static/grt_static_rotation.c
@@ -142,13 +142,13 @@ int static_rotation_main(int argc, char **argv){
     }
 
     // 识别 grid / points 布局，并将坐标展平供统一计算
-    GRT_RECV_NC_INFO recv_info;
-    grt_recv_nc_info_load(in_ncid, &recv_info);
-    size_t npts = recv_info.npts;
-    real_t *norths_flat = recv_info.norths;
-    real_t *easts_flat = recv_info.easts;
-    int out_ndims = (recv_info.layout == GRT_RECV_NC_LAYOUT_POINTS) ? 1 : 2;
-    int out_dimids[2] = {recv_info.dimids[0], recv_info.dimids[1]};
+    GRT_RCV_NC_INFO rcv_info;
+    grt_rcv_nc_info_load(in_ncid, &rcv_info);
+    size_t npts = rcv_info.npts;
+    real_t *norths_flat = rcv_info.norths;
+    real_t *easts_flat = rcv_info.easts;
+    int out_ndims = (rcv_info.layout == GRT_RCV_NC_LAYOUT_POINTS) ? 1 : 2;
+    int out_dimids[2] = {rcv_info.dimids[0], rcv_info.dimids[1]};
 
     // 读入合成位移偏导 varid
     for(int c=0; c<GRT_CHANNEL_NUM; ++c){
@@ -206,7 +206,7 @@ int static_rotation_main(int argc, char **argv){
     // 关闭文件
     NC_CHECK(nc_close(in_ncid));
 
-    grt_recv_nc_info_free(&recv_info);
+    grt_rcv_nc_info_free(&rcv_info);
     GRT_SAFE_FREE_PTR(s_ingrid);
     free_Ctrl(Ctrl);
     return EXIT_SUCCESS;

--- a/pygrt/C_extension/src/static/grt_static_sproj.c
+++ b/pygrt/C_extension/src/static/grt_static_sproj.c
@@ -387,19 +387,19 @@ static void project_stress(
  * 读取普通 points 布局的 depth 变量
  *
  * @param[in] ncid       NetCDF 文件 ID
- * @param[in] recv_info  接收点布局信息
+ * @param[in] rcv_info   接收点布局信息
  * @return 接收点深度数组
  */
-static real_t *read_point_depths(int ncid, const GRT_RECV_NC_INFO *recv_info)
+static real_t *read_point_depths(int ncid, const GRT_RCV_NC_INFO *rcv_info)
 {
     int depth_varid;
     // 深度只用于核对 -Q 文件中的点顺序，不参与应力投影
-    real_t *depths = (real_t *)calloc(recv_info->npts, sizeof(real_t));
+    real_t *depths = (real_t *)calloc(rcv_info->npts, sizeof(real_t));
     if(!find_optional_var(ncid, "depth", &depth_varid)){
         GRT_SAFE_FREE_PTR(depths);
         GRTRaiseError("Points input file does not contain variable \"depth\".");
     }
-    check_var_dimensions(ncid, depth_varid, "depth", 1, recv_info->dimids);
+    check_var_dimensions(ncid, depth_varid, "depth", 1, rcv_info->dimids);
     NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, depth_varid, depths));
     return depths;
 }
@@ -423,37 +423,37 @@ static bool same_coordinate(real_t first, real_t second)
  * 从 -Q 文件读取并检查逐点接收断层形态
  *
  * @param[in]  ncid       输入 NetCDF 文件 ID
- * @param[in]  recv_info  输入接收点布局信息
+ * @param[in]  rcv_info   输入接收点布局信息
  * @param[in]  path       -Q 文件路径
  * @param[out] strikes    各接收点走向角
  * @param[out] dips       各接收点倾角
  * @param[out] rakes      各接收点滑动角
  */
 static void load_geometry_from_Q(
-    int ncid, const GRT_RECV_NC_INFO *recv_info, const char *path,
+    int ncid, const GRT_RCV_NC_INFO *rcv_info, const char *path,
     real_t *strikes, real_t *dips, real_t *rakes)
 {
-    GRT_RECV_POINTS *q_points = grt_recv_points_from_file(path);
+    GRT_RCV_POINTS *q_points = grt_rcv_points_from_file(path);
     if(!q_points->has_geometry){
-        grt_recv_points_free(q_points);
+        grt_rcv_points_free(q_points);
         GRTRaiseError("-Q file \"%s\" must contain exactly 6 columns.", path);
     }
-    if(q_points->npts != recv_info->npts){
+    if(q_points->npts != rcv_info->npts){
         size_t q_npts = q_points->npts;
-        grt_recv_points_free(q_points);
+        grt_rcv_points_free(q_points);
         GRTRaiseError(
             "-Q file \"%s\" has %zu points, but the input file has %zu points.",
-            path, q_npts, recv_info->npts);
+            path, q_npts, rcv_info->npts);
     }
 
     // 先读取输入文件深度，再逐点核对坐标、顺序和接收断层形态
-    real_t *depths = read_point_depths(ncid, recv_info);
-    for(size_t i = 0; i < recv_info->npts; ++i){
-        if(!same_coordinate(q_points->norths[i], recv_info->norths[i]) ||
-            !same_coordinate(q_points->easts[i], recv_info->easts[i]) ||
+    real_t *depths = read_point_depths(ncid, rcv_info);
+    for(size_t i = 0; i < rcv_info->npts; ++i){
+        if(!same_coordinate(q_points->norths[i], rcv_info->norths[i]) ||
+            !same_coordinate(q_points->easts[i], rcv_info->easts[i]) ||
             !same_coordinate(q_points->depths[i], depths[i])){
             GRT_SAFE_FREE_PTR(depths);
-            grt_recv_points_free(q_points);
+            grt_rcv_points_free(q_points);
             GRTRaiseError(
                 "-Q file \"%s\" does not have the same point order and coordinates "
                 "as the input file at point %zu.", path, i);
@@ -461,7 +461,7 @@ static void load_geometry_from_Q(
         if(!geometry_is_defined(
             q_points->strikes[i], q_points->dips[i], q_points->rakes[i])){
             GRT_SAFE_FREE_PTR(depths);
-            grt_recv_points_free(q_points);
+            grt_rcv_points_free(q_points);
             GRTRaiseError("Undefined or invalid receiver geometry in -Q at point %zu.", i);
         }
         strikes[i] = normalize_strike(q_points->strikes[i]);
@@ -469,7 +469,7 @@ static void load_geometry_from_Q(
         rakes[i] = q_points->rakes[i];
     }
     GRT_SAFE_FREE_PTR(depths);
-    grt_recv_points_free(q_points);
+    grt_rcv_points_free(q_points);
 }
 
 
@@ -477,14 +477,14 @@ static void load_geometry_from_Q(
  * 从普通 points 输入变量读取接收断层形态
  *
  * @param[in]  ncid       输入 NetCDF 文件 ID
- * @param[in]  recv_info  输入接收点布局信息
+ * @param[in]  rcv_info   输入接收点布局信息
  * @param[in]  Ctrl       参数控制结构体
  * @param[out] strikes    各接收点走向角
  * @param[out] dips       各接收点倾角
  * @param[out] rakes      各接收点滑动角
  */
 static void load_geometry_from_points(
-    int ncid, const GRT_RECV_NC_INFO *recv_info,
+    int ncid, const GRT_RCV_NC_INFO *rcv_info,
     const GRT_MODULE_CTRL *Ctrl,
     real_t *strikes, real_t *dips, real_t *rakes)
 {
@@ -496,9 +496,9 @@ static void load_geometry_from_points(
     bool has_any_geometry = has_strike || has_dip || has_rake;
     bool has_all_geometry = has_strike && has_dip && has_rake;
 
-    if(has_strike) check_var_dimensions(ncid, strike_varid, "strike", 1, recv_info->dimids);
-    if(has_dip) check_var_dimensions(ncid, dip_varid, "dip", 1, recv_info->dimids);
-    if(has_rake) check_var_dimensions(ncid, rake_varid, "rake", 1, recv_info->dimids);
+    if(has_strike) check_var_dimensions(ncid, strike_varid, "strike", 1, rcv_info->dimids);
+    if(has_dip) check_var_dimensions(ncid, dip_varid, "dip", 1, rcv_info->dimids);
+    if(has_rake) check_var_dimensions(ncid, rake_varid, "rake", 1, rcv_info->dimids);
 
     if(has_all_geometry){
         // 只有三要素完整时才从输入文件读取逐点形态
@@ -509,7 +509,7 @@ static void load_geometry_from_points(
 
     bool geometry_complete = has_all_geometry;
     if(has_all_geometry){
-        for(size_t i = 0; i < recv_info->npts; ++i){
+        for(size_t i = 0; i < rcv_info->npts; ++i){
             if(!geometry_is_defined(strikes[i], dips[i], rakes[i])){
                 geometry_complete = false;
                 break;
@@ -524,7 +524,7 @@ static void load_geometry_from_points(
                 "The input point receiver geometry is ignored; using the new "
                 "manual geometry from -M.");
         }
-        for(size_t i = 0; i < recv_info->npts; ++i){
+        for(size_t i = 0; i < rcv_info->npts; ++i){
             strikes[i] = Ctrl->M.strike;
             dips[i] = Ctrl->M.dip;
             rakes[i] = Ctrl->M.rake;
@@ -538,7 +538,7 @@ static void load_geometry_from_points(
             "Points input has no complete receiver geometry. Set -M<strike>/<dip>/<rake> "
             "or provide a 6-column -Q file.");
     }
-    for(size_t i = 0; i < recv_info->npts; ++i){
+    for(size_t i = 0; i < rcv_info->npts; ++i){
         strikes[i] = normalize_strike(strikes[i]);
     }
 }
@@ -548,7 +548,7 @@ static void load_geometry_from_points(
  * 从有限接收断层 points 输入变量读取接收断层形态
  *
  * @param[in]  ncid          输入 NetCDF 文件 ID
- * @param[in]  recv_info     输入接收点布局信息
+ * @param[in]  rcv_info      输入接收点布局信息
  * @param[in]  nfault_dimid  nfault 维度 ID
  * @param[in]  Ctrl          参数控制结构体
  * @param[out] strikes       各接收点走向角
@@ -556,7 +556,7 @@ static void load_geometry_from_points(
  * @param[out] rakes         各接收点滑动角
  */
 static void load_geometry_from_finite_points(
-    int ncid, const GRT_RECV_NC_INFO *recv_info,
+    int ncid, const GRT_RCV_NC_INFO *rcv_info,
     int nfault_dimid, const GRT_MODULE_CTRL *Ctrl,
     real_t *strikes, real_t *dips, real_t *rakes)
 {
@@ -633,7 +633,7 @@ static void load_geometry_from_finite_points(
     size_t start = 0;
     for(size_t ifault = 0; ifault < nfault; ++ifault){
         if((offsets[ifault] < 0) || ((size_t)offsets[ifault] <= start) ||
-            ((size_t)offsets[ifault] > recv_info->npts)){
+            ((size_t)offsets[ifault] > rcv_info->npts)){
             GRTRaiseError("Invalid offset for finite receiver fault %zu.", ifault);
         }
         size_t end = (size_t)offsets[ifault];
@@ -653,10 +653,10 @@ static void load_geometry_from_finite_points(
         }
         start = end;
     }
-    if(start != recv_info->npts){
+    if(start != rcv_info->npts){
         GRTRaiseError(
             "The last finite receiver offset (%zu) does not match point (%zu).",
-            start, recv_info->npts);
+            start, rcv_info->npts);
     }
 
     GRT_SAFE_FREE_PTR(fault_strikes);
@@ -670,7 +670,7 @@ static void load_geometry_from_finite_points(
  * 根据布局读取并确定每个接收点的断层形态
  *
  * @param[in]  ncid          输入 NetCDF 文件 ID
- * @param[in]  recv_info     输入接收点布局信息
+ * @param[in]  rcv_info      输入接收点布局信息
  * @param[in]  Ctrl          参数控制结构体
  * @param[in]  finite_points 是否为有限接收断层 points 布局
  * @param[in]  nfault_dimid  nfault 维度 ID
@@ -679,7 +679,7 @@ static void load_geometry_from_finite_points(
  * @param[out] rakes         各接收点滑动角
  */
 static void load_receiver_geometry(
-    int ncid, const GRT_RECV_NC_INFO *recv_info,
+    int ncid, const GRT_RCV_NC_INFO *rcv_info,
     const GRT_MODULE_CTRL *Ctrl, bool finite_points, int nfault_dimid,
     real_t *strikes, real_t *dips, real_t *rakes)
 {
@@ -692,12 +692,12 @@ static void load_receiver_geometry(
             GRTRaiseError("Finite receiver points require -M<rake> or -M<rake>+f.");
         }
         load_geometry_from_finite_points(
-            ncid, recv_info, nfault_dimid, Ctrl,
+            ncid, rcv_info, nfault_dimid, Ctrl,
             strikes, dips, rakes);
         return;
     }
 
-    if(recv_info->layout == GRT_RECV_NC_LAYOUT_GRID){
+    if(rcv_info->layout == GRT_RCV_NC_LAYOUT_GRID){
         // grid 没有逐点形态，只能使用完整的手动形态
         if(Ctrl->Q.active){
             GRTRaiseError("-Q can only be used with a points-layout input file.");
@@ -705,7 +705,7 @@ static void load_receiver_geometry(
         if(!Ctrl->M.active || !Ctrl->M.has_geometry || Ctrl->M.force_rake){
             GRTRaiseError("Grid input has no receiver geometry; set -M<strike>/<dip>/<rake>.");
         }
-        for(size_t i = 0; i < recv_info->npts; ++i){
+        for(size_t i = 0; i < rcv_info->npts; ++i){
             strikes[i] = Ctrl->M.strike;
             dips[i] = Ctrl->M.dip;
             rakes[i] = Ctrl->M.rake;
@@ -719,7 +719,7 @@ static void load_receiver_geometry(
     if(Ctrl->Q.active){
         // -Q 提供普通 points 的逐点新形态
         load_geometry_from_Q(
-            ncid, recv_info, Ctrl->Q.s_path, strikes, dips, rakes);
+            ncid, rcv_info, Ctrl->Q.s_path, strikes, dips, rakes);
         return;
     }
 
@@ -728,7 +728,7 @@ static void load_receiver_geometry(
         GRTRaiseError("Points input requires -M<strike>/<dip>/<rake>.");
     }
     load_geometry_from_points(
-        ncid, recv_info, Ctrl, strikes, dips, rakes);
+        ncid, rcv_info, Ctrl, strikes, dips, rakes);
 }
 
 
@@ -813,10 +813,10 @@ int static_sproj_main(int argc, char **argv)
     int ncid;
     NC_CHECK(nc_open(Ctrl->G.s_ingrid, NC_WRITE, &ncid));
 
-    GRT_RECV_NC_INFO recv_info;
-    grt_recv_nc_info_load(ncid, &recv_info);
-    int ndims = (recv_info.layout == GRT_RECV_NC_LAYOUT_POINTS) ? 1 : 2;
-    size_t npts = recv_info.npts;
+    GRT_RCV_NC_INFO rcv_info;
+    grt_rcv_nc_info_load(ncid, &rcv_info);
+    int ndims = (rcv_info.layout == GRT_RCV_NC_LAYOUT_POINTS) ? 1 : 2;
+    size_t npts = rcv_info.npts;
     // 通过 nfault 维度区分普通 points 和有限接收断层 points
     int nfault_dimid;
     int nfault_status = nc_inq_dimid(ncid, "nfault", &nfault_dimid);
@@ -824,7 +824,7 @@ int static_sproj_main(int argc, char **argv)
         NC_CHECK(nfault_status);
     }
     bool finite_points = (nfault_status == NC_NOERR);
-    if((recv_info.layout == GRT_RECV_NC_LAYOUT_GRID) && finite_points){
+    if((rcv_info.layout == GRT_RCV_NC_LAYOUT_GRID) && finite_points){
         GRTRaiseError("Grid input must not contain an nfault dimension.");
     }
 
@@ -832,14 +832,14 @@ int static_sproj_main(int argc, char **argv)
     const char *channels = rot2ZNE ? GRT_ZNE_CODES : GRT_ZRT_CODES;
     // 先把应力分量读入内存，避免在计算过程中反复访问 NetCDF
     real_t *stress6 = (real_t *)calloc(6 * npts, sizeof(real_t));
-    read_stress_components(ncid, channels, npts, ndims, recv_info.dimids, stress6);
+    read_stress_components(ncid, channels, npts, ndims, rcv_info.dimids, stress6);
 
     real_t *strikes = (real_t *)calloc(npts, sizeof(real_t));
     real_t *dips = (real_t *)calloc(npts, sizeof(real_t));
     real_t *rakes = (real_t *)calloc(npts, sizeof(real_t));
     // 根据布局和命令行选项确定每个 point 的接收断层形态
     load_receiver_geometry(
-        ncid, &recv_info, Ctrl, finite_points, nfault_dimid,
+        ncid, &rcv_info, Ctrl, finite_points, nfault_dimid,
         strikes, dips, rakes);
 
     real_t *sigma_n = (real_t *)calloc(npts, sizeof(real_t));
@@ -856,8 +856,8 @@ int static_sproj_main(int argc, char **argv)
         };
         if(!rot2ZNE){
             // ZRT 应力需要根据当前接收点方位角转换为 ZNE
-            real_t distance = hypot(recv_info.norths[i], recv_info.easts[i]);
-            real_t theta = GRT_IS_ZERO(distance) ? 0.0 : atan2(recv_info.easts[i], recv_info.norths[i]);
+            real_t distance = hypot(rcv_info.norths[i], rcv_info.easts[i]);
+            real_t theta = GRT_IS_ZERO(distance) ? 0.0 : atan2(rcv_info.easts[i], rcv_info.norths[i]);
             convert_zrt_stress_to_zne(theta, stress);
         }
 
@@ -867,11 +867,11 @@ int static_sproj_main(int argc, char **argv)
     }
 
     // 追加缺失的结果变量，或覆盖已有结果变量
-    write_projection_variables(ncid, ndims, recv_info.dimids, sigma_n, tau_s);
+    write_projection_variables(ncid, ndims, rcv_info.dimids, sigma_n, tau_s);
     NC_CHECK(nc_close(ncid));
 
     // 关闭文件后释放接收信息和计算缓存
-    grt_recv_nc_info_free(&recv_info);
+    grt_rcv_nc_info_free(&rcv_info);
     GRT_SAFE_FREE_PTR(stress6);
     GRT_SAFE_FREE_PTR(strikes);
     GRT_SAFE_FREE_PTR(dips);

--- a/pygrt/C_extension/src/static/grt_static_strain.c
+++ b/pygrt/C_extension/src/static/grt_static_strain.c
@@ -147,13 +147,13 @@ int static_strain_main(int argc, char **argv){
     }
 
     // 识别 grid / points 布局，并将坐标展平供统一计算
-    GRT_RECV_NC_INFO recv_info;
-    grt_recv_nc_info_load(in_ncid, &recv_info);
-    size_t npts = recv_info.npts;
-    real_t *norths_flat = recv_info.norths;
-    real_t *easts_flat = recv_info.easts;
-    int out_ndims = (recv_info.layout == GRT_RECV_NC_LAYOUT_POINTS) ? 1 : 2;
-    int out_dimids[2] = {recv_info.dimids[0], recv_info.dimids[1]};
+    GRT_RCV_NC_INFO rcv_info;
+    grt_rcv_nc_info_load(in_ncid, &rcv_info);
+    size_t npts = rcv_info.npts;
+    real_t *norths_flat = rcv_info.norths;
+    real_t *easts_flat = rcv_info.easts;
+    int out_ndims = (rcv_info.layout == GRT_RCV_NC_LAYOUT_POINTS) ? 1 : 2;
+    int out_dimids[2] = {rcv_info.dimids[0], rcv_info.dimids[1]};
 
     // 读入合成位移偏导 varid
     for(int c=0; c<GRT_CHANNEL_NUM; ++c){
@@ -211,7 +211,7 @@ int static_strain_main(int argc, char **argv){
     // 关闭文件
     NC_CHECK(nc_close(in_ncid));
 
-    grt_recv_nc_info_free(&recv_info);
+    grt_rcv_nc_info_free(&rcv_info);
     GRT_SAFE_FREE_PTR(s_ingrid);
     free_Ctrl(Ctrl);
     return EXIT_SUCCESS;

--- a/pygrt/C_extension/src/static/grt_static_stress.c
+++ b/pygrt/C_extension/src/static/grt_static_stress.c
@@ -180,18 +180,18 @@ int static_stress_main(int argc, char **argv){
     }
 
     // 识别 grid / points 布局，并将坐标展平供统一计算
-    GRT_RECV_NC_INFO recv_info;
-    grt_recv_nc_info_load(in_ncid, &recv_info);
-    size_t npts = recv_info.npts;
-    real_t *norths_flat = recv_info.norths;
-    real_t *easts_flat = recv_info.easts;
-    int out_ndims = (recv_info.layout == GRT_RECV_NC_LAYOUT_POINTS) ? 1 : 2;
-    int out_dimids[2] = {recv_info.dimids[0], recv_info.dimids[1]};
+    GRT_RCV_NC_INFO rcv_info;
+    grt_rcv_nc_info_load(in_ncid, &rcv_info);
+    size_t npts = rcv_info.npts;
+    real_t *norths_flat = rcv_info.norths;
+    real_t *easts_flat = rcv_info.easts;
+    int out_ndims = (rcv_info.layout == GRT_RCV_NC_LAYOUT_POINTS) ? 1 : 2;
+    int out_dimids[2] = {rcv_info.dimids[0], rcv_info.dimids[1]};
 
     // 逐点物性参数 mu/lam
     real_t *mu  = (real_t *)calloc(npts, sizeof(real_t));
     real_t *lam = (real_t *)calloc(npts, sizeof(real_t));
-    if(recv_info.layout == GRT_RECV_NC_LAYOUT_POINTS){
+    if(rcv_info.layout == GRT_RCV_NC_LAYOUT_POINTS){
         int va_varid;
         if(nc_inq_varid(in_ncid, "rcv_va", &va_varid) == NC_NOERR){
             int vb_varid, rho_varid;
@@ -274,7 +274,7 @@ int static_stress_main(int argc, char **argv){
     // 关闭文件
     NC_CHECK(nc_close(in_ncid));
 
-    grt_recv_nc_info_free(&recv_info);
+    grt_rcv_nc_info_free(&rcv_info);
     GRT_SAFE_FREE_PTR(mu);
     GRT_SAFE_FREE_PTR(lam);
     GRT_SAFE_FREE_PTR(s_ingrid);

--- a/pygrt/C_extension/src/static/grt_static_syn.c
+++ b/pygrt/C_extension/src/static/grt_static_syn.c
@@ -1273,13 +1273,13 @@ static void resolve_finite_fault_subdiv(
  * @param[in]  lib    静态格林函数库
  * @return            新分配的接收点结构体
  */
-static GRT_RECV_POINTS *build_syn_recv(const GRT_MODULE_CTRL *Ctrl, const STGRNLIB *lib)
+static GRT_RCV_POINTS *build_syn_rcv(const GRT_MODULE_CTRL *Ctrl, const STGRNLIB *lib)
 {
     if(Ctrl->Q.active){
-        return grt_recv_points_from_file(Ctrl->Q.s_path);
+        return grt_rcv_points_from_file(Ctrl->Q.s_path);
     }
     if(Ctrl->R.active){
-        return grt_recv_points_from_faults(
+        return grt_rcv_points_from_faults(
             Ctrl->R.nfault, Ctrl->R.faults, Ctrl->R.dL, Ctrl->R.dW);
     }
 
@@ -1288,7 +1288,7 @@ static GRT_RECV_POINTS *build_syn_recv(const GRT_MODULE_CTRL *Ctrl, const STGRNL
     const real_t *norths = Ctrl->isnewNEgrid ? Ctrl->X.norths : lib->norths;
     const real_t *easts  = Ctrl->isnewNEgrid ? Ctrl->Y.easts  : lib->easts;
     real_t deprcv = Ctrl->D.r_active ? Ctrl->D.deprcv : lib->deprcvs[0];
-    return grt_recv_points_from_grid(nnorth, norths, neast, easts, deprcv);
+    return grt_rcv_points_from_grid(nnorth, norths, neast, easts, deprcv);
 }
 
 
@@ -1315,7 +1315,7 @@ static void static_syn_get_medium(
  * @param[in]  path         输出 NetCDF 文件路径
  * @param[in]  Ctrl         static_syn 命令行控制结构体
  * @param[in]  lib          静态格林函数库
- * @param[in]  recv         规则网格、任意点或有限接收断层点列表
+ * @param[in]  rcv          规则网格、任意点或有限接收断层点列表
  * @param[in]  depsrc       点源深度 (km)
  * @param[in]  syn          位移数组
  * @param[in]  syn_upar     位移偏导数组
@@ -1324,7 +1324,7 @@ static void save_syn_nc(
     const char *path,
     const GRT_MODULE_CTRL *Ctrl,
     const STGRNLIB *lib,
-    const GRT_RECV_POINTS *recv,
+    const GRT_RCV_POINTS *rcv,
     real_t depsrc,
     const real_t (*syn)[GRT_CHANNEL_NUM],
     const real_t (*syn_upar)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM])
@@ -1345,7 +1345,7 @@ static void save_syn_nc(
         .has_depsrc = Ctrl->isPointSource,
         .depsrc = depsrc,
         .has_elastic_params = false,
-        .recv = recv,
+        .rcv = rcv,
         .get_medium = static_syn_get_medium,
         .medium_context = (void *)lib,
         .syn = syn,
@@ -1373,12 +1373,12 @@ int static_syn_main(int argc, char **argv){
     }
 
     // 接收点：网格、-Q 逐点或 -R 有限断层子断层中心
-    GRT_RECV_POINTS *recv = build_syn_recv(Ctrl, lib);
-    size_t npts = recv->npts;
-    const real_t *norths = recv->norths;
-    const real_t *easts = recv->easts;
-    const real_t *depths = recv->depths;
-    bool shared_depth = recv->is_grid;
+    GRT_RCV_POINTS *rcv = build_syn_rcv(Ctrl, lib);
+    size_t npts = rcv->npts;
+    const real_t *norths = rcv->norths;
+    const real_t *easts = rcv->easts;
+    const real_t *depths = rcv->depths;
+    bool shared_depth = rcv->is_grid;
 
     real_t (*syn)[GRT_CHANNEL_NUM] = (real_t (*)[GRT_CHANNEL_NUM])calloc(npts, sizeof(real_t) * GRT_CHANNEL_NUM);
     real_t (*syn_upar)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM] =
@@ -1419,7 +1419,7 @@ int static_syn_main(int argc, char **argv){
     }
 
     // 写出 nc（接收介质只在此处按布局查询，不参与合成）
-    save_syn_nc(Ctrl->O.s_outgrid, Ctrl, lib, recv, depsrc, syn, syn_upar);
+    save_syn_nc(Ctrl->O.s_outgrid, Ctrl, lib, rcv, depsrc, syn, syn_upar);
 
     if(!Ctrl->s.active){
         if(Ctrl->isFiniteFault){
@@ -1433,7 +1433,7 @@ int static_syn_main(int argc, char **argv){
 
     GRT_SAFE_FREE_PTR(syn);
     GRT_SAFE_FREE_PTR(syn_upar);
-    grt_recv_points_free(recv);
+    grt_rcv_points_free(rcv);
     grt_stgrnlib_free(lib);
     free_Ctrl(Ctrl);
     return EXIT_SUCCESS;

--- a/pygrt/C_extension/src/static/grt_xy2geo_geo2xy.c
+++ b/pygrt/C_extension/src/static/grt_xy2geo_geo2xy.c
@@ -41,7 +41,7 @@ typedef struct {
 
 /** 输入 NetCDF 文件中的坐标布局信息 */
 typedef struct {
-    GRT_RECV_NC_LAYOUT layout;
+    GRT_RCV_NC_LAYOUT layout;
     size_t first_count;
     size_t second_count;
 } GRT_COORD_INFO;
@@ -300,8 +300,8 @@ static void inspect_coordinate_layout(
     NC_CHECK(nc_inq_varid(ncid, first_name, &first_varid));
     NC_CHECK(nc_inq_varid(ncid, second_name, &second_varid));
 
-    info->layout = grt_recv_nc_get_layout(ncid);
-    if(info->layout == GRT_RECV_NC_LAYOUT_GRID){
+    info->layout = grt_rcv_nc_get_layout(ncid);
+    if(info->layout == GRT_RCV_NC_LAYOUT_GRID){
         int first_dimid, second_dimid;
         NC_CHECK(nc_inq_dimid(ncid, first_name, &first_dimid));
         NC_CHECK(nc_inq_dimid(ncid, second_name, &second_dimid));
@@ -462,7 +462,7 @@ static void check_target_name_available(int ncid, const char *name, bool is_dim)
  * @param[in]  direction 坐标转换方向
  */
 static void write_reference_and_rename_coordinates(
-    int ncid, GRT_RECV_NC_LAYOUT layout, const GRT_MODULE_CTRL *Ctrl,
+    int ncid, GRT_RCV_NC_LAYOUT layout, const GRT_MODULE_CTRL *Ctrl,
     GRT_TRANSFORM_DIRECTION direction)
 {
     const char *first_name, *second_name;
@@ -483,7 +483,7 @@ static void write_reference_and_rename_coordinates(
     check_target_name_available(ncid, target_second, false);
 
     int first_dimid = -1, second_dimid = -1;
-    if(layout == GRT_RECV_NC_LAYOUT_GRID){
+    if(layout == GRT_RCV_NC_LAYOUT_GRID){
         NC_CHECK(nc_inq_dimid(ncid, first_name, &first_dimid));
         NC_CHECK(nc_inq_dimid(ncid, second_name, &second_dimid));
         check_target_name_available(ncid, target_first, true);
@@ -495,7 +495,7 @@ static void write_reference_and_rename_coordinates(
         ncid, NC_GLOBAL, "lat0", NC_REAL, 1, &Ctrl->C.lat0));
     NC_CHECK(NC_FUNC_REAL(nc_put_att)(
         ncid, NC_GLOBAL, "lon0", NC_REAL, 1, &Ctrl->C.lon0));
-    if(layout == GRT_RECV_NC_LAYOUT_GRID){
+    if(layout == GRT_RCV_NC_LAYOUT_GRID){
         NC_CHECK(nc_rename_dim(ncid, first_dimid, target_first));
         NC_CHECK(nc_rename_dim(ncid, second_dimid, target_second));
     }

--- a/pygrt/C_extension/src/static/rcv_points.c
+++ b/pygrt/C_extension/src/static/rcv_points.c
@@ -1,5 +1,5 @@
 /**
- * @file   recv_points.c
+ * @file   rcv_points.c
  * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
  * @date   2026-08
  *
@@ -13,7 +13,7 @@
 #include <ctype.h>
 #include <errno.h>
 
-#include "grt/static/recv_points.h"
+#include "grt/static/rcv_points.h"
 #include "grt/common/checkerror.h"
 #include "grt/common/util.h"
 #include "grt/common/mynetcdf.h"
@@ -49,7 +49,7 @@ static bool parse_receiver_point_line(
     return *nvalues == 3 || *nvalues == 6;
 }
 
-GRT_RECV_POINTS *grt_recv_points_from_grid(
+GRT_RCV_POINTS *grt_rcv_points_from_grid(
     size_t nnorth, const real_t *norths,
     size_t neast,  const real_t *easts,
     real_t depth)
@@ -61,7 +61,7 @@ GRT_RECV_POINTS *grt_recv_points_from_grid(
         GRTRaiseError("Negative receiver depth is not supported.");
     }
 
-    GRT_RECV_POINTS *pts = (GRT_RECV_POINTS *)calloc(1, sizeof(GRT_RECV_POINTS));
+    GRT_RCV_POINTS *pts = (GRT_RCV_POINTS *)calloc(1, sizeof(GRT_RCV_POINTS));
     pts->is_grid = true;
     pts->nnorth = nnorth;
     pts->neast = neast;
@@ -82,7 +82,7 @@ GRT_RECV_POINTS *grt_recv_points_from_grid(
 }
 
 
-GRT_RECV_POINTS *grt_recv_points_from_file(const char *path)
+GRT_RCV_POINTS *grt_rcv_points_from_file(const char *path)
 {
     GRTCheckFileExist(path);
 
@@ -130,7 +130,7 @@ GRT_RECV_POINTS *grt_recv_points_from_file(const char *path)
         GRTRaiseError("No receiver points found in \"%s\".", path);
     }
 
-    GRT_RECV_POINTS *pts = (GRT_RECV_POINTS *)calloc(1, sizeof(GRT_RECV_POINTS));
+    GRT_RCV_POINTS *pts = (GRT_RCV_POINTS *)calloc(1, sizeof(GRT_RCV_POINTS));
     pts->is_grid = false;
     pts->nnorth = 0;
     pts->neast = 0;
@@ -157,7 +157,7 @@ GRT_RECV_POINTS *grt_recv_points_from_file(const char *path)
         size_t nvalues;
         if(!parse_receiver_point_line(line, values, &nvalues) || nvalues != ncolumns){
             GRT_SAFE_FREE_PTR(line);
-            grt_recv_points_free(pts);
+            grt_rcv_points_free(pts);
             fclose(fp);
             GRTRaiseError(
                 "Invalid receiver point at line %zu in \"%s\" "
@@ -166,7 +166,7 @@ GRT_RECV_POINTS *grt_recv_points_from_file(const char *path)
         }
         if(values[2] < 0.0){
             GRT_SAFE_FREE_PTR(line);
-            grt_recv_points_free(pts);
+            grt_rcv_points_free(pts);
             fclose(fp);
             GRTRaiseError("Negative receiver depth at line %zu in \"%s\".", lineno, path);
         }
@@ -187,7 +187,7 @@ GRT_RECV_POINTS *grt_recv_points_from_file(const char *path)
 }
 
 
-void grt_recv_points_free(GRT_RECV_POINTS *pts)
+void grt_rcv_points_free(GRT_RCV_POINTS *pts)
 {
     if(pts == NULL) return;
     // 释放接收点坐标和任意点的逐点几何
@@ -209,7 +209,7 @@ void grt_recv_points_free(GRT_RECV_POINTS *pts)
 }
 
 
-GRT_RECV_POINTS *grt_recv_points_from_faults(
+GRT_RCV_POINTS *grt_rcv_points_from_faults(
     size_t nfault, const FINITE_FAULT *faults, real_t dL, real_t dW)
 {
     if((nfault == 0) || (faults == NULL)){
@@ -219,7 +219,7 @@ GRT_RECV_POINTS *grt_recv_points_from_faults(
         GRTRaiseError("finite receiver dL and dW must both be positive or both be omitted.");
     }
 
-    GRT_RECV_POINTS *pts = (GRT_RECV_POINTS *)calloc(1, sizeof(*pts));
+    GRT_RCV_POINTS *pts = (GRT_RCV_POINTS *)calloc(1, sizeof(*pts));
     pts->is_fault = true;
     pts->nfault = nfault;
     pts->nsubs = (size_t *)calloc(nfault, sizeof(*pts->nsubs));
@@ -268,7 +268,7 @@ GRT_RECV_POINTS *grt_recv_points_from_faults(
 }
 
 
-GRT_RECV_NC_LAYOUT grt_recv_nc_get_layout(int ncid)
+GRT_RCV_NC_LAYOUT grt_rcv_nc_get_layout(int ncid)
 {
     size_t len = 0;
     int status = nc_inq_attlen(ncid, NC_GLOBAL, "layout", &len);
@@ -280,11 +280,11 @@ GRT_RECV_NC_LAYOUT grt_recv_nc_get_layout(int ncid)
     char *layout = (char *)calloc(len + 1, 1);
     NC_CHECK(nc_get_att_text(ncid, NC_GLOBAL, "layout", layout));
 
-    GRT_RECV_NC_LAYOUT result;
-    if(strcmp(layout, GRT_RECV_LAYOUT_GRID) == 0){
-        result = GRT_RECV_NC_LAYOUT_GRID;
-    } else if(strcmp(layout, GRT_RECV_LAYOUT_POINTS) == 0){
-        result = GRT_RECV_NC_LAYOUT_POINTS;
+    GRT_RCV_NC_LAYOUT result;
+    if(strcmp(layout, GRT_RCV_LAYOUT_GRID) == 0){
+        result = GRT_RCV_NC_LAYOUT_GRID;
+    } else if(strcmp(layout, GRT_RCV_LAYOUT_POINTS) == 0){
+        result = GRT_RCV_NC_LAYOUT_POINTS;
     } else {
         GRTRaiseError("unsupported static receiver layout \"%s\".", layout);
     }
@@ -293,16 +293,16 @@ GRT_RECV_NC_LAYOUT grt_recv_nc_get_layout(int ncid)
 }
 
 
-void grt_recv_nc_info_load(int ncid, GRT_RECV_NC_INFO *info)
+void grt_rcv_nc_info_load(int ncid, GRT_RCV_NC_INFO *info)
 {
     if(info == NULL){
         GRTRaiseError("receiver NetCDF info is NULL.");
     }
     memset(info, 0, sizeof(*info));
     // 先确定文件布局，再按布局读取并组织接收坐标
-    info->layout = grt_recv_nc_get_layout(ncid);
+    info->layout = grt_rcv_nc_get_layout(ncid);
 
-    if(info->layout == GRT_RECV_NC_LAYOUT_GRID){
+    if(info->layout == GRT_RCV_NC_LAYOUT_GRID){
         size_t nnorth, neast;
         int north_varid, east_varid;
         NC_CHECK(nc_inq_dimid(ncid, "north", &info->dimids[0]));
@@ -332,7 +332,7 @@ void grt_recv_nc_info_load(int ncid, GRT_RECV_NC_INFO *info)
         return;
     }
 
-    if(info->layout == GRT_RECV_NC_LAYOUT_POINTS){
+    if(info->layout == GRT_RCV_NC_LAYOUT_POINTS){
         int north_varid, east_varid;
         // 一维接收点文件的坐标已经展平，可以直接读取到输出数组
         NC_CHECK(nc_inq_dimid(ncid, "point", &info->dimids[0]));
@@ -349,7 +349,7 @@ void grt_recv_nc_info_load(int ncid, GRT_RECV_NC_INFO *info)
 }
 
 
-void grt_recv_nc_info_free(GRT_RECV_NC_INFO *info)
+void grt_rcv_nc_info_free(GRT_RCV_NC_INFO *info)
 {
     if(info == NULL) return;
     // 坐标数组由该结构体管理，结构体本身由调用方管理
@@ -359,7 +359,7 @@ void grt_recv_nc_info_free(GRT_RECV_NC_INFO *info)
 }
 
 
-bool grt_recv_nc_is_points(int ncid)
+bool grt_rcv_nc_is_points(int ncid)
 {
-    return grt_recv_nc_get_layout(ncid) == GRT_RECV_NC_LAYOUT_POINTS;
+    return grt_rcv_nc_get_layout(ncid) == GRT_RCV_NC_LAYOUT_POINTS;
 }

--- a/pygrt/C_extension/src/static/static_output.c
+++ b/pygrt/C_extension/src/static/static_output.c
@@ -108,10 +108,10 @@ static void write_grid_layout(
     int ncid, const GRT_STATIC_NC_OUTPUT *output,
     int vars[GRT_CHANNEL_NUM], int dvars[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM])
 {
-    const GRT_RECV_POINTS *recv = output->recv;
+    const GRT_RCV_POINTS *rcv = output->rcv;
     int dimids[2];
     int north_varid, east_varid;
-    real_t deprcv = recv->depths[0];
+    real_t deprcv = rcv->depths[0];
     real_t rcv_va, rcv_vb, rcv_rho;
 
     // 规则网格使用统一接收深度，将对应介质参数保存为全局属性
@@ -122,8 +122,8 @@ static void write_grid_layout(
     NC_CHECK(NC_FUNC_REAL(nc_put_att)(ncid, NC_GLOBAL, "rcv_vb", NC_REAL, 1, &rcv_vb));
     NC_CHECK(NC_FUNC_REAL(nc_put_att)(ncid, NC_GLOBAL, "rcv_rho", NC_REAL, 1, &rcv_rho));
 
-    NC_CHECK(nc_def_dim(ncid, "north", recv->nnorth, &dimids[0]));
-    NC_CHECK(nc_def_dim(ncid, "east", recv->neast, &dimids[1]));
+    NC_CHECK(nc_def_dim(ncid, "north", rcv->nnorth, &dimids[0]));
+    NC_CHECK(nc_def_dim(ncid, "east", rcv->neast, &dimids[1]));
     NC_CHECK(nc_def_var(ncid, "north", NC_REAL, 1, &dimids[0], &north_varid));
     NC_CHECK(nc_def_var(ncid, "east", NC_REAL, 1, &dimids[1], &east_varid));
     define_channel_vars(
@@ -131,20 +131,20 @@ static void write_grid_layout(
     // 结束定义模式后写入坐标轴和位移数据
     NC_CHECK(nc_enddef(ncid));
 
-    real_t *north_axis = (real_t *)calloc(recv->nnorth, sizeof(real_t));
-    real_t *east_axis = (real_t *)calloc(recv->neast, sizeof(real_t));
+    real_t *north_axis = (real_t *)calloc(rcv->nnorth, sizeof(real_t));
+    real_t *east_axis = (real_t *)calloc(rcv->neast, sizeof(real_t));
     // 接收点坐标在内存中按 point 展平，写网格文件时恢复为两个坐标轴
-    for(size_t inorth = 0; inorth < recv->nnorth; ++inorth){
-        north_axis[inorth] = recv->norths[inorth * recv->neast];
+    for(size_t inorth = 0; inorth < rcv->nnorth; ++inorth){
+        north_axis[inorth] = rcv->norths[inorth * rcv->neast];
     }
-    for(size_t ieast = 0; ieast < recv->neast; ++ieast){
-        east_axis[ieast] = recv->easts[ieast];
+    for(size_t ieast = 0; ieast < rcv->neast; ++ieast){
+        east_axis[ieast] = rcv->easts[ieast];
     }
     NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, north_varid, north_axis));
     NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, east_varid, east_axis));
     GRT_SAFE_FREE_PTR(north_axis);
     GRT_SAFE_FREE_PTR(east_axis);
-    write_fields(ncid, recv->npts, output->calc_upar, output->syn, output->syn_upar, vars, dvars);
+    write_fields(ncid, rcv->npts, output->calc_upar, output->syn, output->syn_upar, vars, dvars);
 }
 
 /**
@@ -159,12 +159,12 @@ static void write_points_layout(
     int ncid, const GRT_STATIC_NC_OUTPUT *output,
     int vars[GRT_CHANNEL_NUM], int dvars[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM])
 {
-    const GRT_RECV_POINTS *recv = output->recv;
-    // 有限接收断层已经在 GRT_RECV_POINTS 中展开为一维点数组
-    size_t npts = recv->npts;
-    const real_t *norths = recv->norths;
-    const real_t *easts = recv->easts;
-    const real_t *depths = recv->depths;
+    const GRT_RCV_POINTS *rcv = output->rcv;
+    // 有限接收断层已经在 GRT_RCV_POINTS 中展开为一维点数组
+    size_t npts = rcv->npts;
+    const real_t *norths = rcv->norths;
+    const real_t *easts = rcv->easts;
+    const real_t *depths = rcv->depths;
     int point_dimid;
     int point_dimids[1];
     int north_varid, east_varid, depth_varid;
@@ -181,16 +181,16 @@ static void write_points_layout(
     NC_CHECK(nc_def_var(ncid, "rcv_va", NC_REAL, 1, point_dimids, &va_varid));
     NC_CHECK(nc_def_var(ncid, "rcv_vb", NC_REAL, 1, point_dimids, &vb_varid));
     NC_CHECK(nc_def_var(ncid, "rcv_rho", NC_REAL, 1, point_dimids, &rho_varid));
-    if(recv->is_fault){
+    if(rcv->is_fault){
         int fault_dimid;
-        NC_CHECK(nc_def_dim(ncid, "nfault", recv->nfault, &fault_dimid));
+        NC_CHECK(nc_def_dim(ncid, "nfault", rcv->nfault, &fault_dimid));
         NC_CHECK(nc_def_var(ncid, "strike", NC_REAL, 1, &fault_dimid, &strike_varid));
         NC_CHECK(nc_def_var(ncid, "dip", NC_REAL, 1, &fault_dimid, &dip_varid));
         NC_CHECK(nc_def_var(ncid, "rake", NC_REAL, 1, &fault_dimid, &rake_varid));
         NC_CHECK(nc_def_var(ncid, "offset", NC_INT, 1, &fault_dimid, &offset_varid));
         NC_CHECK(nc_def_var(ncid, "stksize", NC_INT, 1, &fault_dimid, &stksize_varid));
         NC_CHECK(nc_def_var(ncid, "dipsize", NC_INT, 1, &fault_dimid, &dipsize_varid));
-    } else if(recv->has_geometry){
+    } else if(rcv->has_geometry){
         NC_CHECK(nc_def_var(ncid, "strike", NC_REAL, 1, point_dimids, &strike_varid));
         NC_CHECK(nc_def_var(ncid, "dip", NC_REAL, 1, point_dimids, &dip_varid));
         NC_CHECK(nc_def_var(ncid, "rake", NC_REAL, 1, point_dimids, &rake_varid));
@@ -215,36 +215,36 @@ static void write_points_layout(
     NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, va_varid, rcv_va));
     NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, vb_varid, rcv_vb));
     NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, rho_varid, rcv_rho));
-    if(recv->is_fault){
+    if(rcv->is_fault){
         // offset 保存每条有限断层点范围的排他性结束索引，最后一个值等于 point
-        int *offsets = (int *)calloc(recv->nfault, sizeof(int));
-        int *stksizes = (int *)calloc(recv->nfault, sizeof(int));
-        int *dipsizes = (int *)calloc(recv->nfault, sizeof(int));
-        for(size_t ifault = 0; ifault < recv->nfault; ++ifault){
-            if(recv->offsets[ifault] > (size_t)INT_MAX){
+        int *offsets = (int *)calloc(rcv->nfault, sizeof(int));
+        int *stksizes = (int *)calloc(rcv->nfault, sizeof(int));
+        int *dipsizes = (int *)calloc(rcv->nfault, sizeof(int));
+        for(size_t ifault = 0; ifault < rcv->nfault; ++ifault){
+            if(rcv->offsets[ifault] > (size_t)INT_MAX){
                 GRTRaiseError("receiver point offset exceeds the NetCDF integer range.");
             }
-            if((recv->stksizes[ifault] > (size_t)INT_MAX) ||
-                (recv->dipsizes[ifault] > (size_t)INT_MAX)){
+            if((rcv->stksizes[ifault] > (size_t)INT_MAX) ||
+                (rcv->dipsizes[ifault] > (size_t)INT_MAX)){
                 GRTRaiseError("receiver fault subdivision count exceeds the NetCDF integer range.");
             }
-            offsets[ifault] = (int)recv->offsets[ifault];
-            stksizes[ifault] = (int)recv->stksizes[ifault];
-            dipsizes[ifault] = (int)recv->dipsizes[ifault];
+            offsets[ifault] = (int)rcv->offsets[ifault];
+            stksizes[ifault] = (int)rcv->stksizes[ifault];
+            dipsizes[ifault] = (int)rcv->dipsizes[ifault];
         }
-        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, strike_varid, recv->fstrikes));
-        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, dip_varid, recv->fdips));
-        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, rake_varid, recv->frakes));
+        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, strike_varid, rcv->fstrikes));
+        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, dip_varid, rcv->fdips));
+        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, rake_varid, rcv->frakes));
         NC_CHECK(nc_put_var_int(ncid, offset_varid, offsets));
         NC_CHECK(nc_put_var_int(ncid, stksize_varid, stksizes));
         NC_CHECK(nc_put_var_int(ncid, dipsize_varid, dipsizes));
         GRT_SAFE_FREE_PTR(offsets);
         GRT_SAFE_FREE_PTR(stksizes);
         GRT_SAFE_FREE_PTR(dipsizes);
-    } else if(recv->has_geometry){
-        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, strike_varid, recv->strikes));
-        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, dip_varid, recv->dips));
-        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, rake_varid, recv->rakes));
+    } else if(rcv->has_geometry){
+        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, strike_varid, rcv->strikes));
+        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, dip_varid, rcv->dips));
+        NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, rake_varid, rcv->rakes));
     }
     GRT_SAFE_FREE_PTR(rcv_va);
     GRT_SAFE_FREE_PTR(rcv_vb);
@@ -263,7 +263,7 @@ void grt_static_save_nc(const GRT_STATIC_NC_OUTPUT *output)
     if((output == NULL) || (output->path == NULL)){
         GRTRaiseError("static NetCDF output description is incomplete.");
     }
-    if(output->recv == NULL){
+    if(output->rcv == NULL){
         GRTRaiseError("static NetCDF output has no receiver layout.");
     }
     if(output->get_medium == NULL){
@@ -272,10 +272,10 @@ void grt_static_save_nc(const GRT_STATIC_NC_OUTPUT *output)
 
     // 有限接收断层和任意接收点使用一维布局，规则网格使用二维布局
     const char *layout;
-    if(output->recv->is_grid && !output->recv->is_fault){
-        layout = GRT_RECV_LAYOUT_GRID;
+    if(output->rcv->is_grid && !output->rcv->is_fault){
+        layout = GRT_RCV_LAYOUT_GRID;
     } else {
-        layout = GRT_RECV_LAYOUT_POINTS;
+        layout = GRT_RCV_LAYOUT_POINTS;
     }
 
     int ncid;
@@ -310,7 +310,7 @@ void grt_static_save_nc(const GRT_STATIC_NC_OUTPUT *output)
     int vars[GRT_CHANNEL_NUM];
     int dvars[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM];
     // 根据接收点布局定义维度、坐标变量和结果变量并写入数据
-    if(output->recv->is_grid && !output->recv->is_fault){
+    if(output->rcv->is_grid && !output->rcv->is_fault){
         write_grid_layout(ncid, output, vars, dvars);
     } else {
         write_points_layout(ncid, output, vars, dvars);

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -22,7 +22,7 @@ from obspy import read
 
 from .cli import format_float, format_range, run_grt
 from .c_interfaces import C_grt_compute_travt1d_from_file, C_grt_free, PREAL
-from .utils import read_nc_variables
+from .utils import _resolve_rcv_points, read_nc_variables
 
 
 PathLike = Union[str, os.PathLike]
@@ -1395,7 +1395,7 @@ class PyModel1D:
         deprcv: Optional[float] = None,
         norths: Optional[Sequence[float]] = None,
         easts: Optional[Sequence[float]] = None,
-        recv_points: Optional[PathLike] = None,
+        rcv_points: Optional[PathLike] = None,
         rcv_fault: Optional[PathLike] = None,
         rcv_fault_size: Optional[Sequence[float]] = None,
         output_path: PathLike,
@@ -1411,6 +1411,7 @@ class PyModel1D:
         zne: bool = False,
         calc_upar: bool = False,
         return_result: bool = False,
+        **kwargs,
     ):
         r"""
         Synthesize static three-component displacement with ``grt static_syn``.
@@ -1421,13 +1422,13 @@ class PyModel1D:
 
         Receivers default to the library north/east grid. Optionally redefine
         them with ``norths``/``easts`` (uniform ``deprcv`` when the library has
-        multiple receiver depths), or with ``recv_points`` for an ASCII file of
+        multiple receiver depths), or with ``rcv_points`` for an ASCII file of
         arbitrary ``north east depth`` points (CLI ``-Q``). Each row may append
         ``strike dip rake`` in degrees; these angles are saved in the output but
-        are not used in synthesis. ``recv_points`` is
+        are not used in synthesis. ``rcv_points`` is
         mutually exclusive with ``norths``/``easts`` and ``deprcv``. If the
         library was built with ``dists`` / ``-R``, the default grid is a 1-D
-        line (north = 0, east = R); set ``norths``/``easts`` or ``recv_points``
+        line (north = 0, east = R); set ``norths``/``easts`` or ``rcv_points``
         to obtain a 2-D field.
         A Coulomb-format finite receiver-fault file can be supplied through
         ``rcv_fault`` (CLI ``-R``); without ``rcv_fault_size`` the subdivision
@@ -1467,25 +1468,25 @@ class PyModel1D:
                                      ``src_fault`` is set.
         :param    deprcv:            Receiver depth in km for grid receivers
                                      (CLI ``-Dr``). Required when the library has
-                                     multiple receiver depths and ``recv_points`` is
+                                     multiple receiver depths and ``rcv_points`` is
                                      not used; optional when it has one, but an
                                      explicit value must match the library. Do not set
-                                     it when using ``recv_points``.
+                                     it when using ``rcv_points``.
         :param    norths:            Optional new north grid as three values
                                      ``(start, stop, step)`` in km. Must be set
                                      together with ``easts``. Mutually exclusive
-                                     with ``recv_points``.
+                                     with ``rcv_points``.
         :param    easts:             Optional new east grid as three values
                                      ``(start, stop, step)`` in km. Must be set
                                      together with ``norths``. Mutually exclusive
-                                     with ``recv_points``.
-        :param    recv_points:       ASCII file of arbitrary receivers
+                                     with ``rcv_points``.
+        :param    rcv_points:        ASCII file of arbitrary receivers
                                      (``north east depth`` in km, optionally
                                      followed by ``strike dip rake`` in degrees;
                                      ``#`` comments). All data rows must use the
                                      same 3- or 6-column format. Mutually exclusive
                                      with ``norths``/``easts`` and ``deprcv``.
-        :param    rcv_fault:        Coulomb-format finite receiver-fault file with 11 data
+        :param    rcv_fault:         Coulomb-format finite receiver-fault file with 11 data
                                      columns; an exact ``rake`` token in the seventh header
                                      column selects Kode 100 rake/net-slip interpretation
                                      (CLI ``-R``). Without ``rcv_fault_size``,
@@ -1493,9 +1494,9 @@ class PyModel1D:
                                      default subdivision size. With that argument,
                                      each fault contributes multiple subfault
                                      centers. Mutually exclusive with
-                                     ``recv_points``, ``norths``/``easts`` and
+                                     ``rcv_points``, ``norths``/``easts`` and
                                      ``deprcv``.
-        :param    rcv_fault_size:   Optional positive ``(dL, dW)`` in km for
+        :param    rcv_fault_size:    Optional positive ``(dL, dW)`` in km for
                                      receiver-fault subdivision along strike / dip;
                                      if omitted, use the smallest positive interval
                                      among epicentral distance, source depth and
@@ -1554,13 +1555,14 @@ class PyModel1D:
         :return: The synthesized NetCDF data when ``return_result`` is true;
                  otherwise ``None``.
         """
+        rcv_points = _resolve_rcv_points(rcv_points, kwargs, "PyModel1D.static_syn")
         if self.stgrn is None:
             raise RuntimeError("Pass stgrn= to PyModel1D(...) before static_syn().")
         output = Path(output_path)
         output.parent.mkdir(parents=True, exist_ok=True)
 
         use_ff = src_fault is not None
-        use_q = recv_points is not None
+        use_q = rcv_points is not None
         use_r = rcv_fault is not None
         use_xy = norths is not None or easts is not None
         has_geometry = strike is not None or dip is not None or rake is not None
@@ -1576,11 +1578,11 @@ class PyModel1D:
         if use_ff and has_point_source_options:
             raise ValueError("src_fault is mutually exclusive with point-source options.")
         if ((use_q or use_r) and use_xy):
-            raise ValueError("recv_points/rcv_fault is mutually exclusive with norths/easts.")
+            raise ValueError("rcv_points/rcv_fault is mutually exclusive with norths/easts.")
         if (use_q and use_r):
-            raise ValueError("recv_points and rcv_fault are mutually exclusive.")
+            raise ValueError("rcv_points and rcv_fault are mutually exclusive.")
         if ((use_q or use_r) and (deprcv is not None)):
-            raise ValueError("recv_points/rcv_fault is mutually exclusive with deprcv.")
+            raise ValueError("rcv_points/rcv_fault is mutually exclusive with deprcv.")
         if use_xy and (norths is None or easts is None):
             raise ValueError("norths and easts must be supplied together.")
         if depsrc is not None and depsrc < 0.0:
@@ -1624,7 +1626,7 @@ class PyModel1D:
         if deprcv is not None:
             command["Dr"] = f"-Dr{format_float(deprcv)}"
         if use_q:
-            command["Q"] = f"-Q{Path(recv_points)}"
+            command["Q"] = f"-Q{Path(rcv_points)}"
         elif use_r:
             r_opt = f"-R{Path(rcv_fault)}"
             if rcv_fault_size is not None:

--- a/pygrt/utils.py
+++ b/pygrt/utils.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import glob
+import warnings
 from copy import deepcopy
 from pathlib import Path
 from typing import List, Optional, Sequence, Union
@@ -81,6 +82,26 @@ __all__ = [
 
 
 PathLike = Union[str, os.PathLike]
+
+
+def _resolve_rcv_points(rcv_points: Optional[PathLike], kwargs: dict, function_name: str):
+    """解析 ``recv_points`` 兼容关键字并返回规范参数"""
+    if "recv_points" in kwargs:
+        legacy_points = kwargs.pop("recv_points")
+        if rcv_points is not None and legacy_points is not None:
+            raise TypeError(f"{function_name}() got both 'rcv_points' and deprecated 'recv_points'.")
+        warnings.warn(
+            "'recv_points' is deprecated; it is an alias of 'rcv_points'.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        if rcv_points is None:
+            rcv_points = legacy_points
+
+    if kwargs:
+        name = next(iter(kwargs))
+        raise TypeError(f"{function_name}() got an unexpected keyword argument {name!r}.")
+    return rcv_points
 
 
 QWV_NUM = 3
@@ -166,7 +187,7 @@ def okada(
     deprcv: Optional[float] = None,
     norths: Optional[Sequence[float]] = None,
     easts: Optional[Sequence[float]] = None,
-    recv_points: Optional[PathLike] = None,
+    rcv_points: Optional[PathLike] = None,
     rcv_fault: Optional[PathLike] = None,
     rcv_fault_size: Optional[Sequence[float]] = None,
     output_path: PathLike,
@@ -179,6 +200,7 @@ def okada(
     zne: bool = False,
     calc_upar: bool = False,
     return_result: bool = False,
+    **kwargs,
 ):
     r"""
     Synthesize static displacement with the Okada homogeneous half-space solution.
@@ -210,14 +232,14 @@ def okada(
     All arguments must be passed by keyword.
 
     :param    modelparams:      Homogeneous half-space parameters ``(vp, vs, rho)``;
-                               velocities are in km/s and density is in g/cm^3
+                                velocities are in km/s and density is in g/cm^3
     :param    depsrc:           Point-source depth in km. Required for point
-                               sources and forbidden for finite faults
+                                sources and forbidden for finite faults
     :param    deprcv:           Receiver depth in km for a regular grid. Forbidden
-                               when ``recv_points`` is used
+                                when ``rcv_points`` is used
     :param    norths:           North grid range ``(start, stop, step)`` in km
     :param    easts:            East grid range ``(start, stop, step)`` in km
-    :param    recv_points:      ASCII receiver file with either ``north east depth``
+    :param    rcv_points:       ASCII receiver file with either ``north east depth``
                                 or ``north east depth strike dip rake``; coordinates
                                 are in km and angles are in degrees
     :param    rcv_fault:        Coulomb-format finite receiver-fault file. Each
@@ -227,9 +249,9 @@ def okada(
                                 in km along strike / dip
     :param    output_path:      Output NetCDF file path
     :param    scale:            Point-source scale in dyne-cm unless
-                               ``scale_with_mu`` is true. Not used for finite faults
+                                ``scale_with_mu`` is true. Not used for finite faults
     :param    scale_with_mu:    If true, pass ``-Su`` and treat ``scale`` as potency
-                               or area times slip in cm^3
+                                or area times slip in cm^3
     :param    strike:           Fault strike in degrees, in [0, 360]
     :param    dip:              Fault dip in degrees, in [0, 90]
     :param    rake:             Slip rake in degrees, in [-180, 180]
@@ -255,10 +277,11 @@ def okada(
             raise ValueError("modelparams must contain exactly three values: (vp, vs, rho).")
     except TypeError:
         raise TypeError("modelparams must be a sequence of (vp, vs, rho).") from None
+    rcv_points = _resolve_rcv_points(rcv_points, kwargs, "okada")
     vp, vs, rho = modelparams
 
     use_ff = src_fault is not None
-    use_q = recv_points is not None
+    use_q = rcv_points is not None
     use_r = rcv_fault is not None
     use_xy = norths is not None or easts is not None
     has_strike = strike is not None
@@ -277,19 +300,19 @@ def okada(
         return f"-M{format_float(strike)}/{format_float(dip)}"
 
     if ((use_q or use_r) and use_xy):
-        raise ValueError("recv_points/rcv_fault is mutually exclusive with norths/easts.")
+        raise ValueError("rcv_points/rcv_fault is mutually exclusive with norths/easts.")
     if (use_q and use_r):
-        raise ValueError("recv_points and rcv_fault are mutually exclusive.")
+        raise ValueError("rcv_points and rcv_fault are mutually exclusive.")
     if use_xy and (norths is None or easts is None):
         raise ValueError("norths and easts must be supplied together.")
     if ((not use_q) and (not use_r) and (not use_xy)):
-        raise ValueError("Specify norths/easts, recv_points or rcv_fault.")
+        raise ValueError("Specify norths/easts, rcv_points or rcv_fault.")
     if depsrc is not None and depsrc < 0.0:
         raise ValueError("depsrc must be nonnegative.")
     if deprcv is not None and deprcv < 0.0:
         raise ValueError("deprcv must be nonnegative.")
     if ((use_q or use_r) and (deprcv is not None)):
-        raise ValueError("recv_points/rcv_fault is mutually exclusive with deprcv.")
+        raise ValueError("rcv_points/rcv_fault is mutually exclusive with deprcv.")
     if rcv_fault_size is not None:
         if (not use_r):
             raise ValueError("rcv_fault_size requires rcv_fault.")
@@ -324,7 +347,7 @@ def okada(
         raise ValueError("deprcv is required for grid receivers.")
 
     if use_q:
-        command.append(f"-Q{Path(recv_points)}")
+        command.append(f"-Q{Path(rcv_points)}")
     elif use_r:
         receiver_option = f"-R{Path(rcv_fault)}"
         if rcv_fault_size is not None:
@@ -465,9 +488,10 @@ def static_sproj(
     strike: Optional[float] = None,
     dip: Optional[float] = None,
     rake: Optional[float] = None,
-    recv_points: Optional[PathLike] = None,
+    rcv_points: Optional[PathLike] = None,
     force_rake: bool = False,
     return_result: bool = False,
+    **kwargs,
 ):
     """
     Project static stress tensors onto receiver-fault geometry in place.
@@ -477,30 +501,31 @@ def static_sproj(
     six stress components produced by ``static_stress``. For grid and ordinary
     points layouts, pass ``strike``, ``dip`` and ``rake`` together. For finite
     receiver points, pass only ``rake`` when the file has undefined rake values;
-    set ``force_rake=True`` to replace every rake. ``recv_points`` corresponds
+    set ``force_rake=True`` to replace every rake. ``rcv_points`` corresponds
     to the C module's ``-Q`` option and must contain six columns per row.
 
     Results are written back to ``path`` as ``sigma_n`` and ``tau_s``.
 
-    :param    path:         Static synthesis NetCDF file containing stress components.
-    :param    strike:       Manual receiver strike in degrees.
-    :param    dip:          Manual receiver dip in degrees.
-    :param    rake:         Manual receiver rake in degrees.
-    :param    recv_points:  Six-column receiver geometry file for the ``-Q`` option.
-    :param    force_rake:   If true, append ``+f`` and force the manual rake for all finite points.
+    :param    path:          Static synthesis NetCDF file containing stress components.
+    :param    strike:        Manual receiver strike in degrees.
+    :param    dip:           Manual receiver dip in degrees.
+    :param    rake:          Manual receiver rake in degrees.
+    :param    rcv_points:    Six-column receiver geometry file for the ``-Q`` option.
+    :param    force_rake:    If true, append ``+f`` and force the manual rake for all finite points.
     :param    return_result: If true, return the processed NetCDF data.
 
     :return: The result from :func:`read_nc_variables` when ``return_result`` is true;
              otherwise ``None``
     """
+    rcv_points = _resolve_rcv_points(rcv_points, kwargs, "static_sproj")
     options = []
     geometry = [value for value in (strike, dip, rake) if value is not None]
     if geometry:
         geometry_text = "/".join(format_float(value) for value in geometry)
         options.append(f"-M{geometry_text}{'+f' if force_rake else ''}")
 
-    if recv_points is not None:
-        options.append(f"-Q{Path(recv_points)}")
+    if rcv_points is not None:
+        options.append(f"-Q{Path(rcv_points)}")
 
     return _run_static_file_module(path, "static_sproj", options, return_result)
 

--- a/test/_compare_c_py/compare_stgrnlib.py
+++ b/test/_compare_c_py/compare_stgrnlib.py
@@ -194,7 +194,7 @@ def compare_syn_cli_py() -> list:
     c_out = CMPDIR / "stsyn_q_c.nc"
     py_out = CMPDIR / "stsyn_q_py.nc"
     c_static_syn(grn, c_out, ["-Ds2", f"-Q{rcv}"])
-    py_static_syn(grn, py_out, depsrc=2.0, recv_points=rcv)
+    py_static_syn(grn, py_out, depsrc=2.0, rcv_points=rcv)
     errors.append(compare_nc_files(py_out, c_out))
 
     print("\n--- syn + strain/rotation/stress ---")

--- a/test/_compare_c_py/test_cli_args.py
+++ b/test/_compare_c_py/test_cli_args.py
@@ -787,7 +787,7 @@ def test_static_syn_and_tensor_postprocess_args():
         )
 
         # 多深度点源 + 任意接收点
-        model.static_syn(scale=1e20, output_path=out, depsrc=2.0, recv_points=HERE / "rcv.txt")
+        model.static_syn(scale=1e20, output_path=out, depsrc=2.0, rcv_points=HERE / "rcv.txt")
         assert_command_has(runner.commands[-1], "static_syn", f"-G{model.stgrn}", f"-O{out}", "-S1e+20", "-Ds2", f"-Q{HERE / 'rcv.txt'}")
 
         # 多深度点源 + 新网格 + 台站深度
@@ -850,7 +850,7 @@ def test_static_sproj_and_coulomb_args():
         pygrt.utils.static_sproj(static, rake=55.0, force_rake=True)
         assert_command_equals(runner.commands[-1], ["static_sproj", f"-G{static}", "-M55+f"])
 
-        pygrt.utils.static_sproj(static, recv_points=receiver)
+        pygrt.utils.static_sproj(static, rcv_points=receiver)
         assert_command_equals(runner.commands[-1], ["static_sproj", f"-G{static}", f"-Q{receiver}"])
 
         pygrt.utils.static_coulomb(static, 0.6)
@@ -867,6 +867,83 @@ def test_static_sproj_and_coulomb_args():
         static.unlink(missing_ok=True)
         receiver.unlink(missing_ok=True)
         dynamic.rmdir()
+
+
+def test_deprecated_recv_points_alias():
+    runner = CapturedRunner()
+    original_pymod = _patch_run_grt(pygrt.pymod, runner)
+    original_utils = _patch_run_grt(pygrt.utils, runner)
+    static = HERE / "_tmp_args_deprecated_sproj.nc"
+    receiver = HERE / "_tmp_args_deprecated_rcv_points.txt"
+
+    def assert_deprecation(caught):
+        assert len(caught) == 1
+        assert issubclass(caught[0].category, DeprecationWarning)
+        message = str(caught[0].message)
+        assert "recv_points" in message
+        assert "rcv_points" in message
+
+    try:
+        model = pygrt.PyModel1D(stgrn=HERE / "_tmp_args_deprecated_static.nc", modelpath=MODEL)
+        static.write_bytes(b"placeholder")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            model.static_syn(
+                scale=1e20,
+                output_path=HERE / "_tmp_args_deprecated_syn.nc",
+                depsrc=2.0,
+                **{"recv_points": receiver},
+            )
+        assert_deprecation(caught)
+        assert_command_has(runner.commands[-1], "static_syn", f"-Q{receiver}")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pygrt.utils.okada(
+                modelparams=(6.0, 3.464, 2.7),
+                depsrc=2.0,
+                output_path=HERE / "_tmp_args_deprecated_okada.nc",
+                scale=1e20,
+                **{"recv_points": receiver},
+            )
+        assert_deprecation(caught)
+        assert_command_has(runner.commands[-1], "okada", f"-Q{receiver}")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pygrt.utils.static_sproj(static, **{"recv_points": receiver})
+        assert_deprecation(caught)
+        assert_command_has(runner.commands[-1], "static_sproj", f"-Q{receiver}")
+
+        try:
+            model.static_syn(
+                scale=1e20,
+                output_path=HERE / "_tmp_args_deprecated_conflict.nc",
+                depsrc=2.0,
+                rcv_points=receiver,
+                **{"recv_points": receiver},
+            )
+        except TypeError as exc:
+            assert "both" in str(exc)
+        else:
+            raise AssertionError("rcv_points and recv_points should not be accepted together")
+
+        try:
+            model.static_syn(
+                scale=1e20,
+                output_path=HERE / "_tmp_args_unexpected_keyword.nc",
+                unexpected=True,
+            )
+        except TypeError as exc:
+            assert "unexpected" in str(exc)
+        else:
+            raise AssertionError("unexpected static_syn keyword should raise TypeError")
+    finally:
+        _restore_run_grt(pygrt.pymod, original_pymod)
+        _restore_run_grt(pygrt.utils, original_utils)
+        static.unlink(missing_ok=True)
+        receiver.unlink(missing_ok=True)
 
 
 def test_tensor_return_result_reads_prefix_only():
@@ -999,6 +1076,7 @@ def main():
         test_source_type_is_inferred_from_source_parameters,
         test_static_syn_and_tensor_postprocess_args,
         test_static_sproj_and_coulomb_args,
+        test_deprecated_recv_points_alias,
         test_tensor_return_result_reads_prefix_only,
         test_renamed_interfaces_fail_with_migration_message,
         test_read_statsfile_ptam_requires_prefix,

--- a/test/lamb2/test_lamb2.py
+++ b/test/lamb2/test_lamb2.py
@@ -39,10 +39,10 @@ for name, kwargs in invalid_lamb2_inputs:
 
 
 R = 10.0
-SOURCE_DEPTH = 5.0
+DEPSRC = 5.0
 AZIMUTH = 30.0
 ts = np.arange(0.0, 2.0 + 1e-8, 1e-2)
-G, dG_source, dG_receiver = pygrt.utils.lamb2(nu=0.25, tbar=ts, R=R, depsrc=SOURCE_DEPTH, azimuth=AZIMUTH)
+G, dG_source, dG_receiver = pygrt.utils.lamb2(nu=0.25, tbar=ts, R=R, depsrc=DEPSRC, azimuth=AZIMUTH)
 
 if not np.allclose(dG_receiver[:, :2], -dG_source[:, :2]):
     raise ValueError("Horizontal receiver and source derivatives violate translation invariance.")
@@ -55,7 +55,7 @@ if not np.allclose(dG_receiver[:, 2, 1, 1:], dG_source[:, 1, 2, 1:]):
 
 for azimuth in (0.0, 90.0, 180.0, 270.0):
     angle_G, angle_source, angle_receiver = pygrt.utils.lamb2(
-        nu=0.25, tbar=np.asarray([0.0, 0.65, 1.05, 1.8]), R=R, depsrc=SOURCE_DEPTH, azimuth=azimuth
+        nu=0.25, tbar=np.asarray([0.0, 0.65, 1.05, 1.8]), R=R, depsrc=DEPSRC, azimuth=azimuth
     )
     if not np.isfinite(angle_G).all() or not np.isfinite(angle_source).all() or not np.isfinite(angle_receiver).all():
         raise ValueError(f"lamb2 returned a non-finite value at azimuth={azimuth:g}.")
@@ -81,13 +81,13 @@ def _check_reciprocity(depth, azimuth):
 
 
 for azimuth in (0.0, 30.0, 90.0, 180.0, 210.0, 360.0):
-    _check_reciprocity(SOURCE_DEPTH, azimuth)
+    _check_reciprocity(DEPSRC, azimuth)
 for depth in (0.5, 2.0, 10.0):
     _check_reciprocity(depth, AZIMUTH)
 
 
 G_surface, dG_surface_source, dG_surface_receiver = pygrt.utils.lamb2(
-    nu=0.25, tbar=ts, R=R, deprcv=SOURCE_DEPTH, azimuth=AZIMUTH
+    nu=0.25, tbar=ts, R=R, deprcv=DEPSRC, azimuth=AZIMUTH
 )
 if not np.isfinite(G_surface).all() or not np.isfinite(dG_surface_source).all() or not np.isfinite(dG_surface_receiver).all():
     raise ValueError("lamb2 returned a non-finite value for the surface-source case.")
@@ -101,7 +101,7 @@ cli_result = subprocess.run(
         "-P0.25",
         "-T0/2/1e-2",
         f"-R{R}",
-        f"-Ds{SOURCE_DEPTH}",
+        f"-Ds{DEPSRC}",
         "-S+slamb2_source+rlamb2_receiver",
         f"-A{AZIMUTH}",
     ],
@@ -131,7 +131,7 @@ surface_cli_result = subprocess.run(
         "-P0.25",
         "-T0/2/1e-2",
         f"-R{R}",
-        f"-Dr{SOURCE_DEPTH}",
+        f"-Dr{DEPSRC}",
         "-S+slamb2_surface_source+rlamb2_surface_receiver",
         f"-A{AZIMUTH}",
     ],
@@ -170,10 +170,10 @@ def _check_lamb2_right_limit(boundary, **depth_kw):
 
 
 main_p_arrival = np.sqrt(0.5 * (1.0 - 2.0 * 0.25) / (1.0 - 0.25))
-for depth_kw in ({"depsrc": SOURCE_DEPTH}, {"deprcv": SOURCE_DEPTH}):
+for depth_kw in ({"depsrc": DEPSRC}, {"deprcv": DEPSRC}):
     _check_lamb2_right_limit(main_p_arrival, **depth_kw)
     _check_lamb2_right_limit(1.0, **depth_kw)
-    main_theta = np.arctan2(R, SOURCE_DEPTH)
+    main_theta = np.arctan2(R, DEPSRC)
     main_t_sp = np.cos(main_theta - np.arcsin(main_p_arrival))
     _check_lamb2_right_limit(main_t_sp, **depth_kw)
 
@@ -184,11 +184,11 @@ def _lamb2_g_over_r(nu, tbar, source, reference_radius):
     radius = np.linalg.norm(source_to_receiver)
     ray = source_to_receiver / radius
     horizontal_distance = np.hypot(source_to_receiver[0], source_to_receiver[1])
-    source_depth = source[2]
+    depsrc = source[2]
     azimuth = np.rad2deg(np.arctan2(ray[1], ray[0])) % 360.0
     G, _, _ = pygrt.utils.lamb2(
         nu=nu, tbar=tbar * reference_radius / radius, R=horizontal_distance,
-        depsrc=source_depth, azimuth=azimuth,
+        depsrc=depsrc, azimuth=azimuth,
     )
     return G / radius
 
@@ -254,11 +254,11 @@ def _lamb2_geometry(source, receiver):
 
 def _lamb2_green_at_physical_time(physical_time, source, receiver):
     distance = np.linalg.norm(receiver - source)
-    horizontal_distance, source_depth, receiver_depth, azimuth = _lamb2_geometry(source, receiver)
-    if source_depth > 0.0 and receiver_depth == 0.0:
-        depth_kw = {"depsrc": source_depth}
-    elif source_depth == 0.0 and receiver_depth > 0.0:
-        depth_kw = {"deprcv": receiver_depth}
+    horizontal_distance, depsrc, deprcv, azimuth = _lamb2_geometry(source, receiver)
+    if depsrc > 0.0 and deprcv == 0.0:
+        depth_kw = {"depsrc": depsrc}
+    elif depsrc == 0.0 and deprcv > 0.0:
+        depth_kw = {"deprcv": deprcv}
     else:
         raise ValueError("lamb2 finite-difference geometry must keep exactly one point underground.")
     return pygrt.utils.lamb2(
@@ -275,7 +275,7 @@ def _check_surface_source_receiver_derivatives():
     receiver = np.array([
         R * np.cos(np.deg2rad(AZIMUTH)),
         R * np.sin(np.deg2rad(AZIMUTH)),
-        SOURCE_DEPTH,
+        DEPSRC,
     ])
     distance = np.linalg.norm(receiver - source)
     times = (0.70, 1.20, 1.80)
@@ -284,7 +284,7 @@ def _check_surface_source_receiver_derivatives():
             nu=0.25,
             tbar=np.asarray([tbar - 1e-3, tbar, tbar + 1e-3]),
             R=R,
-            deprcv=SOURCE_DEPTH,
+            deprcv=DEPSRC,
             azimuth=AZIMUTH,
         )
         expected_receiver = expected_receiver[1]

--- a/test/lamb3/test_lamb3.py
+++ b/test/lamb3/test_lamb3.py
@@ -20,11 +20,11 @@ else:
     raise ValueError("lamb3 should require a positive horizontal distance.")
 
 
-for source_depth, receiver_depth in ((0.0, 1.0), (1.0, 0.0), (0.0, 0.0)):
+for depsrc, deprcv in ((0.0, 1.0), (1.0, 0.0), (0.0, 0.0)):
     try:
         pygrt.utils.lamb3(
             nu=0.25, tbar=np.asarray([0.0]), R=10.0,
-            depsrc=source_depth, deprcv=receiver_depth, azimuth=0.0,
+            depsrc=depsrc, deprcv=deprcv, azimuth=0.0,
         )
     except ValueError:
         pass
@@ -54,8 +54,8 @@ for name, kwargs in invalid_lamb3_inputs:
 
 
 R = 10.0
-SOURCE_DEPTH = 2.0
-RECEIVER_DEPTH = 1.0
+DEPSRC = 2.0
+DEPRCV = 1.0
 AZIMUTH = 30.0
 # 固定 S 波速度只用于把物理时间换算为无量纲时间
 BETA = 1.0
@@ -63,7 +63,7 @@ TS = np.arange(0.0, 2.0 + 1e-8, 1e-2)
 
 
 G, dG_source, dG_receiver = pygrt.utils.lamb3(
-    nu=0.25, tbar=TS, R=R, depsrc=SOURCE_DEPTH, deprcv=RECEIVER_DEPTH, azimuth=AZIMUTH
+    nu=0.25, tbar=TS, R=R, depsrc=DEPSRC, deprcv=DEPRCV, azimuth=AZIMUTH
 )
 
 if G.shape != (len(TS), 3, 3):
@@ -83,11 +83,11 @@ def _check_lamb3_right_limit(boundary):
     epsilon = min(1e-8, dt * 1e-5)
     exact, _, _ = pygrt.utils.lamb3(
         nu=0.25, tbar=np.asarray([boundary, boundary + dt]), R=R,
-        depsrc=SOURCE_DEPTH, deprcv=RECEIVER_DEPTH, azimuth=AZIMUTH,
+        depsrc=DEPSRC, deprcv=DEPRCV, azimuth=AZIMUTH,
     )
     right, _, _ = pygrt.utils.lamb3(
         nu=0.25, tbar=np.asarray([boundary + epsilon]), R=R,
-        depsrc=SOURCE_DEPTH, deprcv=RECEIVER_DEPTH, azimuth=AZIMUTH,
+        depsrc=DEPSRC, deprcv=DEPRCV, azimuth=AZIMUTH,
     )
     if not np.allclose(exact[0], right[0], rtol=1e-10, atol=1e-12):
         raise ValueError(f"lamb3 does not use the right-hand value at tbar={boundary:g}.")
@@ -99,13 +99,13 @@ _check_lamb3_right_limit(1.0)
 
 
 reciprocal_closed, reciprocal_closed_source, _ = pygrt.utils.lamb3(
-    nu=0.25, tbar=TS, R=R, depsrc=RECEIVER_DEPTH, deprcv=SOURCE_DEPTH, azimuth=AZIMUTH + 180.0
+    nu=0.25, tbar=TS, R=R, depsrc=DEPRCV, deprcv=DEPSRC, azimuth=AZIMUTH + 180.0
 )
 expected_closed_vertical = np.transpose(reciprocal_closed_source[:, 2], (0, 2, 1))
 if not np.allclose(dG_receiver[:, 2], expected_closed_vertical, rtol=2e-6, atol=1e-5):
     raise ValueError("lamb3 receiver vertical derivatives violate reciprocity.")
 
-for source_depth, receiver_depth, azimuth in (
+for depsrc, deprcv, azimuth in (
     (0.8, 1.7, 0.0),
     (1.7, 0.8, 90.0),
     (4.0, 0.7, 210.0),
@@ -113,14 +113,14 @@ for source_depth, receiver_depth, azimuth in (
 ):
     angle_times = np.asarray([0.7, 1.2, 1.8])
     angle_G, angle_source, angle_receiver = pygrt.utils.lamb3(
-        nu=0.25, tbar=angle_times, R=R, depsrc=source_depth, deprcv=receiver_depth, azimuth=azimuth
+        nu=0.25, tbar=angle_times, R=R, depsrc=depsrc, deprcv=deprcv, azimuth=azimuth
     )
     swapped_G, swapped_source, _ = pygrt.utils.lamb3(
-        nu=0.25, tbar=angle_times, R=R, depsrc=receiver_depth, deprcv=source_depth,
+        nu=0.25, tbar=angle_times, R=R, depsrc=deprcv, deprcv=depsrc,
         azimuth=(azimuth + 180.0) % 360.0,
     )
     if not np.isfinite(angle_G).all() or not np.isfinite(angle_source).all() or not np.isfinite(angle_receiver).all():
-        raise ValueError(f"lamb3 returned a non-finite value at case {(source_depth, receiver_depth, azimuth)}.")
+        raise ValueError(f"lamb3 returned a non-finite value at case {(depsrc, deprcv, azimuth)}.")
     if not np.isfinite(swapped_G).all() or not np.isfinite(swapped_source).all():
         raise ValueError(f"lamb3 reciprocal case returned a non-finite value at azimuth={azimuth:g}.")
     expected_angle_vertical = np.transpose(swapped_source[:, 2], (0, 2, 1))
@@ -142,7 +142,7 @@ cli_result = subprocess.run(
         "-P0.25",
         "-T0/2/1e-2",
         f"-R{R}",
-        f"-D{SOURCE_DEPTH}/{RECEIVER_DEPTH}",
+        f"-D{DEPSRC}/{DEPRCV}",
         "-S+slamb3_source+rlamb3_receiver",
         f"-A{AZIMUTH}",
     ],
@@ -174,23 +174,23 @@ def _lamb3_geometry(source, receiver):
 
 def _lamb3_green_at_physical_time(physical_time, source, receiver):
     distance = np.linalg.norm(receiver - source)
-    horizontal_distance, source_depth, receiver_depth, azimuth = _lamb3_geometry(source, receiver)
+    horizontal_distance, depsrc, deprcv, azimuth = _lamb3_geometry(source, receiver)
     return pygrt.utils.lamb3(
         nu=0.25,
         tbar=np.asarray([physical_time * BETA / distance]),
         R=horizontal_distance,
-        depsrc=source_depth,
-        deprcv=receiver_depth,
+        depsrc=depsrc,
+        deprcv=deprcv,
         azimuth=azimuth,
     )[0][0]
 
 
-def _check_lamb3_geometry_derivatives(horizontal_distance, source_depth, receiver_depth):
-    source = np.array([0.0, 0.0, source_depth])
+def _check_lamb3_geometry_derivatives(horizontal_distance, depsrc, deprcv):
+    source = np.array([0.0, 0.0, depsrc])
     receiver = np.array([
         horizontal_distance * np.cos(np.deg2rad(AZIMUTH)),
         horizontal_distance * np.sin(np.deg2rad(AZIMUTH)),
-        receiver_depth,
+        deprcv,
     ])
     distance = np.linalg.norm(receiver - source)
     times = (0.70, 0.85, 1.20, 1.50, 1.80)
@@ -199,8 +199,8 @@ def _check_lamb3_geometry_derivatives(horizontal_distance, source_depth, receive
             nu=0.25,
             tbar=np.asarray([tbar - 1e-3, tbar, tbar + 1e-3]),
             R=horizontal_distance,
-            depsrc=source_depth,
-            deprcv=receiver_depth,
+            depsrc=depsrc,
+            deprcv=deprcv,
             azimuth=AZIMUTH,
         )
         expected_source = expected_source[1]
@@ -227,13 +227,13 @@ def _check_lamb3_geometry_derivatives(horizontal_distance, source_depth, receive
                 if not np.allclose(finite_difference, expected[coordinate], rtol=5e-3, atol=2e-3):
                     raise ValueError(
                         f"lamb3 {kind} derivative failed at case "
-                        f"({horizontal_distance:g}, {source_depth:g}, {receiver_depth:g}), "
+                        f"({horizontal_distance:g}, {depsrc:g}, {deprcv:g}), "
                         f"tbar={tbar:g}, coordinate={coordinate + 1}"
                     )
 
 
-for source_depth, receiver_depth in ((0.5, 0.1), (2.0, 1.0), (10.0, 5.0)):
-    _check_lamb3_geometry_derivatives(10.0, source_depth, receiver_depth)
+for depsrc, deprcv in ((0.5, 0.1), (2.0, 1.0), (10.0, 5.0)):
+    _check_lamb3_geometry_derivatives(10.0, depsrc, deprcv)
 
 shallow_ts = np.arange(1.49, 1.53 + 1e-8, 2e-3)
 _, shallow_source, shallow_receiver = pygrt.utils.lamb3(

--- a/test/okada/test_okada.py
+++ b/test/okada/test_okada.py
@@ -161,7 +161,7 @@ def main():
     okada(
         modelparams=(6.0, 3.464, 2.7),
         depsrc=10.0,
-        recv_points=rcv_fault_q,
+        rcv_points=rcv_fault_q,
         output_path="okada_rq.nc",
         scale=1.0e12,
         scale_with_mu=True,

--- a/test/static_syn/test_static_syn.py
+++ b/test/static_syn/test_static_syn.py
@@ -266,7 +266,7 @@ pymod_m.static_syn(
 
 rcv = Path("rcv_pts.txt")
 rcv.write_text("# north east depth (km)\n0 0 0\n1 2 0\n-1 1 0\n")
-pymod_m.static_syn(scale=1e16, output_path="stsyn_q.nc", depsrc=2.0, recv_points=rcv)
+pymod_m.static_syn(scale=1e16, output_path="stsyn_q.nc", depsrc=2.0, rcv_points=rcv)
 with netcdf_file("stsyn_q.nc", mmap=False) as f:
     assert "point" in f.dimensions
     assert f.dimensions["point"] == 3
@@ -332,14 +332,14 @@ pymod_mr.static_syn(scale=1e20, output_path="stsyn_dr.nc", deprcv=0.25, norths=[
 
 # -------------------- 错误参数 --------------------
 try:
-    pymod_m.static_syn(scale=1e20, output_path="stsyn_bad.nc", recv_points=rcv, norths=[-1.0, 1.0, 1.0], easts=[-1.0, 1.0, 1.0])
-    raise AssertionError("recv_points with norths/easts should raise")
+    pymod_m.static_syn(scale=1e20, output_path="stsyn_bad.nc", rcv_points=rcv, norths=[-1.0, 1.0, 1.0], easts=[-1.0, 1.0, 1.0])
+    raise AssertionError("rcv_points with norths/easts should raise")
 except ValueError:
     pass
 
 try:
-    pymod_m.static_syn(scale=1e20, output_path="stsyn_bad.nc", recv_points=rcv, deprcv=0.0)
-    raise AssertionError("recv_points with deprcv should raise")
+    pymod_m.static_syn(scale=1e20, output_path="stsyn_bad.nc", rcv_points=rcv, deprcv=0.0)
+    raise AssertionError("rcv_points with deprcv should raise")
 except ValueError:
     pass
 

--- a/test/tensors/test_tensors.py
+++ b/test/tensors/test_tensors.py
@@ -39,7 +39,7 @@ pygrt.utils.static_rotation("stsyn_zne.nc")
 
 rcv = Path("rcv_pts.txt")
 rcv.write_text("# north east depth (km)\n0 0 0\n1 2 0\n-1 1 0\n")
-pymod_s.static_syn(scale=1e20, output_path="stsyn_q.nc", recv_points=rcv, calc_upar=True)
+pymod_s.static_syn(scale=1e20, output_path="stsyn_q.nc", rcv_points=rcv, calc_upar=True)
 pygrt.utils.static_strain("stsyn_q.nc")
 pygrt.utils.static_stress("stsyn_q.nc")
 pygrt.utils.static_rotation("stsyn_q.nc")


### PR DESCRIPTION
This PR standardizes receiver-related identifiers from `recv` to `rcv` across the C implementation, Python APIs, tests, and documentation.

- Renames the static receiver-point files to `rcv_points.c/.h`
- Updates C types, functions, fields, variables, and include paths
- Makes `rcv_points` the canonical Python argument
- Keeps `recv_points` as a deprecated Python compatibility alias
- Renames Lamb source and receiver depth identifiers to `depsrc` and `deprcv`
- Updates tests, tutorials, generated API documentation, and build artifacts
