### PR TITLE
REFAC: rename receiver-function module to "rcvfn"

### DIFF
--- a/docs/source/Formula/index.rst
+++ b/docs/source/Formula/index.rst
@@ -46,7 +46,7 @@
 
     - :doc:`others/uiz`
     - :doc:`others/DS_zero`
-    - :doc:`others/rftn`
+    - :doc:`others/rcvfn`
 
 
 
@@ -67,4 +67,4 @@
 
     others/uiz
     others/DS_zero
-    others/rftn
+    others/rcvfn

--- a/docs/source/Formula/others/rcvfn.rst
+++ b/docs/source/Formula/others/rcvfn.rst
@@ -17,7 +17,7 @@
 这里省略点源柱面谐展开的阶数下标 :math:`m`，沿用同一归一化记号：
 
 .. math::
-    :label: rftn-qw
+    :label: rcvfn-qw
 
     q=k\phi+\frac{\partial\psi}{\partial z},
     \qquad
@@ -53,7 +53,7 @@
 位移仍由 P 势函数的一次梯度和 SV 势函数的双旋度组成：
 
 .. math::
-    :label: rftn-potential
+    :label: rcvfn-potential
 
     \mathbf{u}
     =\nabla\phi
@@ -77,7 +77,7 @@
 水平和垂向位移分量分别为
 
 .. math::
-    :label: rftn-displacement
+    :label: rcvfn-displacement
 
     u_R
     &=\frac{\partial\phi}{\partial x}
@@ -104,13 +104,13 @@
 完成与点源相同的 R/T 矩阵递推后，在自由表面得到 :math:`q,w`。
 记两种入射波对应的自由表面响应为
 :math:`(q_P,w_P)` 和 :math:`(q_{SV},w_{SV})`。
-直接使用 :eq:`rftn-displacement`，即可得到对应分量响应，
+直接使用 :eq:`rcvfn-displacement`，即可得到对应分量响应，
 再按如下式子即可计算得到接收函数。
 
 P 入射时使用水平分量与垂向分量之比：
 
 .. math::
-    :label: rftn-ratio-p
+    :label: rcvfn-ratio-p
 
     R_P(\omega)
     =\frac{U_R^{(P)}}{U_Z^{(P)}}
@@ -119,7 +119,7 @@ P 入射时使用水平分量与垂向分量之比：
 SV 入射时使用垂向分量与水平分量之比：
 
 .. math::
-    :label: rftn-ratio-sv
+    :label: rcvfn-ratio-sv
 
     R_{SV}(\omega)
     =\frac{U_Z^{(SV)}}{U_R^{(SV)}}
@@ -141,5 +141,5 @@ R/T 递推得到的 :math:`q,w` 响应。
     =\frac{\widetilde V_S}{\omega}
     =\mathrm{i}\frac{\widetilde V_S}{\mathrm{i}\omega}.
 
-因此绝对分量只需在 :eq:`rftn-displacement` 的基础上乘以相应的单位入射位移因子；
+因此绝对分量只需在 :eq:`rcvfn-displacement` 的基础上乘以相应的单位入射位移因子；
 这不会改变上面的接收函数比值。

--- a/docs/source/Module/index.rst
+++ b/docs/source/Module/index.rst
@@ -164,7 +164,7 @@
     - :doc:`okada`
     - :doc:`xy2geo`
     - :doc:`geo2xy`
-    - :doc:`rftn`
+    - :doc:`rcvfn`
 
 .. toctree::
     :maxdepth: 1
@@ -196,4 +196,4 @@
     okada
     xy2geo
     geo2xy
-    rftn
+    rcvfn

--- a/docs/source/Module/rcvfn.rst
+++ b/docs/source/Module/rcvfn.rst
@@ -4,7 +4,7 @@
 .. include:: common_OPTs.rst_
 
 
-rftn
+rcvfn
 =================
 
 :简介: 计算平面入射 P 或 SV 波的接收函数及自由表面位移响应
@@ -12,7 +12,7 @@ rftn
 语法
 -----------
 
-**grt rftn**
+**grt rcvfn**
 |-M|\ *model*
 ( |-P|\ *rayp* | |-I|\ *inca*\ [/\ *idx*] )
 |-T|\ **P|S**
@@ -28,11 +28,11 @@ rftn
 描述
 --------
 
-**rftn** 将入射波视为沿指定水平射线参数传播的单位平面波，在一维水平层状半空间中计算其到达自由表面后的 P-SV 响应。
+**rcvfn** 将入射波视为沿指定水平射线参数传播的单位平面波，在一维水平层状半空间中计算其到达自由表面后的 P-SV 响应。
 入射波从模型底部半空间，或 |-I| 指定的模型层，向上入射。
 
 默认只保存接收函数；设置 |-W| 后，还会保存单位入射位移对应的 Z/R 响应。
-具体公式详见 :doc:`/Formula/others/rftn`。
+具体公式详见 :doc:`/Formula/others/rcvfn`。
 
 SAC 头段中的 ``user0``、``user1``、``user2`` 分别记录虚频系数 :math:`\omega_I`、水平射线参数 *rayp* 和高斯滤波参数 *alp*。
 
@@ -100,4 +100,4 @@ SAC 头段中的 ``user0``、``user1``、``user2`` 分别记录虚频系数 :mat
 示例
 -------
 
-+ :doc:`/Tutorial/receiver_function/rftn`
++ :doc:`/Tutorial/receiver_function/rcvfn`

--- a/docs/source/Tutorial/receiver_function/rcvfn.rst
+++ b/docs/source/Tutorial/receiver_function/rcvfn.rst
@@ -6,8 +6,8 @@
 
 基于相同的广义反射透射系数矩阵方法，
 **PyGRT** 可计算层状模型中单位平面入射 P 或 SV 波在自由表面的接收函数。
-C 模块见 :doc:`/Module/rftn`，Python 中对应 :meth:`PyModel1D.rftn() <pygrt.pymod.PyModel1D.rftn>`。
-具体公式详见 :doc:`/Formula/others/rftn`。
+C 模块见 :doc:`/Module/rcvfn`，Python 中对应 :meth:`PyModel1D.rcvfn() <pygrt.pymod.PyModel1D.rcvfn>`。
+具体公式详见 :doc:`/Formula/others/rcvfn`。
 
 以下示例使用如下模型文件：
 
@@ -28,8 +28,8 @@ C 模块见 :doc:`/Module/rftn`，Python 中对应 :meth:`PyModel1D.rftn() <pygr
 
         .. literalinclude:: run/run.sh
             :language: bash
-            :start-after: BEGIN CLI RFTN
-            :end-before: END CLI RFTN
+            :start-after: BEGIN CLI RCVFN
+            :end-before: END CLI RCVFN
 
         使用 **-W** 可以附加输出 Z/R 响应。
 
@@ -37,8 +37,8 @@ C 模块见 :doc:`/Module/rftn`，Python 中对应 :meth:`PyModel1D.rftn() <pygr
 
         .. literalinclude:: run/run.py
             :language: python
-            :start-after: BEGIN PYTHON RFTN
-            :end-before: END PYTHON RFTN
+            :start-after: BEGIN PYTHON RCVFN
+            :end-before: END PYTHON RCVFN
 
         设置 ``write_components=True`` 可以附加输出 Z/R 响应。
 
@@ -54,23 +54,23 @@ C 模块见 :doc:`/Module/rftn`，Python 中对应 :meth:`PyModel1D.rftn() <pygr
       - 附加输出（如果有设置）
       - 时间参考零点
     * - P
-      - *P_rftn.sac*
+      - *P_rcvfn.sac*
       - *P_Z.sac*、*P_R.sac*
       - P 波到时
     * - SV
-      - *S_rftn.sac*
+      - *S_rcvfn.sac*
       - *S_Z.sac*、*S_R.sac*
       - S 波到时
 
 以下结果图每个子图单独按最大绝对振幅归一化，仅用于比较波形形状；
 每幅图包含三行，依次为接收函数以及 Z/R 响应。
 
-.. figure:: run/rftn_P.svg
+.. figure:: run/P_rcvfn.svg
     :align: center
 
     入射 P 波
 
-.. figure:: run/rftn_S.svg
+.. figure:: run/S_rcvfn.svg
     :align: center
 
     入射 SV 波

--- a/docs/source/Tutorial/receiver_function/run/run.py
+++ b/docs/source/Tutorial/receiver_function/run/run.py
@@ -4,10 +4,10 @@ import pygrt
 from obspy import read
 
 # -----------------------------------------------------------------------------------
-# BEGIN PYTHON RFTN
+# BEGIN PYTHON RCVFN
 model = pygrt.PyModel1D(modelpath="mod1")
 
-model.rftn(
+model.rcvfn(
     wtype="P",
     rayp=0.03,
     nt=500,
@@ -19,7 +19,7 @@ model.rftn(
     upsampling_n=5,
 )
 
-model.rftn(
+model.rcvfn(
     wtype="S",
     inca=10.0,
     idx=0,
@@ -31,7 +31,7 @@ model.rftn(
     write_components=True,
     upsampling_n=5,
 )
-# END PYTHON RFTN
+# END PYTHON RCVFN
 # -----------------------------------------------------------------------------------
 
 
@@ -39,7 +39,7 @@ model.rftn(
 ARRIVAL_TIME = 0.0
 PLOT_SPAN = 12.0
 OFFSET = 5.0
-RFTN_COLOR = "tab:red"
+RCVFN_COLOR = "tab:red"
 COMPONENT_COLOR = "tab:blue"
 PHASE_LINE_COLOR = "0.45"
 PLOT_CASES = (
@@ -82,7 +82,7 @@ def vertical_travel_times(velocity: np.ndarray, rayp: float, thickness: np.ndarr
 
 def phase_arrivals(case: dict):
     prefix = case["prefix"]
-    trace = read(f"PY_{prefix}/{prefix}_rftn.sac")[0]
+    trace = read(f"PY_{prefix}/{prefix}_rcvfn.sac")[0]
     rayp = float(trace.stats.sac.user1)
     thickness, vp, vs, depths = read_model("mod1")
     p_times = vertical_travel_times(vp, rayp, thickness)
@@ -114,7 +114,7 @@ def read_trace(directory: str, name: str):
 
 
 rows = (
-    ("{}_rftn.sac", "Receiver function", RFTN_COLOR),
+    ("{}_rcvfn.sac", "Receiver function", RCVFN_COLOR),
     ("{}_Z.sac", "Vertical response", COMPONENT_COLOR),
     ("{}_R.sac", "Radial response", COMPONENT_COLOR),
 )
@@ -164,7 +164,7 @@ def plot_case(case: dict) -> None:
         if irow == len(rows) - 1:
             ax.set_xlabel(case["xlabel"])
 
-    fig.savefig(f"rftn_{prefix}.svg", bbox_inches="tight")
+    fig.savefig(f"{prefix}_rcvfn.svg", bbox_inches="tight")
     plt.close(fig)
 
 

--- a/docs/source/Tutorial/receiver_function/run/run.sh
+++ b/docs/source/Tutorial/receiver_function/run/run.sh
@@ -2,14 +2,14 @@
 
 set -euo pipefail
 
-rm -rf CLI_P CLI_S PY_P PY_S rftn.svg rftn_P.svg rftn_S.svg
+rm -rf CLI_* PY_* *.svg
 
 # -----------------------------------------------------------------------------------
-# BEGIN CLI RFTN
+# BEGIN CLI RCVFN
 # P 波使用水平射线参数，SV 波使用底部半空间的入射角
-grt rftn -Mmod1 -P0.03 -TP -N500/0.1 -A5.0 -E-10 -W -OCLI_P
-grt rftn -Mmod1 -I10/0 -TS -N500/0.1 -A5.0 -E-10 -W -OCLI_S
-# END CLI RFTN
+grt rcvfn -Mmod1 -P0.03 -TP -N500/0.1 -A5.0 -E-10 -W -OCLI_P
+grt rcvfn -Mmod1 -I10/0 -TS -N500/0.1 -A5.0 -E-10 -W -OCLI_S
+# END CLI RCVFN
 # -----------------------------------------------------------------------------------
 
 python run.py

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@
       - :doc:`Tutorial/dynamic/index`
       - :doc:`Tutorial/modal/index`
       - :doc:`Tutorial/static/index`
-      - :doc:`Tutorial/receiver_function/rftn`
+      - :doc:`Tutorial/receiver_function/rcvfn`
       - :doc:`Gallery/gallery`
 
    .. grid-item-card::  PyGRT 进阶
@@ -65,7 +65,7 @@
    Tutorial/dynamic/index
    Tutorial/modal/index
    Tutorial/static/index 
-   Tutorial/receiver_function/rftn
+   Tutorial/receiver_function/rcvfn
    Gallery/gallery
 
 .. toctree::

--- a/pygrt/C_extension/src/dynamic/grt_rcvfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_rcvfn.c
@@ -1,5 +1,5 @@
 /**
- * @file   grt_rftn.c
+ * @file   grt_rcvfn.c
  * @author Zhu Dengda (zhudengda@mail.iggcas.ac.cn)
  * @date   2026-09
  *
@@ -15,24 +15,24 @@
 #undef I    ///< 取消标准复数单位宏，避免与命令行选项 I 冲突
 #define IMAG _Complex_I   ///< 复数单位，避免与标准复数宏 I 冲突
 
-#define GRT_RFTN_N_ZETA        0.8
-#define GRT_RFTN_N_UPSAMPLE    1
-#define GRT_RFTN_A_ALP         1.0
+#define GRT_RCVFN_N_ZETA        0.8
+#define GRT_RCVFN_N_UPSAMPLE    1
+#define GRT_RCVFN_A_ALP         1.0
 
 
 /** 入射波类型 */
 typedef enum {
-    GRT_RFTN_INCIDENT_P = 0,    ///< P 波
-    GRT_RFTN_INCIDENT_SV,       ///< SV 波
-} GRT_RFTN_INCIDENT;
+    GRT_RCVFN_INCIDENT_P = 0,    ///< P 波
+    GRT_RCVFN_INCIDENT_SV,       ///< SV 波
+} GRT_RCVFN_INCIDENT;
 
 
 /** 输出结果类型 */
 typedef enum {
-    GRT_RFTN_OUTPUT_RATIO = 0,  ///< 接收函数比值
-    GRT_RFTN_OUTPUT_Z,          ///< 垂向位移响应
-    GRT_RFTN_OUTPUT_R,          ///< 径向位移响应
-} GRT_RFTN_OUTPUT;
+    GRT_RCVFN_OUTPUT_RATIO = 0,  ///< 接收函数比值
+    GRT_RCVFN_OUTPUT_Z,          ///< 垂向位移响应
+    GRT_RCVFN_OUTPUT_R,          ///< 径向位移响应
+} GRT_RCVFN_OUTPUT;
 
 
 /** 接收函数子模块的参数控制结构体 */
@@ -69,7 +69,7 @@ typedef struct {
     /** 入射波类型选项 */
     struct {
         bool active;
-        GRT_RFTN_INCIDENT incident; ///< 入射波类型
+        GRT_RCVFN_INCIDENT incident; ///< 入射波类型
     } T;
     /** 高斯低通滤波选项 */
     struct {
@@ -95,7 +95,7 @@ typedef struct {
     struct {
         bool active;
     } s;
-} GRT_RFTN_CTRL;
+} GRT_MODULE_CTRL;
 
 
 /**
@@ -103,7 +103,7 @@ typedef struct {
  *
  * @param[in,out] Ctrl  接收函数模块参数控制结构体指针
  */
-static void free_Ctrl(GRT_RFTN_CTRL *Ctrl)
+static void free_Ctrl(GRT_MODULE_CTRL *Ctrl)
 {
     if(Ctrl == NULL) return;
     // 释放模型输入
@@ -119,12 +119,12 @@ static void free_Ctrl(GRT_RFTN_CTRL *Ctrl)
 static void print_help(void)
 {
 printf("\n"
-"[grt rftn] %s\n\n", GRT_VERSION); printf(
+"[grt rcvfn] %s\n\n", GRT_VERSION); printf(
 "    Compute receiver functions for a unit plane incident P or SV wave.\n\n"
 "\n\n"
 "Usage:\n"
 "----------------------------------------------------------------\n"
-"    grt rftn -M<model> (-P<rayp>|-I<inca>[/<idx>]) -T<P|S>\n"
+"    grt rcvfn -M<model> (-P<rayp>|-I<inca>[/<idx>]) -T<P|S>\n"
 "             -N<nt>/<dt>[+w<zeta>][+n<fac>][+a][+f]\n"
 "             [-A<alp>] [-E<delay>] [-W] -O<output_dir> [-s] [-h]\n\n"
 "\n"
@@ -146,7 +146,7 @@ printf("\n"
 "                 <dt>:   time interval (secs). \n"
 "                 +w<zeta>: define the coefficient of imaginary \n"
 "                           frequency wI=zeta*PI/T, where T=nt*dt.\n"
-"                           Default zeta=%.1f.\n", GRT_RFTN_N_ZETA); printf(
+"                           Default zeta=%.1f.\n", GRT_RCVFN_N_ZETA); printf(
 "                 +n<fac>:  upsampling factor (integer)\n"
 "                           i.e.  nt <-- nt * <fac>\n"
 "                                 dt <-- dt / <fac>\n"
@@ -156,7 +156,7 @@ printf("\n"
 "                 +f:       skip the amplitude compensation from \n"
 "                           imaginary frequency.\n"
 "\n"
-"    -A<alp>      Gaussian low-pass filter parameter (default %.1f).\n", GRT_RFTN_A_ALP); printf(
+"    -A<alp>      Gaussian low-pass filter parameter (default %.1f).\n", GRT_RCVFN_A_ALP); printf(
 "                 H(f)=exp[-(pi*f/alp)^2]; filter corner frequency ≈ alp/pi.\n"
 "\n"
 "    -E<delay>    Additional delay before the P arrival. The program\n"
@@ -174,11 +174,11 @@ printf("\n"
 
 
 /** 解析命令行选项 */
-static void getopt_from_command(GRT_RFTN_CTRL *Ctrl, int argc, char **argv)
+static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
 {
-    Ctrl->N.zeta = GRT_RFTN_N_ZETA;
-    Ctrl->N.upsample_n = GRT_RFTN_N_UPSAMPLE;
-    Ctrl->A.alp = GRT_RFTN_A_ALP;
+    Ctrl->N.zeta = GRT_RCVFN_N_ZETA;
+    Ctrl->N.upsample_n = GRT_RCVFN_N_UPSAMPLE;
+    Ctrl->A.alp = GRT_RCVFN_A_ALP;
 
     int opt;
     while((opt = getopt(argc, argv, ":M:P:I:N:T:A:E:O:Wsh")) != -1){
@@ -271,10 +271,10 @@ static void getopt_from_command(GRT_RFTN_CTRL *Ctrl, int argc, char **argv)
             // -T<P|S>
             case 'T':
                 if(strcmp(optarg, "P") == 0){
-                    Ctrl->T.incident = GRT_RFTN_INCIDENT_P;
+                    Ctrl->T.incident = GRT_RCVFN_INCIDENT_P;
                 }
                 else if(strcmp(optarg, "S") == 0){
-                    Ctrl->T.incident = GRT_RFTN_INCIDENT_SV;
+                    Ctrl->T.incident = GRT_RCVFN_INCIDENT_SV;
                 }
                 else{
                     GRTBadOptionError(T, "Use -TP or -TS.");
@@ -454,7 +454,7 @@ static real_t compute_vertical_travel_time(const MODEL1D *mod1d, const real_t ra
 
 
 /** 根据水平射线参数或入射角准备入射层和截取后的模型 */
-static void prepare_incidence(GRT_RFTN_CTRL *Ctrl)
+static void prepare_incidence(GRT_MODULE_CTRL *Ctrl)
 {
     MODEL1D *mod1d = Ctrl->M.mod1d;
     size_t original_nlayer = mod1d->n;
@@ -468,11 +468,11 @@ static void prepare_incidence(GRT_RFTN_CTRL *Ctrl)
         Ctrl->P.incident_idx = Ctrl->I.idx;
 
         size_t incident_layer = keep_nlayer - 1;
-        real_t velocity = (Ctrl->T.incident == GRT_RFTN_INCIDENT_P) ?
+        real_t velocity = (Ctrl->T.incident == GRT_RCVFN_INCIDENT_P) ?
             mod1d->Va[incident_layer] : mod1d->Vb[incident_layer];
         if(velocity <= 0.0){
             GRTRaiseError("The selected incident layer has no valid %s-wave velocity.",
-                Ctrl->T.incident == GRT_RFTN_INCIDENT_P ? "P" : "SV");
+                Ctrl->T.incident == GRT_RCVFN_INCIDENT_P ? "P" : "SV");
         }
         Ctrl->P.rayp = sin(Ctrl->I.inca*DEG1) / velocity;
     }
@@ -494,13 +494,13 @@ static void prepare_incidence(GRT_RFTN_CTRL *Ctrl)
 
     Ctrl->M.mod1d = truncate_model(mod1d, keep_nlayer);
 
-    real_t incident_velocity = (Ctrl->T.incident == GRT_RFTN_INCIDENT_P) ?
+    real_t incident_velocity = (Ctrl->T.incident == GRT_RCVFN_INCIDENT_P) ?
         Ctrl->M.mod1d->Va[Ctrl->M.mod1d->n - 1] : Ctrl->M.mod1d->Vb[Ctrl->M.mod1d->n - 1];
     real_t sin_inca = Ctrl->P.rayp * incident_velocity;
     if(sin_inca >= 1.0){
         GRTRaiseError(
             "The incident %s wave is not propagating in the selected layer for rayp %.9g.",
-            Ctrl->T.incident == GRT_RFTN_INCIDENT_P ? "P" : "SV", Ctrl->P.rayp);
+            Ctrl->T.incident == GRT_RCVFN_INCIDENT_P ? "P" : "SV", Ctrl->P.rayp);
     }
     Ctrl->P.inca = asin(sin_inca) / DEG1;
 
@@ -519,7 +519,7 @@ static void prepare_incidence(GRT_RFTN_CTRL *Ctrl)
  * @return                          矩阵求逆状态
  */
 static int compute_one_frequency(
-    MODEL1D_STATE *mstat, cplx_t k0, GRT_RFTN_INCIDENT incident,
+    MODEL1D_STATE *mstat, cplx_t k0, GRT_RCVFN_INCIDENT incident,
     cplx_t *q_m, cplx_t *w_m, cplx_t *incident_velocity)
 {
     if(!isfinite(creal(k0)) || !isfinite(cimag(k0)) || cabs(k0) == 0.0){
@@ -533,7 +533,7 @@ static int compute_one_frequency(
         return GRT_INVERSE_FAILURE;
     }
 
-    size_t incident_index = (incident == GRT_RFTN_INCIDENT_P) ? 0 : 1;
+    size_t incident_index = (incident == GRT_RCVFN_INCIDENT_P) ? 0 : 1;
     *q_m = R_EV[0][incident_index];
     *w_m = R_EV[1][incident_index];
     if(!isfinite(creal(*q_m)) || !isfinite(cimag(*q_m)) ||
@@ -542,7 +542,7 @@ static int compute_one_frequency(
     }
 
     size_t incident_layer = mstat->mod1d->n - 1;
-    if(incident == GRT_RFTN_INCIDENT_P){
+    if(incident == GRT_RCVFN_INCIDENT_P){
         *incident_velocity = mstat->mod1d->Va[incident_layer] * mstat->atna[incident_layer];
     }
     else{
@@ -567,7 +567,7 @@ static int compute_one_frequency(
  * @param[in]     wI                虚频系数
  */
 static void compute_frequency_responses(
-    MODEL1D *mod1d, const real_t rayp, const GRT_RFTN_INCIDENT incident,
+    MODEL1D *mod1d, const real_t rayp, const GRT_RCVFN_INCIDENT incident,
     cplx_t q_m[], cplx_t w_m[], cplx_t incident_velocity[],
     const size_t nf, const real_t df, const real_t wI)
 {
@@ -612,7 +612,7 @@ static void compute_frequency_responses(
  */
 static size_t assemble_spectrum(
     const cplx_t q_m[], const cplx_t w_m[], const cplx_t incident_velocity[],
-    const GRT_RFTN_INCIDENT incident, const GRT_RFTN_OUTPUT output,
+    const GRT_RCVFN_INCIDENT incident, const GRT_RCVFN_OUTPUT output,
     cplx_t spectrum[], const size_t nf, const real_t df,
     const real_t wI, const real_t alp)
 {
@@ -632,13 +632,13 @@ static size_t assemble_spectrum(
         real_t gauss = exp(-gauss_exponent);
 
         cplx_t response;
-        if(output == GRT_RFTN_OUTPUT_RATIO){
-            cplx_t denominator = (incident == GRT_RFTN_INCIDENT_P) ? w_m[iw] : q_m[iw];
+        if(output == GRT_RCVFN_OUTPUT_RATIO){
+            cplx_t denominator = (incident == GRT_RCVFN_INCIDENT_P) ? w_m[iw] : q_m[iw];
             if(cabs(denominator) == 0.0){
                 ++nfailed;
                 continue;
             }
-            response = (incident == GRT_RFTN_INCIDENT_P) ? IMAG*q_m[iw]/w_m[iw] : -IMAG*w_m[iw]/q_m[iw];
+            response = (incident == GRT_RCVFN_INCIDENT_P) ? IMAG*q_m[iw]/w_m[iw] : -IMAG*w_m[iw]/q_m[iw];
         }
         else{
             cplx_t omega = PI2*(iw*df) - IMAG*wI;
@@ -650,8 +650,8 @@ static size_t assemble_spectrum(
 
             // 将单位入射波势系数转换为单位位移
             cplx_t unit_displacement_factor = incident_velocity[iw]/(IMAG*omega);
-            cplx_t displacement = (output == GRT_RFTN_OUTPUT_Z) ? w_m[iw] : IMAG*q_m[iw];
-            if(incident == GRT_RFTN_INCIDENT_SV){
+            cplx_t displacement = (output == GRT_RCVFN_OUTPUT_Z) ? w_m[iw] : IMAG*q_m[iw];
+            if(incident == GRT_RCVFN_INCIDENT_SV){
                 // 应用 SV 入射波相位修正
                 displacement *= IMAG;
             }
@@ -688,7 +688,7 @@ static size_t assemble_spectrum(
  * @param[in] phase_time        频谱相位延迟
  */
 static void write_result_sac(
-    const GRT_RFTN_INCIDENT incident, const GRT_RFTN_OUTPUT output, const char *path,
+    const GRT_RCVFN_INCIDENT incident, const GRT_RCVFN_OUTPUT output, const char *path,
     const cplx_t spectrum[], const size_t nt, const real_t dt,
     const real_t rayp, const real_t alp, const bool skip_imag_comps,
     const size_t nf, const real_t df, const real_t wI,
@@ -707,11 +707,11 @@ static void write_result_sac(
     snprintf(sac->hd.kuser0, sizeof(sac->hd.kuser0), "wI");
     snprintf(sac->hd.kuser1, sizeof(sac->hd.kuser1), "rayp");
     snprintf(sac->hd.kuser2, sizeof(sac->hd.kuser2), "alp");
-    const char incident_name = (incident == GRT_RFTN_INCIDENT_P) ? 'P' : 'S';
-    if(output == GRT_RFTN_OUTPUT_RATIO){
-        snprintf(sac->hd.kcmpnm, sizeof(sac->hd.kcmpnm), "%c_RFTN", incident_name);
+    const char incident_name = (incident == GRT_RCVFN_INCIDENT_P) ? 'P' : 'S';
+    if(output == GRT_RCVFN_OUTPUT_RATIO){
+        snprintf(sac->hd.kcmpnm, sizeof(sac->hd.kcmpnm), "%c_RCVFN", incident_name);
     }
-    else if(output == GRT_RFTN_OUTPUT_Z){
+    else if(output == GRT_RCVFN_OUTPUT_Z){
         snprintf(sac->hd.kcmpnm, sizeof(sac->hd.kcmpnm), "%c_Z", incident_name);
     }
     else{
@@ -755,10 +755,10 @@ static void write_result_sac(
 }
 
 
-/** rftn 子模块主函数 */
-int rftn_main(int argc, char **argv)
+/** rcvfn 子模块主函数 */
+int rcvfn_main(int argc, char **argv)
 {
-    GRT_RFTN_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
     getopt_from_command(Ctrl, argc, argv);
 
     Ctrl->M.mod1d = grt_read_mod1d_from_file(Ctrl->M.s_modelpath, -1.0, -1.0, true);
@@ -767,7 +767,7 @@ int rftn_main(int argc, char **argv)
         return EXIT_FAILURE;
     }
     prepare_incidence(Ctrl);
-    if(Ctrl->T.incident == GRT_RFTN_INCIDENT_SV && Ctrl->M.mod1d->isLiquid[Ctrl->M.mod1d->n - 1]){
+    if(Ctrl->T.incident == GRT_RCVFN_INCIDENT_SV && Ctrl->M.mod1d->isLiquid[Ctrl->M.mod1d->n - 1]){
         GRTRaiseError("SV incidence is not defined when the bottom halfspace is liquid.");
     }
 
@@ -784,7 +784,7 @@ int rftn_main(int argc, char **argv)
     real_t ts = NAN;
     real_t begin_time;
     real_t phase_components;
-    if(Ctrl->T.incident == GRT_RFTN_INCIDENT_P){
+    if(Ctrl->T.incident == GRT_RCVFN_INCIDENT_P){
         tp = compute_vertical_travel_time(Ctrl->M.mod1d, Ctrl->P.rayp, true);
         begin_time = delay;
     }
@@ -796,7 +796,7 @@ int rftn_main(int argc, char **argv)
     phase_components = tp + delay;
 
     if(!Ctrl->s.active){
-        const char *wave_name = (Ctrl->T.incident == GRT_RFTN_INCIDENT_P) ? "P" : "SV";
+        const char *wave_name = (Ctrl->T.incident == GRT_RCVFN_INCIDENT_P) ? "P" : "SV";
         const char *layer_name = (Ctrl->P.incident_idx == 0) ? "halfspace" : "layer";
 
         GRTRaiseInfo("Incident wave: %s", wave_name);
@@ -804,7 +804,7 @@ int rftn_main(int argc, char **argv)
         GRTRaiseInfo("incidence layer: reverse-%zu %s", Ctrl->P.incident_idx, layer_name);
         GRTRaiseInfo("incidence angle = %.6g deg.", Ctrl->P.inca);
 
-        if(Ctrl->T.incident == GRT_RFTN_INCIDENT_P){
+        if(Ctrl->T.incident == GRT_RCVFN_INCIDENT_P){
             GRTRaiseInfo("Vertical travel time: Tp = %.6g s", tp);
             GRTRaiseInfo("begin time = %.6g s", begin_time);
         }
@@ -828,15 +828,15 @@ int rftn_main(int argc, char **argv)
         Ctrl->M.mod1d, Ctrl->P.rayp, Ctrl->T.incident,
         q_m, w_m, incident_velocity, nf, df, wI);
 
-    const GRT_RFTN_OUTPUT output_types[] = {
-        GRT_RFTN_OUTPUT_RATIO, GRT_RFTN_OUTPUT_Z, GRT_RFTN_OUTPUT_R,
+    const GRT_RCVFN_OUTPUT output_types[] = {
+        GRT_RCVFN_OUTPUT_RATIO, GRT_RCVFN_OUTPUT_Z, GRT_RCVFN_OUTPUT_R,
     };
-    const char *output_names[] = {"rftn", "Z", "R"};
+    const char *output_names[] = {"rcvfn", "Z", "R"};
     const real_t phase_times[] = {begin_time, phase_components, phase_components};
     size_t noutputs = Ctrl->W.write_components ? 3 : 1;
-    const char incident_name = (Ctrl->T.incident == GRT_RFTN_INCIDENT_P) ? 'P' : 'S';
+    const char incident_name = (Ctrl->T.incident == GRT_RCVFN_INCIDENT_P) ? 'P' : 'S';
     for(size_t ioutput = 0; ioutput < noutputs; ++ioutput){
-        GRT_RFTN_OUTPUT output = output_types[ioutput];
+        GRT_RCVFN_OUTPUT output = output_types[ioutput];
         size_t nfailed = assemble_spectrum(
             q_m, w_m, incident_velocity, Ctrl->T.incident, output,
             spectrum, nf, df, wI, Ctrl->A.alp);
@@ -853,10 +853,10 @@ int rftn_main(int argc, char **argv)
             nf, df, wI, begin_time, phase_times[ioutput]);
 
         if(!Ctrl->s.active){
-            if(output == GRT_RFTN_OUTPUT_RATIO){
+            if(output == GRT_RCVFN_OUTPUT_RATIO){
                 GRTRaiseInfo("Saved receiver function to %s", path);
             }
-            else if(output == GRT_RFTN_OUTPUT_Z){
+            else if(output == GRT_RCVFN_OUTPUT_Z){
                 GRTRaiseInfo("Saved vertical response to %s", path);
             }
             else{

--- a/pygrt/C_extension/src/grt.c
+++ b/pygrt/C_extension/src/grt.c
@@ -23,7 +23,7 @@
     X(eigenv)              \
     X(eigenfn)             \
     X(modsum)              \
-    X(rftn)                \
+    X(rcvfn)               \
     /* static */           \
     X(static_greenfn)      \
     X(static_syn)          \

--- a/pygrt/pymod.py
+++ b/pygrt/pymod.py
@@ -189,7 +189,7 @@ class PyModel1D:
     1. Create :class:`PyModel1D` with the Green's function path(s) actually needed
        (``grn`` and/or ``stgrn``) and optional ``modelpath``.
     2. Compute modal dispersion, receiver functions and Green's functions with
-       :meth:`eigenv`, :meth:`eigenfn`, :meth:`modsum`, :meth:`rftn`,
+       :meth:`eigenv`, :meth:`eigenfn`, :meth:`modsum`, :meth:`rcvfn`,
        :meth:`greenfn` or :meth:`static_greenfn` (the required paths depend on
        the method).
     3. Synthesize waveforms or static fields with :meth:`syn` or
@@ -916,7 +916,7 @@ class PyModel1D:
         """Legacy interface renamed to :meth:`greenfn`; calling it raises an error."""
         raise RuntimeError("compute_grn() has been renamed to greenfn(); use greenfn() instead.")
 
-    def rftn(
+    def rcvfn(
         self,
         *,
         wtype: str,
@@ -938,10 +938,10 @@ class PyModel1D:
         r"""
         Compute receiver functions for a plane incident P or SV wave.
 
-        This method wraps the ``grt rftn`` command. The incident wave is
+        This method wraps the ``grt rcvfn`` command. The incident wave is
         specified by either a horizontal ray parameter ``rayp`` or an upward
         incidence angle ``inca`` at the selected reverse-indexed model layer.
-        Results are written as ``P_rftn.sac`` or ``S_rftn.sac`` below
+        Results are written as ``P_rcvfn.sac`` or ``S_rcvfn.sac`` below
         ``output_path``; ``write_components=True`` also writes the corresponding
         ``Z`` and ``R`` response files. All arguments must be passed by keyword.
 
@@ -974,7 +974,7 @@ class PyModel1D:
         :return: ``None``. SAC files are written below ``output_path``.
         """
         if self.modelpath is None:
-            raise RuntimeError("Pass modelpath= to PyModel1D(...) before rftn().")
+            raise RuntimeError("Pass modelpath= to PyModel1D(...) before rcvfn().")
         if not isinstance(wtype, str) or wtype.upper() not in {"P", "S"}:
             raise ValueError('wtype must be "P" or "S".')
         if (rayp is None) == (inca is None):
@@ -1006,7 +1006,7 @@ class PyModel1D:
             raise ValueError("delay must be finite.")
 
         command = {
-            "subcommand": "rftn",
+            "subcommand": "rcvfn",
             "M": f"-M{self.modelpath}",
         }
         if rayp is not None:

--- a/test/_compare_c_py/test_cli_args.py
+++ b/test/_compare_c_py/test_cli_args.py
@@ -486,14 +486,14 @@ def test_modal_cli_argument_mapping():
         _restore_run_grt(pygrt.pymod, original)
 
 
-def test_rftn_cli_argument_mapping():
+def test_rcvfn_cli_argument_mapping():
     runner = CapturedRunner()
     original = _patch_run_grt(pygrt.pymod, runner)
-    output = HERE / "_tmp_args_rftn"
+    output = HERE / "_tmp_args_rcvfn"
     try:
         model = pygrt.PyModel1D(modelpath=MODEL)
 
-        model.rftn(
+        model.rcvfn(
             wtype="p",
             rayp=0.12,
             nt=128,
@@ -511,7 +511,7 @@ def test_rftn_cli_argument_mapping():
         assert_command_equals(
             runner.commands[-1],
             [
-                "rftn",
+                "rcvfn",
                 f"-M{MODEL}",
                 "-P0.12",
                 "-TP",
@@ -524,7 +524,7 @@ def test_rftn_cli_argument_mapping():
         )
         assert runner.kwargs[-1].get("print_log") is False
 
-        model.rftn(
+        model.rcvfn(
             wtype="S",
             inca=30.0,
             idx=2,
@@ -535,7 +535,7 @@ def test_rftn_cli_argument_mapping():
         assert_command_equals(
             runner.commands[-1],
             [
-                "rftn",
+                "rcvfn",
                 f"-M{MODEL}",
                 "-I30/2",
                 "-TS",
@@ -552,7 +552,7 @@ def test_rftn_cli_argument_mapping():
             {"rayp": 0.1, "idx": 1},
         ):
             try:
-                model.rftn(wtype="P", nt=8, dt=0.1, output_path=output, **kwargs)
+                model.rcvfn(wtype="P", nt=8, dt=0.1, output_path=output, **kwargs)
             except ValueError:
                 pass
             else:
@@ -1070,7 +1070,7 @@ def main():
         test_run_grt_forwards_warnings_and_errors,
         test_greenfn_default_and_optional_flags,
         test_modal_cli_argument_mapping,
-        test_rftn_cli_argument_mapping,
+        test_rcvfn_cli_argument_mapping,
         test_static_greenfn_xy_and_dists,
         test_syn_source_and_time_function_options,
         test_source_type_is_inferred_from_source_parameters,

--- a/test/rcvfn/test_rcvfn.py
+++ b/test/rcvfn/test_rcvfn.py
@@ -34,8 +34,8 @@ def expect_value_error(callable_obj, message: str) -> None:
 
 model = pygrt.PyModel1D(modelpath=MODEL)
 
-# 与 test_rftn.sh 中的 C 命令对应的 P 波参数
-model.rftn(
+# 与 test_rcvfn.sh 中的 C 命令对应的 P 波参数
+model.rcvfn(
     wtype="P",
     rayp=0.12,
     nt=64,
@@ -47,11 +47,11 @@ model.rftn(
 compare_sac_dirs(
     Path("C_P"),
     Path("PY_P"),
-    {"P_rftn.sac", "P_Z.sac", "P_R.sac"},
+    {"P_rcvfn.sac", "P_Z.sac", "P_R.sac"},
 )
 
-# 与 test_rftn.sh 中的 C 命令对应的 SV 波参数
-model.rftn(
+# 与 test_rcvfn.sh 中的 C 命令对应的 SV 波参数
+model.rcvfn(
     wtype="S",
     inca=20.0,
     idx=2,
@@ -70,28 +70,28 @@ model.rftn(
 compare_sac_dirs(
     Path("C_S"),
     Path("PY_S"),
-    {"S_rftn.sac", "S_Z.sac", "S_R.sac"},
+    {"S_rcvfn.sac", "S_Z.sac", "S_R.sac"},
 )
 
 # Python 端输入检查
 expect_value_error(
-    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.1, inca=20.0),
+    lambda: model.rcvfn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.1, inca=20.0),
     "rayp and inca should be mutually exclusive",
 )
 expect_value_error(
-    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad"),
+    lambda: model.rcvfn(wtype="P", nt=8, dt=0.1, output_path="bad"),
     "one of rayp and inca should be required",
 )
 expect_value_error(
-    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.1, idx=1),
+    lambda: model.rcvfn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.1, idx=1),
     "idx should require inca",
 )
 expect_value_error(
-    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad", inca=90.0),
+    lambda: model.rcvfn(wtype="P", nt=8, dt=0.1, output_path="bad", inca=90.0),
     "inca should be below 90 degrees",
 )
 expect_value_error(
-    lambda: model.rftn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.0),
+    lambda: model.rcvfn(wtype="P", nt=8, dt=0.1, output_path="bad", rayp=0.0),
     "rayp should be positive",
 )
 

--- a/test/rcvfn/test_rcvfn.sh
+++ b/test/rcvfn/test_rcvfn.sh
@@ -16,29 +16,29 @@ expect_fail() {
     echo "OK (failed as expected): $desc"
 }
 
-grt rftn -h
+grt rcvfn -h
 
 # P 波水平射线参数，输出接收函数和绝对位移分量
-grt rftn -M../milrow -P0.12 -TP -N64/0.05 -W -OC_P -s
-test -f C_P/P_rftn.sac
+grt rcvfn -M../milrow -P0.12 -TP -N64/0.05 -W -OC_P -s
+test -f C_P/P_rcvfn.sac
 test -f C_P/P_Z.sac
 test -f C_P/P_R.sac
 
 # SV 波入射角，指定反向入射层并覆盖可选频域参数
-grt rftn -M../milrow -I20/2 -TS -N64/0.05+w0.9+n2+a+f -A0.8 -E0.5 -W -OC_S -s
-test -f C_S/S_rftn.sac
+grt rcvfn -M../milrow -I20/2 -TS -N64/0.05+w0.9+n2+a+f -A0.8 -E0.5 -W -OC_S -s
+test -f C_S/S_rcvfn.sac
 test -f C_S/S_Z.sac
 test -f C_S/S_R.sac
 
 expect_fail "-P and -I are mutually exclusive" \
-    grt rftn -M../milrow -P0.12 -I20 -TP -N8/0.1 -OC_BAD
+    grt rcvfn -M../milrow -P0.12 -I20 -TP -N8/0.1 -OC_BAD
 
 expect_fail "one of -P and -I is required" \
-    grt rftn -M../milrow -TP -N8/0.1 -OC_BAD
+    grt rcvfn -M../milrow -TP -N8/0.1 -OC_BAD
 
 expect_fail "incidence angle must be below 90 degrees" \
-    grt rftn -M../milrow -I90 -TP -N8/0.1 -OC_BAD
+    grt rcvfn -M../milrow -I90 -TP -N8/0.1 -OC_BAD
 
-python -u test_rftn.py
+python -u test_rcvfn.py
 
 rm -rf C_P C_S PY_P PY_S


### PR DESCRIPTION
- Renamed the C module, entry point, internal identifiers, CLI subcommand, and SAC component label.
- Renamed `PyModel1D.rftn()` to `PyModel1D.rcvfn()` without changing its arguments or numerical behavior.
- Updated output filenames, tests, tutorials, Sphinx pages, cross-references, and equation labels.
- Removed the old `rftn` CLI and Python API names without compatibility aliases.
