### PR TITLE
REFAC: centralize checked memory allocation macros

### DIFF
--- a/pygrt/C_extension/include/grt/common/const.h
+++ b/pygrt/C_extension/include/grt/common/const.h
@@ -12,6 +12,7 @@
 #include <complex.h> 
 #include <tgmath.h>
 #include <omp.h>
+#include <stdlib.h>
 
 #include "grt/common/checkerror.h"
 
@@ -82,6 +83,35 @@ typedef double complex cplx_t;
 #define GRT_SQUARE(x) ((x) * (x))  ///< 计算一个数的平方
 
 // 内存管理
+#define GRT_SAFE_MALLOC(size) ({ \
+    size_t grt_size_ = (size); \
+    void *grt_ptr_ = malloc(grt_size_); \
+    if(grt_ptr_ == NULL && grt_size_ != 0){ \
+        GRTRaiseError("malloc failed."); \
+    } \
+    grt_ptr_; \
+})
+
+#define GRT_SAFE_CALLOC(nmemb, size) ({ \
+    size_t grt_nmemb_ = (nmemb); \
+    size_t grt_size_ = (size); \
+    void *grt_ptr_ = calloc(grt_nmemb_, grt_size_); \
+    if(grt_ptr_ == NULL && grt_nmemb_ != 0 && \
+       grt_size_ != 0){ \
+        GRTRaiseError("calloc failed."); \
+    } \
+    grt_ptr_; \
+})
+
+#define GRT_SAFE_REALLOC(ptr, size) ({ \
+    size_t grt_size_ = (size); \
+    void *grt_ptr_ = realloc((ptr), grt_size_); \
+    if(grt_ptr_ == NULL && grt_size_ != 0){ \
+        GRTRaiseError("realloc failed."); \
+    } \
+    grt_ptr_; \
+})
+
 // 释放单个指针
 #define GRT_SAFE_FREE_PTR(ptr) ({\
     if(ptr!=NULL) {\

--- a/pygrt/C_extension/src/common/finite_fault.c
+++ b/pygrt/C_extension/src/common/finite_fault.c
@@ -186,7 +186,7 @@ FINITE_FAULT *grt_finite_fault_load_coulomb(const char *path, size_t *nfault)
             GRTRaiseError("invalid Coulomb Kode at line %zu of %s.", line_number, path);
         }
 
-        faults = (FINITE_FAULT *)realloc(faults, sizeof(FINITE_FAULT) * (n + 1));
+        faults = GRT_SAFE_REALLOC(faults, sizeof(FINITE_FAULT) * (n + 1));
         FINITE_FAULT *f = faults + n;
         memset(f, 0, sizeof(*f));
 

--- a/pygrt/C_extension/src/common/model.c
+++ b/pygrt/C_extension/src/common/model.c
@@ -53,10 +53,10 @@ static cplx_t select_vertical_root(const cplx_t k, const cplx_t root)
     
 MODEL1D * grt_init_mod1d(size_t n)
 {
-    MODEL1D *mod1d = (MODEL1D *)calloc(1, sizeof(MODEL1D));
+    MODEL1D *mod1d = GRT_SAFE_CALLOC(1, sizeof(MODEL1D));
     mod1d->n = n;
 
-    #define X(P, T)  mod1d->P = (T*)calloc(n, sizeof(T));
+    #define X(P, T)  mod1d->P = GRT_SAFE_CALLOC(n, sizeof(T));
         __MODEL1D_FOR_EACH_ARRAY
     #undef X
 
@@ -65,7 +65,7 @@ MODEL1D * grt_init_mod1d(size_t n)
 
 MODEL1D * grt_copy_mod1d(const MODEL1D *mod1d1)
 {
-    MODEL1D *mod1d2 = (MODEL1D *)calloc(1, sizeof(MODEL1D));
+    MODEL1D *mod1d2 = GRT_SAFE_CALLOC(1, sizeof(MODEL1D));
 
     // 先直接赋值，实现浅拷贝
     *mod1d2 = *mod1d1;
@@ -73,7 +73,7 @@ MODEL1D * grt_copy_mod1d(const MODEL1D *mod1d1)
     // 对指针部分再重新申请内存并赋值，实现深拷贝
     size_t n = mod1d1->n;
     #define X(P, T)  \
-        mod1d2->P = (T*)calloc(n, sizeof(T));\
+        mod1d2->P = GRT_SAFE_CALLOC(n, sizeof(T));\
         memcpy(mod1d2->P, mod1d1->P, sizeof(T)*n);\
 
         __MODEL1D_FOR_EACH_ARRAY
@@ -83,8 +83,7 @@ MODEL1D * grt_copy_mod1d(const MODEL1D *mod1d1)
     mod1d2->modarr = NULL;
     mod1d2->nmodarr = 0;
     if(mod1d1->modarr != NULL && mod1d1->nmodarr > 0){
-        mod1d2->modarr = (real_t (*)[GRT_MODARR_NCOL])malloc(
-            sizeof(real_t) * GRT_MODARR_NCOL * mod1d1->nmodarr);
+        mod1d2->modarr = GRT_SAFE_MALLOC(sizeof(real_t) * GRT_MODARR_NCOL * mod1d1->nmodarr);
         memcpy(mod1d2->modarr, mod1d1->modarr, sizeof(real_t) * GRT_MODARR_NCOL * mod1d1->nmodarr);
         mod1d2->nmodarr = mod1d1->nmodarr;
     }
@@ -96,7 +95,7 @@ void grt_realloc_mod1d(MODEL1D *mod1d, size_t n)
 {
     mod1d->n = n;
 
-    #define X(P, T)  mod1d->P = (T*)realloc(mod1d->P, n*sizeof(T));
+    #define X(P, T)  mod1d->P = GRT_SAFE_REALLOC(mod1d->P, n*sizeof(T));
         __MODEL1D_FOR_EACH_ARRAY
     #undef X
 }
@@ -158,7 +157,7 @@ real_t (* grt_read_modarr_from_file(
             GRTRaiseError("In model file, line %zu, Vs==0.0 is not supported.\n", iline);
         }
 
-        modarr = (real_t (*)[GRT_MODARR_NCOL])realloc(
+        modarr = GRT_SAFE_REALLOC(
             modarr, sizeof(real_t) * GRT_MODARR_NCOL * (nlay + 1));
         modarr[nlay][0] = h;
         modarr[nlay][1] = va;
@@ -255,8 +254,7 @@ MODEL1D * grt_read_mod1d_from_modarr(
     }
 
     // 拷贝后再改末层厚度，避免改动调用方数组
-    real_t (*modarr_work)[GRT_MODARR_NCOL] = (real_t (*)[GRT_MODARR_NCOL])malloc(
-        sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
+    real_t (*modarr_work)[GRT_MODARR_NCOL] = GRT_SAFE_MALLOC(sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
     memcpy(modarr_work, modarr, sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
 
     for(size_t i = 0; i < nlayer; ++i){
@@ -393,7 +391,7 @@ MODEL1D * grt_read_mod1d_from_modarr(
     GRT_SAFE_FREE_PTR(modarr_work);
 
     // 保存未做层插入的原始矩阵
-    mod1d->modarr = (real_t (*)[GRT_MODARR_NCOL])calloc(nlayer, sizeof(real_t) * GRT_MODARR_NCOL);
+    mod1d->modarr = GRT_SAFE_CALLOC(nlayer, sizeof(real_t) * GRT_MODARR_NCOL);
     memcpy(mod1d->modarr, modarr, sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
     mod1d->nmodarr = nlayer;
 
@@ -435,11 +433,11 @@ void grt_set_mod1d_boundary(MODEL1D *mod1d, GRT_BOUND_TYPE topbound, GRT_BOUND_T
 
 MODEL1D_STATE * grt_init_mod1d_state(MODEL1D *mod1d)
 {
-    MODEL1D_STATE *mstat = (MODEL1D_STATE *)calloc(1, sizeof(MODEL1D_STATE));
+    MODEL1D_STATE *mstat = GRT_SAFE_CALLOC(1, sizeof(MODEL1D_STATE));
     size_t n = mod1d->n;
     mstat->mod1d = mod1d;
 
-    #define X(P, T)  mstat->P = (T*)calloc(n, sizeof(T));
+    #define X(P, T)  mstat->P = GRT_SAFE_CALLOC(n, sizeof(T));
         __MODEL1D_STATE_FOR_EACH_ARRAY
     #undef X
 
@@ -449,7 +447,7 @@ MODEL1D_STATE * grt_init_mod1d_state(MODEL1D *mod1d)
 
 MODEL1D_STATE * grt_copy_mod1d_state(const MODEL1D_STATE *mstat1)
 {
-    MODEL1D_STATE *mstat2 = (MODEL1D_STATE *)calloc(1, sizeof(MODEL1D_STATE));
+    MODEL1D_STATE *mstat2 = GRT_SAFE_CALLOC(1, sizeof(MODEL1D_STATE));
 
     // 先直接赋值，实现浅拷贝
     *mstat2 = *mstat1;
@@ -457,7 +455,7 @@ MODEL1D_STATE * grt_copy_mod1d_state(const MODEL1D_STATE *mstat1)
     // 对指针部分再重新申请内存并赋值，实现深拷贝
     size_t n = mstat1->mod1d->n;
     #define X(P, T)  \
-        mstat2->P = (T*)calloc(n, sizeof(T));\
+        mstat2->P = GRT_SAFE_CALLOC(n, sizeof(T));\
         memcpy(mstat2->P, mstat1->P, sizeof(T)*n);\
 
         __MODEL1D_STATE_FOR_EACH_ARRAY

--- a/pygrt/C_extension/src/common/myfftw.c
+++ b/pygrt/C_extension/src/common/myfftw.c
@@ -14,20 +14,17 @@
 #define X(T, s, S) \
 static GRT_FFTW##S##_HOLDER *  grt_init_fftw##s##_holder(const size_t nt, const real_t dt, const size_t nf_valid, const real_t df)\
 {\
-    GRT_FFTW##S##_HOLDER *fh = (GRT_FFTW##S##_HOLDER*)calloc(1, sizeof(GRT_FFTW##S##_HOLDER));\
-    if (!fh) {\
-        GRTRaiseError("Failed to allocate memory.\n");\
-    }\
+    GRT_FFTW##S##_HOLDER *fh = GRT_SAFE_CALLOC(1, sizeof(GRT_FFTW##S##_HOLDER));\
     fh->nt = nt;\
     fh->dt = dt;\
     fh->nf_valid = nf_valid;\
     fh->nf = nt/2+1;\
     fh->df = df;\
-    fh->w_t = (T*)calloc(nt, sizeof(T));\
+    fh->w_t = GRT_SAFE_CALLOC(nt, sizeof(T));\
     fh->W_f = (fftw##s##_complex*)fftw##s##_malloc(sizeof(fftw##s##_complex) * fh->nf);\
     memset(fh->w_t, 0, sizeof(T)*nt);\
     memset(fh->W_f, 0, sizeof(fftw##s##_complex)*fh->nf);\
-    if (!fh->w_t || !fh->W_f) {\
+    if (!fh->W_f) {\
         GRTRaiseError("Failed to allocate arrays.\n");\
     }\
     return fh;\

--- a/pygrt/C_extension/src/common/sacio.c
+++ b/pygrt/C_extension/src/common/sacio.c
@@ -19,7 +19,7 @@ SACTRACE * grt_read_SACTRACE(const char *path, const bool headonly)
 {
     GRTCheckFileExist(path);
 
-    SACTRACE *sac = (SACTRACE *)calloc(1, sizeof(SACTRACE));
+    SACTRACE *sac = GRT_SAFE_CALLOC(1, sizeof(SACTRACE));
 
     if (headonly) {
         if(read_sac_head(path, &sac->hd) != 0){
@@ -37,18 +37,18 @@ SACTRACE * grt_read_SACTRACE(const char *path, const bool headonly)
 
 SACTRACE * grt_copy_SACTRACE(SACTRACE *sac, bool zero_value)
 {
-    SACTRACE *sac2 = (SACTRACE *)calloc(1, sizeof(SACTRACE));
+    SACTRACE *sac2 = GRT_SAFE_CALLOC(1, sizeof(SACTRACE));
     *sac2 = *sac;
-    sac2->data = (float *)calloc(sac->hd.npts, sizeof(float));
+    sac2->data = GRT_SAFE_CALLOC(sac->hd.npts, sizeof(float));
     if(!zero_value) memcpy(sac2->data, sac->data, sizeof(float)*sac->hd.npts);
     return sac2;
 }
 
 SACTRACE * grt_new_SACTRACE(float dt, int nt, float b0)
 {
-    SACTRACE *sac = (SACTRACE *)calloc(1, sizeof(SACTRACE));
+    SACTRACE *sac = GRT_SAFE_CALLOC(1, sizeof(SACTRACE));
     sac->hd = new_sac_head(dt, nt, b0);
-    sac->data = (float *)calloc(nt, sizeof(float));
+    sac->data = GRT_SAFE_CALLOC(nt, sizeof(float));
     return sac;
 }
 

--- a/pygrt/C_extension/src/common/search.c
+++ b/pygrt/C_extension/src/common/search.c
@@ -209,8 +209,7 @@ int grt_argsort(
     if (n > (size_t)-1 / element_size ||
         n > (size_t)-1 / sizeof(GRTArgSortPair)) return -1;
 
-    GRTArgSortPair *pairs = malloc(n * sizeof(*pairs));
-    if (pairs == NULL) return -2;
+    GRTArgSortPair *pairs = GRT_SAFE_MALLOC(n * sizeof(*pairs));
 
     const unsigned char *bytes = base;
     for (size_t i = 0; i < n; i++) {

--- a/pygrt/C_extension/src/common/travt.c
+++ b/pygrt/C_extension/src/common/travt.c
@@ -19,7 +19,7 @@ real_t grt_compute_travt1d(
     const size_t isrc, const size_t ircv, const real_t dist)
 {
     // 以防速度数组中存在零速度的情况，这里新建数组以去除0速度
-    real_t *Vel = (real_t*)malloc(sizeof(real_t)*nlay);
+    real_t *Vel = GRT_SAFE_MALLOC(sizeof(real_t)*nlay);
     for(size_t i=0; i<nlay; ++i){
         Vel[i] = (Vel0[i] <= 0.0)? 1e-6 : Vel0[i];  // 给一个极慢值
     }
@@ -389,11 +389,7 @@ real_t *grt_compute_travt1d_from_file(
     }
 
     // 按 [Tp0, Ts0, Tp1, Ts1, ...] 交错排列
-    real_t *out = (real_t*)malloc(sizeof(real_t) * nr * 2);
-    if(out == NULL){
-        grt_free_mod1d(mod1d);
-        return NULL;
-    }
+    real_t *out = GRT_SAFE_MALLOC(sizeof(real_t) * nr * 2);
 
     for(size_t i = 0; i < nr; ++i){
         out[2*i] = grt_compute_travt1d(

--- a/pygrt/C_extension/src/common/util.c
+++ b/pygrt/C_extension/src/common/util.c
@@ -27,9 +27,9 @@ char ** grt_string_split(const char *string, const char *delim, size_t *size)
     *size = 0;
 
     while(token != NULL){
-        s_split = (char**)realloc(s_split, sizeof(char*)*(*size+1));
+        s_split = GRT_SAFE_REALLOC(s_split, sizeof(char*)*(*size+1));
         s_split[*size] = NULL;
-        s_split[*size] = (char*)realloc(s_split[*size], sizeof(char)*(strlen(token)+1));
+        s_split[*size] = GRT_SAFE_REALLOC(s_split[*size], sizeof(char)*(strlen(token)+1));
         strcpy(s_split[*size], token);
 
         token = strtok(NULL, delim);
@@ -43,7 +43,7 @@ char ** grt_string_split(const char *string, const char *delim, size_t *size)
 char ** grt_string_from_file(FILE *fp, size_t *size){
     char **s_split = NULL;
     *size = 0;
-    s_split = (char**)realloc(s_split, sizeof(char*)*(*size+1));
+    s_split = GRT_SAFE_REALLOC(s_split, sizeof(char*)*(*size+1));
     s_split[*size] = NULL;
 
     size_t len=0;
@@ -56,7 +56,7 @@ char ** grt_string_from_file(FILE *fp, size_t *size){
             s_split[*size][line_len - 1] = '\0';
         }
         (*size)++;
-        s_split = (char**)realloc(s_split, sizeof(char*)*(*size+1));
+        s_split = GRT_SAFE_REALLOC(s_split, sizeof(char*)*(*size+1));
         s_split[*size] = NULL;
     }
     return s_split;
@@ -81,7 +81,7 @@ real_t *grt_parse_real_array(const char *optarg, size_t *size, char ***s_values,
             GRTRaiseError("-%c: start (%f) > end (%f).", optname, a1, a2);
         }
         n = (size_t)floor((a2 - a1) / delta) + 1;
-        s_vals = (char **)calloc(n, sizeof(char *));
+        s_vals = GRT_SAFE_CALLOC(n, sizeof(char *));
         for(size_t i = 0; i < n; ++i){
             GRT_SAFE_ASPRINTF(&s_vals[i], "%.15g", a1 + delta * i);
         }
@@ -97,7 +97,7 @@ real_t *grt_parse_real_array(const char *optarg, size_t *size, char ***s_values,
         GRTRaiseError("-%c: empty value list.", optname);
     }
 
-    real_t *values = (real_t *)calloc(n, sizeof(real_t));
+    real_t *values = GRT_SAFE_CALLOC(n, sizeof(real_t));
     for(size_t i = 0; i < n; ++i){
         values[i] = atof(s_vals[i]);
         if(values[i] < 0.0){
@@ -193,7 +193,7 @@ static bool grt_is_numeric_field(const char *begin, const char *end)
 
     // strtod 需要以字符串结束符结尾，因此复制指定的字符串区间
     size_t length = (size_t)(end - begin);
-    char *value = (char *)calloc(length + 1, sizeof(char));
+    char *value = GRT_SAFE_CALLOC(length + 1, sizeof(char));
     memcpy(value, begin, length);
 
     // strtod 支持小数、科学计数法以及正负号
@@ -410,10 +410,7 @@ ssize_t grt_getline(char **lineptr, size_t *n, FILE *stream){
     // 如果缓冲区为空，分配初始缓冲区
     if (buf == NULL || size == 0) {
         size = 128;
-        buf = malloc(size);
-        if (buf == NULL) {
-            return -1;
-        }
+        buf = GRT_SAFE_MALLOC(size);
     }
     
     // 逐字符读取直到换行符或EOF
@@ -421,11 +418,7 @@ ssize_t grt_getline(char **lineptr, size_t *n, FILE *stream){
         // 检查是否需要扩展缓冲区
         if (len + 1 >= size) {
             size_t new_size = size * 2;
-            char *new_buf = realloc(buf, new_size);
-            if (new_buf == NULL) {
-                free(buf);
-                return -1;
-            }
+            char *new_buf = GRT_SAFE_REALLOC(buf, new_size);
             buf = new_buf;
             size = new_size;
         }

--- a/pygrt/C_extension/src/dynamic/grn.c
+++ b/pygrt/C_extension/src/dynamic/grn.c
@@ -42,7 +42,7 @@
 static void recordin_GRN(size_t iw, size_t nr, cplx_t coef, cplxIntegGrid sumJ[nr], pcplxChnlGrid u[nr])
 {
     // 局部变量，将某个频点的格林函数谱临时存放
-    cplxChnlGrid *tmp_u = (cplxChnlGrid *)calloc(nr, sizeof(*tmp_u));
+    cplxChnlGrid *tmp_u = GRT_SAFE_CALLOC(nr, sizeof(*tmp_u));
 
     for(size_t ir=0; ir<nr; ++ir){
         grt_merge_Pk(sumJ[ir], tmp_u[ir]);
@@ -73,7 +73,7 @@ void grt_integ_grn_spec(MODEL1D *mod1d, K_INTEG_PROCESS *Kproc, GRNSPEC *grn, co
     int progress=0;
 
     // 记录每个频率的计算中是否有除0错误
-    int *freq_invstats = (int *)calloc(grn->nf2 + 1, sizeof(int));
+    int *freq_invstats = GRT_SAFE_CALLOC(grn->nf2 + 1, sizeof(int));
 
     mod1d->omgref = PI2*grn->freqs[grn->nf2];
 

--- a/pygrt/C_extension/src/dynamic/grnspec.c
+++ b/pygrt/C_extension/src/dynamic/grnspec.c
@@ -16,15 +16,15 @@
 
 void grt_grnspec_allocate_u(GRNSPEC *grn)
 {
-    grn->u = (pcplxChnlGrid *) calloc(grn->nr, sizeof(*grn->u));
-    grn->uiz = (grn->calc_upar)? (pcplxChnlGrid *) calloc(grn->nr, sizeof(*grn->uiz)) : NULL;
-    grn->uir = (grn->calc_upar)? (pcplxChnlGrid *) calloc(grn->nr, sizeof(*grn->uir)) : NULL;
+    grn->u = GRT_SAFE_CALLOC(grn->nr, sizeof(*grn->u));
+    grn->uiz = (grn->calc_upar)? GRT_SAFE_CALLOC(grn->nr, sizeof(*grn->uiz)) : NULL;
+    grn->uir = (grn->calc_upar)? GRT_SAFE_CALLOC(grn->nr, sizeof(*grn->uir)) : NULL;
 
     for(size_t ir = 0; ir < grn->nr; ++ir){
         GRT_LOOP_ChnlGrid(im, c){
-            grn->u[ir][im][c] = (cplx_t*) calloc(grn->nf, sizeof(cplx_t));
-            if(grn->uiz)  grn->uiz[ir][im][c] = (cplx_t*)calloc(grn->nf, sizeof(cplx_t));
-            if(grn->uir)  grn->uir[ir][im][c] = (cplx_t*)calloc(grn->nf, sizeof(cplx_t));
+            grn->u[ir][im][c] = GRT_SAFE_CALLOC(grn->nf, sizeof(cplx_t));
+            if(grn->uiz)  grn->uiz[ir][im][c] = GRT_SAFE_CALLOC(grn->nf, sizeof(cplx_t));
+            if(grn->uir)  grn->uir[ir][im][c] = GRT_SAFE_CALLOC(grn->nf, sizeof(cplx_t));
         }
     }
 }

--- a/pygrt/C_extension/src/dynamic/grt_greenfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_greenfn.c
@@ -452,8 +452,8 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
                     Ctrl->D.ndepsrc = 1;
                     Ctrl->D.ndeprcv = 1;
-                    Ctrl->D.depsrcs = (real_t *)calloc(1, sizeof(real_t));
-                    Ctrl->D.deprcvs = (real_t *)calloc(1, sizeof(real_t));
+                    Ctrl->D.depsrcs = GRT_SAFE_CALLOC(1, sizeof(real_t));
+                    Ctrl->D.deprcvs = GRT_SAFE_CALLOC(1, sizeof(real_t));
                     Ctrl->D.depsrcs[0] = depsrc;
                     Ctrl->D.deprcvs[0] = deprcv;
                 }
@@ -764,7 +764,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     Ctrl->S.s_raw = strdup(optarg);
                     Ctrl->S.s_statsidxs = grt_string_split(optarg, ",", &Ctrl->S.nstatsidxs);
                     // 转为浮点数
-                    Ctrl->S.statsidxs = (size_t*)realloc(Ctrl->S.statsidxs, sizeof(size_t)*(Ctrl->S.nstatsidxs));
+                    Ctrl->S.statsidxs = GRT_SAFE_REALLOC(Ctrl->S.statsidxs, sizeof(size_t)*(Ctrl->S.nstatsidxs));
                     for(size_t i=0; i<Ctrl->S.nstatsidxs; ++i){
                         int tmp = atoi(Ctrl->S.s_statsidxs[i]);
                         if(tmp < 0){
@@ -892,7 +892,7 @@ static void prepare_grn_spec(
 
     size_t nf = nt / 2 + 1;
     real_t df = 1.0 / winT;
-    real_t *freqs = (real_t *)malloc(nf * sizeof(real_t));
+    real_t *freqs = GRT_SAFE_MALLOC(nf * sizeof(real_t));
     for(size_t i = 0; i < nf; ++i){
         freqs[i] = i * df;
     }
@@ -985,7 +985,7 @@ static void compute_greenfn_one(GRT_MODULE_CTRL *Ctrl) {
     if(Ctrl->S.active && Ctrl->S.statsidxs == NULL){
         // 另外两个字符相关的指针仍指向 NULL
         Ctrl->S.nstatsidxs = grn->nf;
-        Ctrl->S.statsidxs = (size_t*)realloc(Ctrl->S.statsidxs, sizeof(size_t)*(Ctrl->S.nstatsidxs));
+        Ctrl->S.statsidxs = GRT_SAFE_REALLOC(Ctrl->S.statsidxs, sizeof(size_t)*(Ctrl->S.nstatsidxs));
         for(size_t i=0; i < Ctrl->S.nstatsidxs; ++i){
             Ctrl->S.statsidxs[i] = i;
         }
@@ -1039,9 +1039,9 @@ static void compute_greenfn_one(GRT_MODULE_CTRL *Ctrl) {
     sac->hd.user8 = mod1d->Rho[mod1d->isrc];
     
     // 为每个震中距设置对应的变量
-    real_t (*travtPS)[2] = (real_t (*)[2])calloc(grn->nr, sizeof(real_t)*2);
-    real_t *begintimes = (real_t *)calloc(grn->nr, sizeof(real_t));
-    char **outputdirs = (char **)calloc(grn->nr, sizeof(char *));
+    real_t (*travtPS)[2] = GRT_SAFE_CALLOC(grn->nr, sizeof(real_t)*2);
+    real_t *begintimes = GRT_SAFE_CALLOC(grn->nr, sizeof(real_t));
+    char **outputdirs = GRT_SAFE_CALLOC(grn->nr, sizeof(char *));
     for(size_t ir = 0; ir < Ctrl->R.nr; ++ir){
         real_t dist = Ctrl->R.rs[ir];
 
@@ -1096,7 +1096,7 @@ static void compute_greenfn_one(GRT_MODULE_CTRL *Ctrl) {
 
 /** 子模块主函数 */
 int greenfn_main(int argc, char **argv) {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 

--- a/pygrt/C_extension/src/dynamic/grt_kernel.c
+++ b/pygrt/C_extension/src/dynamic/grt_kernel.c
@@ -189,8 +189,8 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
             // 震源和场点深度， -Ddepsrc/deprcv
             case 'D':
                 Ctrl->D.active = true;
-                Ctrl->D.s_depsrc = (char*)malloc(sizeof(char)*(strlen(optarg)+1));
-                Ctrl->D.s_deprcv = (char*)malloc(sizeof(char)*(strlen(optarg)+1));
+                Ctrl->D.s_depsrc = GRT_SAFE_MALLOC(sizeof(char)*(strlen(optarg)+1));
+                Ctrl->D.s_deprcv = GRT_SAFE_MALLOC(sizeof(char)*(strlen(optarg)+1));
                 if(2 != sscanf(optarg, "%[^/]/%s", Ctrl->D.s_depsrc, Ctrl->D.s_deprcv)){
                     GRTBadOptionError(D, "");
                 };
@@ -271,7 +271,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                     if(Ctrl->F.nf < 2){
                         GRTBadOptionError(F, "Too few frequency points, only %zu.", Ctrl->F.nf);
                     }
-                    Ctrl->F.freqs = (real_t *)calloc(Ctrl->F.nf, sizeof(real_t));
+                    Ctrl->F.freqs = GRT_SAFE_CALLOC(Ctrl->F.nf, sizeof(real_t));
                     for(size_t i=0; i<Ctrl->F.nf; ++i){
                         Ctrl->F.freqs[i] = a1 + df*i;
                     }
@@ -316,7 +316,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                         }
 
                         Ctrl->C.nc = floor((a2-a1)/df) + 1;
-                        Ctrl->C.c_phases = (real_t *)calloc(Ctrl->C.nc, sizeof(real_t));
+                        Ctrl->C.c_phases = GRT_SAFE_CALLOC(Ctrl->C.nc, sizeof(real_t));
                         for(size_t i=0; i<Ctrl->C.nc; ++i){
                             Ctrl->C.c_phases[i] = a1 + df*i;
                         }
@@ -374,7 +374,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
 /** 子模块主函数 */
 int kernel_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     // 传入参数 
     getopt_from_command(Ctrl, argc, argv);
@@ -396,7 +396,7 @@ int kernel_main(int argc, char **argv)
         Ctrl->C.cmin = 0.8 * vmin;
         Ctrl->C.cmax = vmax;
         Ctrl->C.nc = floor((Ctrl->C.cmax - Ctrl->C.cmin)/Ctrl->C.dc) + 1;
-        Ctrl->C.c_phases = (real_t *)calloc(Ctrl->C.nc, sizeof(real_t));
+        Ctrl->C.c_phases = GRT_SAFE_CALLOC(Ctrl->C.nc, sizeof(real_t));
         for(size_t i=0; i<Ctrl->C.nc; ++i){
             Ctrl->C.c_phases[i] = Ctrl->C.cmin + Ctrl->C.dc*i;
         }

--- a/pygrt/C_extension/src/dynamic/grt_rcvfn.c
+++ b/pygrt/C_extension/src/dynamic/grt_rcvfn.c
@@ -758,7 +758,7 @@ static void write_result_sac(
 /** rcvfn 子模块主函数 */
 int rcvfn_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
     getopt_from_command(Ctrl, argc, argv);
 
     Ctrl->M.mod1d = grt_read_mod1d_from_file(Ctrl->M.s_modelpath, -1.0, -1.0, true);
@@ -818,10 +818,10 @@ int rcvfn_main(int argc, char **argv)
 
     size_t nt = Ctrl->N.nt*Ctrl->N.upsample_n;
     real_t dt = Ctrl->N.dt/Ctrl->N.upsample_n;
-    cplx_t *q_m = calloc(nf, sizeof(*q_m));
-    cplx_t *w_m = calloc(nf, sizeof(*w_m));
-    cplx_t *incident_velocity = calloc(nf, sizeof(*incident_velocity));
-    cplx_t *spectrum = calloc(nf, sizeof(*spectrum));
+    cplx_t *q_m = GRT_SAFE_CALLOC(nf, sizeof(*q_m));
+    cplx_t *w_m = GRT_SAFE_CALLOC(nf, sizeof(*w_m));
+    cplx_t *incident_velocity = GRT_SAFE_CALLOC(nf, sizeof(*incident_velocity));
+    cplx_t *spectrum = GRT_SAFE_CALLOC(nf, sizeof(*spectrum));
 
     // 频率递推只执行一次，后续输出复用 q_m 和 w_m
     compute_frequency_responses(

--- a/pygrt/C_extension/src/dynamic/grt_rotation.c
+++ b/pygrt/C_extension/src/dynamic/grt_rotation.c
@@ -80,7 +80,7 @@ static void compute_rotation(
 
 /** 子模块主函数 */
 int rotation_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
     
@@ -131,7 +131,7 @@ int rotation_main(int argc, char **argv){
             upar[c2][c] = insac->data;
             insac->data = NULL;
             grt_free_SACTRACE(insac);
-            res[c2][c] = calloc(npts, sizeof(*res[c2][c]));
+            res[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(*res[c2][c]));
         }
     }
     compute_rotation(npts, dist, u, upar, res, rot2ZNE);

--- a/pygrt/C_extension/src/dynamic/grt_strain.c
+++ b/pygrt/C_extension/src/dynamic/grt_strain.c
@@ -83,7 +83,7 @@ static void compute_strain(
 
 /** 子模块主函数 */
 int strain_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
     
@@ -133,7 +133,7 @@ int strain_main(int argc, char **argv){
             upar[c2][c] = insac->data;
             insac->data = NULL;
             grt_free_SACTRACE(insac);
-            res[c2][c] = calloc(npts, sizeof(*res[c2][c]));
+            res[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(*res[c2][c]));
         }
     }
     compute_strain(npts, dist, u, upar, res, rot2ZNE);

--- a/pygrt/C_extension/src/dynamic/grt_stress.c
+++ b/pygrt/C_extension/src/dynamic/grt_stress.c
@@ -87,8 +87,8 @@ static void compute_stress(
 
     // 联络项（1e-5: km→cm）：r≠0 用 u/r；r=0 改用 ∂_r u，与 syn 中 (1/r)∂_θ 有限部分配套
     // 时域先算好 ur_over_r / ut_over_r，再 FFT，避免频域再分支缩放
-    float *ur_over_r = (float *)malloc(sizeof(float)*npts);
-    float *ut_over_r = (float *)malloc(sizeof(float)*npts);
+    float *ur_over_r = GRT_SAFE_MALLOC(sizeof(float)*npts);
+    float *ut_over_r = GRT_SAFE_MALLOC(sizeof(float)*npts);
     for(size_t i=0; i<npts; ++i){
         ur_over_r[i] = GRT_IS_ZERO(dist) ? upar[1][1][i] : (u[1][i] / dist * 1e-5f);
         ut_over_r[i] = GRT_IS_ZERO(dist) ? upar[1][2][i] : (u[2][i] / dist * 1e-5f);
@@ -141,7 +141,7 @@ static void compute_stress(
 
 
 int stress_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
     
@@ -201,7 +201,7 @@ int stress_main(int argc, char **argv){
             upar[c2][c] = insac->data;
             insac->data = NULL;
             grt_free_SACTRACE(insac);
-            res[c2][c] = calloc(npts, sizeof(*res[c2][c]));
+            res[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(*res[c2][c]));
         }
     }
     compute_stress(npts, dt, dist, va, vb, rho, Qainv, Qbinv, u, upar, res, rot2ZNE);

--- a/pygrt/C_extension/src/dynamic/grt_syn.c
+++ b/pygrt/C_extension/src/dynamic/grt_syn.c
@@ -421,7 +421,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
                 } else {
                     Ctrl->D.active = true;
-                    Ctrl->D.tfparams = (char*)malloc(sizeof(char) * (strlen(optarg) + 1));
+                    Ctrl->D.tfparams = GRT_SAFE_MALLOC(sizeof(char) * (strlen(optarg) + 1));
                     if(optarg[1] != '/' || 1 != sscanf(optarg, "%c", &Ctrl->D.tftype) || 1 != sscanf(optarg + 2, "%s", Ctrl->D.tfparams)){
                         GRTBadOptionError(D, "");
                     }
@@ -588,10 +588,7 @@ static void append_unique_real(real_t **values, size_t *nvalues, real_t value, c
 {
     if(real_value_exists(*values, *nvalues, value, tolerance)) return;
 
-    real_t *new_values = (real_t *)realloc(*values, sizeof(real_t) * (*nvalues + 1));
-    if(new_values == NULL){
-        GRTRaiseError("Failed to allocate Green's-function directory metadata.");
-    }
+    real_t *new_values = GRT_SAFE_REALLOC(*values, sizeof(real_t) * (*nvalues + 1));
     new_values[*nvalues] = value;
     *values = new_values;
     *nvalues += 1;
@@ -940,7 +937,7 @@ static void syn_postprocess_trace(SACTRACE *sac, SACTRACE *tfsac, int int_times,
             fac *= dfac;
         }
 
-        float *convarr = (float *)calloc(nt, sizeof(float));
+        float *convarr = GRT_SAFE_CALLOC(nt, sizeof(float));
         grt_oaconvolve(sac->data, nt, tfsac->data, tfsac->hd.npts, convarr, nt, true);
         fac = 1.0f;
         dfac = expf(wI * dt);
@@ -964,7 +961,7 @@ static void syn_postprocess_trace(SACTRACE *sac, SACTRACE *tfsac, int int_times,
 /** 子模块主函数 */
 int syn_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 

--- a/pygrt/C_extension/src/dynamic/signals.c
+++ b/pygrt/C_extension/src/dynamic/signals.c
@@ -112,7 +112,7 @@ float * grt_get_time_function(int *TFnt, float dt, const char tftype, const char
 //     int tfnt=0;
 //     tfarr = grt_get_time_function(&tfnt, dt, tftype, tfparams);
 
-//     float *yarr = (float*)calloc(nt, sizeof(float));
+//     float *yarr = GRT_SAFE_CALLOC(nt, sizeof(float));
 //     // 线性卷积
 //     grt_oaconvolve(arr, nt, tfarr, tfnt, yarr, nt, false);
 
@@ -217,7 +217,7 @@ float * grt_get_parabola_wave(float dt, float *Tlen, int *Nt){
     nt += 2;
     tlen = (nt-1)*dt;
 
-    float *arr = (float*)calloc(nt, sizeof(float));
+    float *arr = GRT_SAFE_CALLOC(nt, sizeof(float));
     float fac=1.0/(nt-1);
     float pha=0.0;
     for(int n=0; n<nt; ++n){
@@ -266,7 +266,7 @@ float * grt_get_trap_wave(float dt, float *T1, float *T2, float *T3, int *Nt){
 
     // 总点数
     int nt = n1+n2+n3 - 2;
-    float *arr = (float*)calloc(nt, sizeof(float));
+    float *arr = GRT_SAFE_CALLOC(nt, sizeof(float));
 
     float fac=0.0, y=0.0;
     // 上坡
@@ -308,7 +308,7 @@ float * grt_get_ricker_wave(float dt, float f0, int *Nt){
 
     float t0 = 1.0/f0;
     int nt = (floorf(t0/dt) + 1) * 2; // 估计2倍长度够包含
-    float *arr = (float*)calloc(nt, sizeof(float));
+    float *arr = GRT_SAFE_CALLOC(nt, sizeof(float));
 
     float PPI = PI*PI;
     float ff0 = f0*f0;
@@ -326,7 +326,7 @@ float * grt_get_ricker_wave(float dt, float f0, int *Nt){
 
 
 float * grt_get_custom_wave(int *Nt, const char *tfparams){
-    float *tfarr = (float*)malloc(sizeof(float)*1);
+    float *tfarr = GRT_SAFE_MALLOC(sizeof(float)*1);
     FILE *fp;
     if((fp = fopen(tfparams, "r")) == NULL){
         GRTRaiseError("custom time function file open error.\n");
@@ -351,7 +351,7 @@ float * grt_get_custom_wave(int *Nt, const char *tfparams){
             GRTRaiseError("custom time function file should contain exactly one column at line %zu.\n", lineno);
         }
 
-        tfarr = (float*)realloc(tfarr, sizeof(float)*(nt+1));
+        tfarr = GRT_SAFE_REALLOC(tfarr, sizeof(float)*(nt+1));
         tfarr[nt] = value;
         sum += tfarr[nt];
         nt++;

--- a/pygrt/C_extension/src/grt.c
+++ b/pygrt/C_extension/src/grt.c
@@ -182,7 +182,7 @@ int dispatch_command(GRT_MAIN_CTRL *Ctrl, int argc, char **argv) {
 /** 主函数 */
 int main(int argc, char **argv) {
     GRT_MODULE_NAME = GRT_MAIN_COMMAND;
-    GRT_MAIN_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MAIN_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     if(argc <= 2){
         getopt_from_command(Ctrl, argc, argv);

--- a/pygrt/C_extension/src/integral/dwm.c
+++ b/pygrt/C_extension/src/integral/dwm.c
@@ -39,7 +39,7 @@ real_t grt_discrete_integ(
     bool iendk = true;
 
     // 每个震中距的k循环是否结束
-    bool *iendkrs = (bool *)calloc(nr, sizeof(bool)); // 自动初始化为 false
+    bool *iendkrs = GRT_SAFE_CALLOC(nr, sizeof(bool)); // 自动初始化为 false
     bool iendk0 = false;
 
     size_t nk = floor(kmax / dk) + 1L;

--- a/pygrt/C_extension/src/integral/fim.c
+++ b/pygrt/C_extension/src/integral/fim.c
@@ -38,7 +38,7 @@ real_t grt_linear_filon_integ(
     bool iendk = true;
 
     // 每个震中距的k循环是否结束
-    bool *iendkrs = (bool *)calloc(nr, sizeof(bool)); // 自动初始化为 false
+    bool *iendkrs = GRT_SAFE_CALLOC(nr, sizeof(bool)); // 自动初始化为 false
     bool iendk0 = false;
 
     size_t nk = floor((kmax - k0) / dk) + 1L;

--- a/pygrt/C_extension/src/integral/integ_process.c
+++ b/pygrt/C_extension/src/integral/integ_process.c
@@ -29,7 +29,7 @@ void grt_KPROC_init_fstats(
 
     // 为当前频率创建波数积分记录文件
     // PTAM为每个震中距都创建波数积分记录文件
-    Kproc->ptam_fstatsnr = (FILE *(*)[2])calloc(nr, sizeof(*Kproc->ptam_fstatsnr));
+    Kproc->ptam_fstatsnr = GRT_SAFE_CALLOC(nr, sizeof(*Kproc->ptam_fstatsnr));
     char *fname = NULL;
     GRT_SAFE_ASPRINTF(&fname, "%s/K%s", statsstr, suffix);
     Kproc->fstats = fopen(fname, "wb");

--- a/pygrt/C_extension/src/integral/k_integ.c
+++ b/pygrt/C_extension/src/integral/k_integ.c
@@ -21,33 +21,33 @@
 
 K_INTEG * grt_init_K_INTEG(const bool calc_upar, const size_t nr)
 {
-    K_INTEG *K = (K_INTEG *)calloc(1, sizeof(K_INTEG));
+    K_INTEG *K = GRT_SAFE_CALLOC(1, sizeof(K_INTEG));
     K->calc_upar = calc_upar;
     K->nr = nr;
-    K->sumJ  = (cplxIntegGrid *)calloc(nr, sizeof(cplxIntegGrid));
+    K->sumJ  = GRT_SAFE_CALLOC(nr, sizeof(cplxIntegGrid));
     K->sumJz = K->sumJr = NULL;
     if(calc_upar){
-        K->sumJz = (cplxIntegGrid *)calloc(nr, sizeof(cplxIntegGrid));
-        K->sumJr = (cplxIntegGrid *)calloc(nr, sizeof(cplxIntegGrid));
+        K->sumJz = GRT_SAFE_CALLOC(nr, sizeof(cplxIntegGrid));
+        K->sumJr = GRT_SAFE_CALLOC(nr, sizeof(cplxIntegGrid));
     }
     return K;
 }
 
 K_INTEG * grt_copy_K_INTEG(const K_INTEG *K)
 {
-    K_INTEG *K0 = (K_INTEG *)calloc(1, sizeof(K_INTEG));
+    K_INTEG *K0 = GRT_SAFE_CALLOC(1, sizeof(K_INTEG));
     // 先直接赋值，实现浅拷贝
     *K0 = *K;
 
     // 对指针部分再重新申请内存并赋值，实现深拷贝
     size_t nr = K->nr;
-    K0->sumJ  = (cplxIntegGrid *)calloc(nr, sizeof(cplxIntegGrid));
+    K0->sumJ  = GRT_SAFE_CALLOC(nr, sizeof(cplxIntegGrid));
     memcpy(K0->sumJ, K->sumJ, sizeof(cplxIntegGrid)*nr);
     K0->sumJz = K0->sumJr = NULL;
     if(K->calc_upar){
-        K0->sumJz = (cplxIntegGrid *)calloc(nr, sizeof(cplxIntegGrid));
+        K0->sumJz = GRT_SAFE_CALLOC(nr, sizeof(cplxIntegGrid));
         memcpy(K0->sumJz, K->sumJz, sizeof(cplxIntegGrid)*nr);
-        K0->sumJr = (cplxIntegGrid *)calloc(nr, sizeof(cplxIntegGrid));
+        K0->sumJr = GRT_SAFE_CALLOC(nr, sizeof(cplxIntegGrid));
         memcpy(K0->sumJr, K->sumJr, sizeof(cplxIntegGrid)*nr);
     }
     return K0;

--- a/pygrt/C_extension/src/integral/ptam.c
+++ b/pygrt/C_extension/src/integral/ptam.c
@@ -246,7 +246,7 @@ void grt_PTA_method(
 
     // 使用宏函数，方便定义
     #define __CALLOC_ARRAY(VAR, TYP, __ARR) \
-        TYP (*VAR)__ARR = (TYP (*)__ARR)calloc(nr, sizeof(*VAR));
+        TYP (*VAR)__ARR = GRT_SAFE_CALLOC(nr, sizeof(*VAR));
 
     // 用于接收F(ki,w)Jm(ki*r)ki
     // 存储采样的值，维度3表示通过连续3个点来判断波峰或波谷
@@ -282,8 +282,8 @@ void grt_PTA_method(
     #undef __ARR
     #undef __CALLOC_ARRAY
 
-    size_t *waits_max = (size_t *)calloc(nr, sizeof(*waits_max));
-    bool *iendkrs = (bool *)calloc(nr, sizeof(*iendkrs));
+    size_t *waits_max = GRT_SAFE_CALLOC(nr, sizeof(*waits_max));
+    bool *iendkrs = GRT_SAFE_CALLOC(nr, sizeof(*iendkrs));
     for(size_t ir = 0; ir < nr; ++ir){
         if(GRT_IS_ZERO(rs[ir]))  continue;
         waits_max[ir] = (size_t)ceil(PI/(rs[ir]*dk)) + 5;  // + 5 以防万一

--- a/pygrt/C_extension/src/integral/safim.c
+++ b/pygrt/C_extension/src/integral/safim.c
@@ -66,7 +66,7 @@ typedef struct {
 
 /** 初始化区间栈 */
 static void stack_init(KIntervalStack *stack, size_t init_capacity) {
-    stack->data = (KInterval*)malloc(init_capacity * sizeof(KInterval));
+    stack->data = GRT_SAFE_MALLOC(init_capacity * sizeof(KInterval));
     stack->size = 0;
     stack->capacity = init_capacity;
 }
@@ -76,7 +76,7 @@ static void stack_push(KIntervalStack *stack, KInterval item) {
     // 扩容
     if(stack->size >= stack->capacity){
         stack->capacity *= 2;
-        stack->data = (KInterval*)realloc(stack->data, stack->capacity * sizeof(KInterval));
+        stack->data = GRT_SAFE_REALLOC(stack->data, stack->capacity * sizeof(KInterval));
     }
     stack->data[stack->size++] = item;
 }

--- a/pygrt/C_extension/src/lamb/grt_lamb1.c
+++ b/pygrt/C_extension/src/lamb/grt_lamb1.c
@@ -123,7 +123,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
 
                     Ctrl->T.nt = floor((a2-a1)/delta) + 1;
-                    Ctrl->T.ts = (real_t*)calloc(Ctrl->T.nt, sizeof(real_t));
+                    Ctrl->T.ts = GRT_SAFE_CALLOC(Ctrl->T.nt, sizeof(real_t));
                     for(int i=0; i<Ctrl->T.nt; ++i){
                         Ctrl->T.ts[i] = a1 + delta*i;
                     }
@@ -156,7 +156,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
 /** 模块主函数 */
 int lamb1_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     // 传入参数 
     getopt_from_command(Ctrl, argc, argv);

--- a/pygrt/C_extension/src/lamb/grt_lamb2.c
+++ b/pygrt/C_extension/src/lamb/grt_lamb2.c
@@ -160,7 +160,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                         GRTBadOptionError(T, "t1(%f) > t2(%f).", t1, t2);
                     }
                     Ctrl->T.nt = (int)floor((t2 - t1) / dt) + 1;
-                    Ctrl->T.ts = (real_t *)calloc((size_t)Ctrl->T.nt, sizeof(*Ctrl->T.ts));
+                    Ctrl->T.ts = GRT_SAFE_CALLOC((size_t)Ctrl->T.nt, sizeof(*Ctrl->T.ts));
                     for (int i = 0; i < Ctrl->T.nt; ++i) {
                         Ctrl->T.ts[i] = t1 + dt * i;
                     }
@@ -242,15 +242,9 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
 static void run_lamb2_with_derivative_outputs(const GRT_MODULE_CTRL *Ctrl)
 {
     const size_t nt = (size_t)Ctrl->T.nt;
-    real_t (*G)[3][3] = calloc(nt, sizeof(*G));
-    real_t (*dG_source)[3][3][3] = calloc(nt, sizeof(*dG_source));
-    real_t (*dG_receiver)[3][3][3] = calloc(nt, sizeof(*dG_receiver));
-    if (G == NULL || dG_source == NULL || dG_receiver == NULL) {
-        GRT_SAFE_FREE_PTR(G);
-        GRT_SAFE_FREE_PTR(dG_source);
-        GRT_SAFE_FREE_PTR(dG_receiver);
-        GRTRaiseError("Cannot allocate lamb2 output arrays.\n");
-    }
+    real_t (*G)[3][3] = GRT_SAFE_CALLOC(nt, sizeof(*G));
+    real_t (*dG_source)[3][3][3] = GRT_SAFE_CALLOC(nt, sizeof(*dG_source));
+    real_t (*dG_receiver)[3][3][3] = GRT_SAFE_CALLOC(nt, sizeof(*dG_receiver));
 
     FILE *source_file = NULL;
     FILE *receiver_file = NULL;
@@ -282,7 +276,7 @@ static void run_lamb2_with_derivative_outputs(const GRT_MODULE_CTRL *Ctrl)
 
 int lamb2_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
     getopt_from_command(Ctrl, argc, argv);
     if (Ctrl->S.active) {
         run_lamb2_with_derivative_outputs(Ctrl);

--- a/pygrt/C_extension/src/lamb/grt_lamb3.c
+++ b/pygrt/C_extension/src/lamb/grt_lamb3.c
@@ -148,7 +148,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
                         GRTBadOptionError(T, "t1(%f) > t2(%f).", t1, t2);
                     }
                     Ctrl->T.nt = (int)floor((t2 - t1) / dt) + 1;
-                    Ctrl->T.ts = calloc((size_t)Ctrl->T.nt, sizeof(*Ctrl->T.ts));
+                    Ctrl->T.ts = GRT_SAFE_CALLOC((size_t)Ctrl->T.nt, sizeof(*Ctrl->T.ts));
                     for(int i = 0; i < Ctrl->T.nt; ++i){
                         Ctrl->T.ts[i] = t1 + dt * i;
                     }
@@ -216,15 +216,9 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv)
 static void run_lamb3_with_derivative_outputs(const GRT_MODULE_CTRL *Ctrl)
 {
     const size_t nt = (size_t)Ctrl->T.nt;
-    real_t (*G)[3][3] = calloc(nt, sizeof(*G));
-    real_t (*dG_source)[3][3][3] = calloc(nt, sizeof(*dG_source));
-    real_t (*dG_receiver)[3][3][3] = calloc(nt, sizeof(*dG_receiver));
-    if (G == NULL || dG_source == NULL || dG_receiver == NULL) {
-        GRT_SAFE_FREE_PTR(G);
-        GRT_SAFE_FREE_PTR(dG_source);
-        GRT_SAFE_FREE_PTR(dG_receiver);
-        GRTRaiseError("Cannot allocate lamb3 output arrays.\n");
-    }
+    real_t (*G)[3][3] = GRT_SAFE_CALLOC(nt, sizeof(*G));
+    real_t (*dG_source)[3][3][3] = GRT_SAFE_CALLOC(nt, sizeof(*dG_source));
+    real_t (*dG_receiver)[3][3][3] = GRT_SAFE_CALLOC(nt, sizeof(*dG_receiver));
 
     FILE *source_file = NULL;
     FILE *receiver_file = NULL;
@@ -255,7 +249,7 @@ static void run_lamb3_with_derivative_outputs(const GRT_MODULE_CTRL *Ctrl)
 
 int lamb3_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
     getopt_from_command(Ctrl, argc, argv);
     if (Ctrl->S.active) {
         run_lamb3_with_derivative_outputs(Ctrl);

--- a/pygrt/C_extension/src/lamb/lamb2.c
+++ b/pygrt/C_extension/src/lamb/lamb2.c
@@ -598,8 +598,8 @@ void grt_solve_lamb2(
     bool need_P = tEnd >= V.k;
     bool need_S = tEnd >= 1.0 || (V.supercritical && ts[0] < 1.0 && tEnd >= V.t_sp);
     /* 大型多项式系数工作区放在堆上，避免占用线程栈 */
-    LAMB2_COEFF_SET *coefficients = calloc(1, sizeof(*coefficients));
-    LAMB2_PF_COEFFICIENTS *pf_coefficients = calloc(1, sizeof(*pf_coefficients));
+    LAMB2_COEFF_SET *coefficients = GRT_SAFE_CALLOC(1, sizeof(*coefficients));
+    LAMB2_PF_COEFFICIENTS *pf_coefficients = GRT_SAFE_CALLOC(1, sizeof(*pf_coefficients));
     if (need_P) {
         make_lamb2_P_coefficients(&V, coefficients);
         make_partial_fraction_set(coefficients, V.y, V.kp2, false, V.use_angle_ratio, V.angle_ratio, &pf_coefficients->P);
@@ -611,11 +611,11 @@ void grt_solve_lamb2(
     GRT_SAFE_FREE_PTR(coefficients);
 
     bool isprint = (G == NULL && dG_source == NULL && dG_receiver == NULL);
-    real_t(*F)[3][3] = G != NULL ? G : calloc((size_t)nt, sizeof(*F));
-    real_t(*Fk_source)[3][3][3] = calloc((size_t)nt, sizeof(*Fk_source));
-    real_t(*Fk_receiver)[3][3][3] = calloc((size_t)nt, sizeof(*Fk_receiver));
-    real_t(*dG_source_tmp)[3][3][3] = dG_source != NULL ? dG_source : calloc((size_t)nt, sizeof(*dG_source_tmp));
-    real_t(*dG_receiver_tmp)[3][3][3] = dG_receiver != NULL ? dG_receiver : calloc((size_t)nt, sizeof(*dG_receiver_tmp));
+    real_t(*F)[3][3] = G != NULL ? G : GRT_SAFE_CALLOC((size_t)nt, sizeof(*F));
+    real_t(*Fk_source)[3][3][3] = GRT_SAFE_CALLOC((size_t)nt, sizeof(*Fk_source));
+    real_t(*Fk_receiver)[3][3][3] = GRT_SAFE_CALLOC((size_t)nt, sizeof(*Fk_receiver));
+    real_t(*dG_source_tmp)[3][3][3] = dG_source != NULL ? dG_source : GRT_SAFE_CALLOC((size_t)nt, sizeof(*dG_source_tmp));
+    real_t(*dG_receiver_tmp)[3][3][3] = dG_receiver != NULL ? dG_receiver : GRT_SAFE_CALLOC((size_t)nt, sizeof(*dG_receiver_tmp));
 
     for (int i = 0; i < nt; ++i) {
         real_t tbar = shift_lamb2_boundary(ts[i], &V, tbar_eps);

--- a/pygrt/C_extension/src/lamb/lamb3.c
+++ b/pygrt/C_extension/src/lamb/lamb3.c
@@ -290,7 +290,7 @@ static void make_coefficients(const LAMB3_VARS *V, const bool need_P, const bool
                               LAMB3_PF_COEFFICIENTS *coefficients) {
     /* 原始和部分分式系数体积较大，统一放在堆上，并按到时跳过未用到的项 */
     if (need_P || need_S) {
-        LAMB3_COEFF_SET *reflection_raw = calloc(1, sizeof(*reflection_raw));
+        LAMB3_COEFF_SET *reflection_raw = GRT_SAFE_CALLOC(1, sizeof(*reflection_raw));
         if (need_P) {
             make_lamb3_P_coefficients(V, reflection_raw);
             make_reflection_pf_set(reflection_raw, V->rayleigh, V->kp2, &coefficients->P);
@@ -303,7 +303,7 @@ static void make_coefficients(const LAMB3_VARS *V, const bool need_P, const bool
     }
 
     if (need_PS || need_SP) {
-        LAMB3_CONVERSION_COEFF_SET *conversion_raw = calloc(1, sizeof(*conversion_raw));
+        LAMB3_CONVERSION_COEFF_SET *conversion_raw = GRT_SAFE_CALLOC(1, sizeof(*conversion_raw));
         /* 接收点竖向导数对应交换深度后的 PS/SP 项 */
         LAMB3_VARS reciprocal = *V;
         reciprocal.depsrc = V->deprcv;
@@ -1574,15 +1574,15 @@ void grt_solve_lamb3(
     const bool need_PS = tEnd >= V.tps;
     const bool need_SP = tEnd >= V.tsp;
     /* 大型部分分式系数工作区放在堆上，避免占用线程栈 */
-    LAMB3_PF_COEFFICIENTS *coefficients = calloc(1, sizeof(*coefficients));
+    LAMB3_PF_COEFFICIENTS *coefficients = GRT_SAFE_CALLOC(1, sizeof(*coefficients));
     make_coefficients(&V, need_P, need_S, need_PS, need_SP, coefficients);
 
     bool isprint = G == NULL && dG_source == NULL && dG_receiver == NULL;
-    real_t(*F)[3][3] = G != NULL ? G : calloc((size_t)nt, sizeof(*F));
-    real_t(*Fk_source)[3][3][3] = calloc((size_t)nt, sizeof(*Fk_source));
-    real_t(*Fk_receiver)[3][3][3] = calloc((size_t)nt, sizeof(*Fk_receiver));
-    real_t(*dG_source_tmp)[3][3][3] = dG_source != NULL ? dG_source : calloc((size_t)nt, sizeof(*dG_source_tmp));
-    real_t(*dG_receiver_tmp)[3][3][3] = dG_receiver != NULL ? dG_receiver : calloc((size_t)nt, sizeof(*dG_receiver_tmp));
+    real_t(*F)[3][3] = G != NULL ? G : GRT_SAFE_CALLOC((size_t)nt, sizeof(*F));
+    real_t(*Fk_source)[3][3][3] = GRT_SAFE_CALLOC((size_t)nt, sizeof(*Fk_source));
+    real_t(*Fk_receiver)[3][3][3] = GRT_SAFE_CALLOC((size_t)nt, sizeof(*Fk_receiver));
+    real_t(*dG_source_tmp)[3][3][3] = dG_source != NULL ? dG_source : GRT_SAFE_CALLOC((size_t)nt, sizeof(*dG_source_tmp));
+    real_t(*dG_receiver_tmp)[3][3][3] = dG_receiver != NULL ? dG_receiver : GRT_SAFE_CALLOC((size_t)nt, sizeof(*dG_receiver_tmp));
 
     for (int i = 0; i < nt; ++i) {
         LAMB3_F value;

--- a/pygrt/C_extension/src/lamb/lamb_util.c
+++ b/pygrt/C_extension/src/lamb/lamb_util.c
@@ -20,10 +20,7 @@ static bool is_derivative_suboption(const char *text)
 
 static char *copy_path(const char *start, const size_t length)
 {
-    char *path = calloc(length + 1, sizeof(*path));
-    if (path == NULL) {
-        GRTRaiseError("Cannot allocate a Lamb derivative output path.\n");
-    }
+    char *path = GRT_SAFE_CALLOC(length + 1, sizeof(*path));
     memcpy(path, start, length);
     return path;
 }

--- a/pygrt/C_extension/src/modal/eigenfn.c
+++ b/pygrt/C_extension/src/modal/eigenfn.c
@@ -233,8 +233,8 @@ void grt_get_mod_potential_Up_Down_Rayl(
     memcpy(&mod_potRaylLove_Up[iref][0], potRaylLoveUp, sizeof(cplx_t)*GRT_RAYL_DIM);
 
     // 计算 RD_RL, RU_FR 矩阵
-    RT_MATRIX *Mall_FR = (RT_MATRIX *)calloc(nlay, sizeof(RT_MATRIX));
-    RT_MATRIX *Mall_RL = (RT_MATRIX *)calloc(nlay, sizeof(RT_MATRIX));
+    RT_MATRIX *Mall_FR = GRT_SAFE_CALLOC(nlay, sizeof(RT_MATRIX));
+    RT_MATRIX *Mall_RL = GRT_SAFE_CALLOC(nlay, sizeof(RT_MATRIX));
     grt_GRT_matrix_allLayer_Rayl(mstat, creal(mstat->k), Mall_RL, Mall_FR);
 
     // 向下传播
@@ -270,8 +270,8 @@ void grt_get_mod_potential_Up_Down_Love(
     memcpy(&mod_potRaylLove_Down[iref][0], potRaylLove, sizeof(cplx_t)*GRT_LOVE_DIM);
 
     // 计算 RDL_RL, RUL_FR 矩阵
-    RT_MATRIX *Mall_FR = (RT_MATRIX *)calloc(nlay, sizeof(RT_MATRIX));
-    RT_MATRIX *Mall_RL = (RT_MATRIX *)calloc(nlay, sizeof(RT_MATRIX));
+    RT_MATRIX *Mall_FR = GRT_SAFE_CALLOC(nlay, sizeof(RT_MATRIX));
+    RT_MATRIX *Mall_RL = GRT_SAFE_CALLOC(nlay, sizeof(RT_MATRIX));
     grt_GRT_matrix_allLayer_Love(mstat, creal(mstat->k), Mall_RL, Mall_FR);
 
     // 向下传播

--- a/pygrt/C_extension/src/modal/grt_eigenfn.c
+++ b/pygrt/C_extension/src/modal/grt_eigenfn.c
@@ -199,7 +199,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                         }
                     }
                     Ctrl->N.nmode = floor((a2-a1)/dif) + 1;
-                    Ctrl->N.modes = (size_t *)calloc(Ctrl->N.nmode, sizeof(size_t));
+                    Ctrl->N.modes = GRT_SAFE_CALLOC(Ctrl->N.nmode, sizeof(size_t));
                     for(size_t i=0; i < Ctrl->N.nmode; ++i){
                         Ctrl->N.modes[i] = a1 + dif*i;
                     }
@@ -260,7 +260,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
                     if(nscan == 3 || nscan == 1){
                         Ctrl->F.nf = floor((a2-a1)/df) + 1;
-                        Ctrl->F.freqs = (real_t*)calloc(Ctrl->F.nf, sizeof(real_t));
+                        Ctrl->F.freqs = GRT_SAFE_CALLOC(Ctrl->F.nf, sizeof(real_t));
                         for(size_t i=0; i<Ctrl->F.nf; ++i){
                             if(isperiod){
                                 Ctrl->F.freqs[Ctrl->F.nf-1 - i] = 1.0/(a1 + df*i);
@@ -272,7 +272,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     else if(nscan == 2){
                         // 只约束最大值和最小值，内存申请由读取频散文件的过程中进行
                         Ctrl->F.nf = 2;
-                        Ctrl->F.freqs = (real_t*)calloc(Ctrl->F.nf, sizeof(real_t));
+                        Ctrl->F.freqs = GRT_SAFE_CALLOC(Ctrl->F.nf, sizeof(real_t));
                         Ctrl->F.freqs[0] = a1;
                         Ctrl->F.freqs[1] = a2;
                         Ctrl->F.def_range = true;
@@ -375,7 +375,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                                 }
 
                                 Ctrl->W.nz = floor((a2-a1)/dif) + 1;
-                                Ctrl->W.zs = (real_t*)calloc(Ctrl->W.nz, sizeof(real_t));
+                                Ctrl->W.zs = GRT_SAFE_CALLOC(Ctrl->W.nz, sizeof(real_t));
                                 for(size_t i=0; i<Ctrl->W.nz; ++i){
                                     Ctrl->W.zs[i] = a1 + dif*i;
                                 }
@@ -406,7 +406,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
     // -N 的默认项，仅处理基阶
     if( ! Ctrl->N.active ){
         Ctrl->N.nmode = 1;
-        Ctrl->N.modes = (size_t *)calloc(Ctrl->N.nmode, sizeof(size_t));
+        Ctrl->N.modes = GRT_SAFE_CALLOC(Ctrl->N.nmode, sizeof(size_t));
         Ctrl->N.modes[0] = 0;
     }
 
@@ -473,9 +473,9 @@ static void grt_eigenfn_egy_udisp_phaseK_util(
             size_t iref = eigv->c_roots_iref[ic];
 
             // 模型每个物理层介质下方 z_j+ 的垂直波函数
-            cplx_t (*mod_potRaylLove_Down)[ncols] = (cplx_t (*)[ncols])calloc(nlay, sizeof(cplx_t)*ncols);
+            cplx_t (*mod_potRaylLove_Down)[ncols] = GRT_SAFE_CALLOC(nlay, sizeof(cplx_t)*ncols);
             // 模型每个物理层介质上方 z_j- 的垂直波函数，申请 n+1 的内存，方便后续不必讨论“半空间中的上行波场”
-            cplx_t (*mod_potRaylLove_Up)[ncols] = (cplx_t (*)[ncols])calloc(nlay + 1, sizeof(cplx_t)*ncols);
+            cplx_t (*mod_potRaylLove_Up)[ncols] = GRT_SAFE_CALLOC(nlay + 1, sizeof(cplx_t)*ncols);
 
             cplx_t potRaylLove[ncols];  memset(potRaylLove, 0, sizeof(cplx_t)*ncols);
             cplx_t potRaylLoveUp[ncols];  memset(potRaylLoveUp, 0, sizeof(cplx_t)*ncols);
@@ -514,7 +514,7 @@ static void grt_eigenfn_egy_udisp_phaseK_util(
 
 /* 子模块主函数 */
 int eigenfn_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     // 传入参数 
     getopt_from_command(Ctrl, argc, argv);
@@ -522,21 +522,21 @@ int eigenfn_main(int argc, char **argv){
     // 读取频散及其中保存的模型
     char *modelname = NULL;
     MODEL1D *mod1d = NULL;
-    EIGENV_INFO *eigmet = (EIGENV_INFO *)calloc(1, sizeof(EIGENV_INFO));
+    EIGENV_INFO *eigmet = GRT_SAFE_CALLOC(1, sizeof(EIGENV_INFO));
     grt_read_dispersion(Ctrl->C.s_filepath, eigmet, &modelname, &mod1d);
     GRT_SAFE_FREE_PTR(modelname);
 
     // 根据命令行参数确定出所需的部分频散信息
-    EIGENFN_INFO *eigfnmet = (EIGENFN_INFO *)calloc(1, sizeof(EIGENFN_INFO));
+    EIGENFN_INFO *eigfnmet = GRT_SAFE_CALLOC(1, sizeof(EIGENFN_INFO));
     grt_filter_eigenfn_info(
         Ctrl->F.nf, Ctrl->F.freqs, Ctrl->F.def_range,
         Ctrl->N.nmode, Ctrl->N.modes, eigmet, eigfnmet);
     
     // 初始化 eigfn
-    eigfnmet->eigfn = (EIGENFN **)calloc(eigfnmet->nf, sizeof(EIGENFN *));
+    eigfnmet->eigfn = GRT_SAFE_CALLOC(eigfnmet->nf, sizeof(EIGENFN *));
     for(size_t iw = 0; iw < eigfnmet->nf; ++iw){
         size_t cnum = eigfnmet->eigv[iw].n;
-        eigfnmet->eigfn[iw] = (EIGENFN *)calloc(cnum, sizeof(EIGENFN));
+        eigfnmet->eigfn[iw] = GRT_SAFE_CALLOC(cnum, sizeof(EIGENFN));
     }
 
     // 判断每个深度值对应的层位
@@ -544,13 +544,13 @@ int eigenfn_main(int argc, char **argv){
         // 若不指定等距深度，则使用模型界面深度
         if(Ctrl->W.nz == 0){
             Ctrl->W.nz = mod1d->n;
-            Ctrl->W.zs = (real_t *)calloc(Ctrl->W.nz, sizeof(real_t));
+            Ctrl->W.zs = GRT_SAFE_CALLOC(Ctrl->W.nz, sizeof(real_t));
             memcpy(Ctrl->W.zs, mod1d->Dep, sizeof(real_t)*mod1d->n);
         }
         eigfnmet->nz = Ctrl->W.nz;
-        eigfnmet->zs = (real_t *)calloc(eigfnmet->nz, sizeof(real_t));
+        eigfnmet->zs = GRT_SAFE_CALLOC(eigfnmet->nz, sizeof(real_t));
         memcpy(eigfnmet->zs, Ctrl->W.zs, sizeof(real_t)*eigfnmet->nz);
-        eigfnmet->z_irefs = (size_t *)calloc(eigfnmet->nz, sizeof(size_t));
+        eigfnmet->z_irefs = GRT_SAFE_CALLOC(eigfnmet->nz, sizeof(size_t));
         for(size_t iz = 0; iz < Ctrl->W.nz; ++iz){
             size_t ziref = 0;
             for(ziref=0; ziref < mod1d->n-1; ++ziref){
@@ -576,9 +576,9 @@ int eigenfn_main(int argc, char **argv){
                 // 避免一些因浮点误差而产生的极细层
                 if(fabs(thk - h) < dz*1e-5)  break;
 
-                eigfnmet->cpar_z_irefs = (size_t *)realloc(eigfnmet->cpar_z_irefs, sizeof(size_t)*(eigfnmet->cpar_nz+1));
+                eigfnmet->cpar_z_irefs = GRT_SAFE_REALLOC(eigfnmet->cpar_z_irefs, sizeof(size_t)*(eigfnmet->cpar_nz+1));
                 eigfnmet->cpar_z_irefs[eigfnmet->cpar_nz] = iy;
-                eigfnmet->cpar_zs = (real_t *)realloc(eigfnmet->cpar_zs, sizeof(real_t)*(eigfnmet->cpar_nz+1));
+                eigfnmet->cpar_zs = GRT_SAFE_REALLOC(eigfnmet->cpar_zs, sizeof(real_t)*(eigfnmet->cpar_nz+1));
                 eigfnmet->cpar_zs[eigfnmet->cpar_nz] = mod1d->Dep[iy] + h;
 
                 h += dz;
@@ -598,12 +598,12 @@ int eigenfn_main(int argc, char **argv){
 
             eigfntmp->eigenC = eigfnmet->eigv[iw].c_roots[ic];
             if(Ctrl->W.active){
-                eigfntmp->fn = (cplx_t (*)[4])calloc(eigfnmet->nz, sizeof(*eigfntmp->fn));
+                eigfntmp->fn = GRT_SAFE_CALLOC(eigfnmet->nz, sizeof(*eigfntmp->fn));
             }
             
             if(Ctrl->calc_egyint){
-                eigfntmp->csens = (cplx_t (*)[GRT_SNSTVTY_MAX])calloc(eigfnmet->cpar_nz, sizeof(*eigfntmp->csens));
-                eigfntmp->usens = (cplx_t (*)[GRT_SNSTVTY_MAX])calloc(eigfnmet->cpar_nz, sizeof(*eigfntmp->usens));
+                eigfntmp->csens = GRT_SAFE_CALLOC(eigfnmet->cpar_nz, sizeof(*eigfntmp->csens));
+                eigfntmp->usens = GRT_SAFE_CALLOC(eigfnmet->cpar_nz, sizeof(*eigfntmp->usens));
             }
         }
     }

--- a/pygrt/C_extension/src/modal/grt_eigenv.c
+++ b/pygrt/C_extension/src/modal/grt_eigenv.c
@@ -290,7 +290,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
 
                     Ctrl->F.nf = floor((a2-a1)/df) + 1;
-                    Ctrl->F.freqs = (real_t*)calloc(Ctrl->F.nf, sizeof(real_t));
+                    Ctrl->F.freqs = GRT_SAFE_CALLOC(Ctrl->F.nf, sizeof(real_t));
                     for(size_t i = 0; i < Ctrl->F.nf; ++i){
                         if(isperiod){
                             Ctrl->F.freqs[Ctrl->F.nf-1 - i] = 1.0/(a1 + df*i);
@@ -355,7 +355,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     if(Ctrl->F.freqs != NULL)  free(Ctrl->F.freqs);
                     // 仅申请单一频率，用于输出久期函数值
                     Ctrl->F.nf = 1;
-                    Ctrl->F.freqs = (real_t*)calloc(Ctrl->F.nf, sizeof(real_t));
+                    Ctrl->F.freqs = GRT_SAFE_CALLOC(Ctrl->F.nf, sizeof(real_t));
                     Ctrl->F.freqs[0] = fx;
 
                     GRT_SAFE_FREE_PTR(string);
@@ -461,7 +461,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
 /** 子模块主函数 */
 int eigenv_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     // 传入参数 
     getopt_from_command(Ctrl, argc, argv);
@@ -476,9 +476,9 @@ int eigenv_main(int argc, char **argv){
     }
 
     // 将信息转入结构体
-    EIGENV_INFO *eigmet = (EIGENV_INFO *)calloc(1, sizeof(EIGENV_INFO));
+    EIGENV_INFO *eigmet = GRT_SAFE_CALLOC(1, sizeof(EIGENV_INFO));
     eigmet->nf = Ctrl->F.nf;
-    eigmet->freqs = (real_t *)calloc(eigmet->nf, sizeof(real_t));
+    eigmet->freqs = GRT_SAFE_CALLOC(eigmet->nf, sizeof(real_t));
     memcpy(eigmet->freqs, Ctrl->F.freqs, sizeof(real_t)*eigmet->nf);
     eigmet->nmode = Ctrl->N.nmode;
     eigmet->wtype = Ctrl->S.wtype;
@@ -489,7 +489,7 @@ int eigenv_main(int argc, char **argv){
     eigmet->rtol = Ctrl->T.rtol;
     eigmet->vgap = Ctrl->T.vgap;
     // 存储频散值的结构体
-    eigmet->eigv = (EIGENV *)calloc(eigmet->nf, sizeof(EIGENV));
+    eigmet->eigv = GRT_SAFE_CALLOC(eigmet->nf, sizeof(EIGENV));
 
     // 相速度搜索范围
     if(Ctrl->X.manual_crange)

--- a/pygrt/C_extension/src/modal/grt_modsum.c
+++ b/pygrt/C_extension/src/modal/grt_modsum.c
@@ -276,7 +276,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                         }
                     }
                     Ctrl->N.nmode = floor((a2-a1)/dif) + 1;
-                    Ctrl->N.modes = (size_t *)calloc(Ctrl->N.nmode, sizeof(size_t));
+                    Ctrl->N.modes = GRT_SAFE_CALLOC(Ctrl->N.nmode, sizeof(size_t));
                     for(size_t i=0; i < Ctrl->N.nmode; ++i){
                         Ctrl->N.modes[i] = a1 + dif*i;
                     }
@@ -286,7 +286,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
             // 频率值 -Ff1/f2  指定频率范围
             case 'F':
                 Ctrl->F.active = true;
-                Ctrl->F.freqs = (real_t *)calloc(2, sizeof(real_t));
+                Ctrl->F.freqs = GRT_SAFE_CALLOC(2, sizeof(real_t));
                 if(2 != sscanf(optarg, "%lf/%lf", Ctrl->F.freqs, Ctrl->F.freqs+1)){
                     GRTBadOptionError(F, "");
                 };
@@ -321,8 +321,8 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
                     Ctrl->D.ndepsrc = 1;
                     Ctrl->D.ndeprcv = 1;
-                    Ctrl->D.depsrcs = (real_t *)calloc(1, sizeof(real_t));
-                    Ctrl->D.deprcvs = (real_t *)calloc(1, sizeof(real_t));
+                    Ctrl->D.depsrcs = GRT_SAFE_CALLOC(1, sizeof(real_t));
+                    Ctrl->D.deprcvs = GRT_SAFE_CALLOC(1, sizeof(real_t));
                     Ctrl->D.depsrcs[0] = depsrc;
                     Ctrl->D.deprcvs[0] = deprcv;
                 }
@@ -446,7 +446,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
     // -N 的默认项，仅处理基阶
     if( ! Ctrl->N.active ){
         Ctrl->N.nmode = 1;
-        Ctrl->N.modes = (size_t *)calloc(Ctrl->N.nmode, sizeof(size_t));
+        Ctrl->N.modes = GRT_SAFE_CALLOC(Ctrl->N.nmode, sizeof(size_t));
         Ctrl->N.modes[0] = 0;
     }
     
@@ -475,7 +475,7 @@ static void compute_modsum_one(
     }
 
     // 根据命令行参数确定出所需的部分频散信息
-    EIGENFN_INFO *eigfnmet = (EIGENFN_INFO *)calloc(1, sizeof(EIGENFN_INFO));
+    EIGENFN_INFO *eigfnmet = GRT_SAFE_CALLOC(1, sizeof(EIGENFN_INFO));
     grt_filter_eigenfn_info(
         Ctrl->F.nf, Ctrl->F.freqs, true,
         Ctrl->N.nmode, Ctrl->N.modes, eigmet, eigfnmet);
@@ -493,10 +493,10 @@ static void compute_modsum_one(
     }
 
     // 初始化 eigfn
-    eigfnmet->eigfn = (EIGENFN **)calloc(eigfnmet->nf, sizeof(EIGENFN *));
+    eigfnmet->eigfn = GRT_SAFE_CALLOC(eigfnmet->nf, sizeof(EIGENFN *));
     for(size_t iw = 0; iw < eigfnmet->nf; ++iw){
         size_t cnum = eigfnmet->eigv[iw].n;
-        eigfnmet->eigfn[iw] = (EIGENFN *)calloc(cnum, sizeof(EIGENFN));
+        eigfnmet->eigfn[iw] = GRT_SAFE_CALLOC(cnum, sizeof(EIGENFN));
     }
 
     // FFT需要的参数，包括零频和区域外的（从原频散文件确定，因此本模块中 -F 的作用仅用于筛选频段）
@@ -509,7 +509,7 @@ static void compute_modsum_one(
     GRNSPEC *grn = &(GRNSPEC){0};
     {
         grn->nf = fft_nf;
-        grn->freqs = (real_t *)calloc(fft_nf, sizeof(real_t));   // 单独增加 0 频
+        grn->freqs = GRT_SAFE_CALLOC(fft_nf, sizeof(real_t));   // 单独增加 0 频
         memcpy(grn->freqs+1, eigmet->freqs, sizeof(real_t)*eigmet->nf);
         grn->nf1 = 0;
         grn->nf2 = fft_nf-1;
@@ -554,9 +554,9 @@ static void compute_modsum_one(
     sac->hd.user8 = mod1d->Rho[mod1d->isrc];
     
     // 为每个震中距设置对应的变量
-    real_t (*travtPS)[2] = (real_t (*)[2])calloc(grn->nr, sizeof(real_t)*2);
-    real_t *begintimes = (real_t *)calloc(grn->nr, sizeof(real_t));
-    char **outputdirs = (char **)calloc(grn->nr, sizeof(char *));
+    real_t (*travtPS)[2] = GRT_SAFE_CALLOC(grn->nr, sizeof(real_t)*2);
+    real_t *begintimes = GRT_SAFE_CALLOC(grn->nr, sizeof(real_t));
+    char **outputdirs = GRT_SAFE_CALLOC(grn->nr, sizeof(char *));
     for(size_t ir = 0; ir < Ctrl->R.nr; ++ir){
         real_t dist = Ctrl->R.rs[ir];
 
@@ -612,7 +612,7 @@ static void compute_modsum_one(
 
 /* 子模块主函数 */
 int modsum_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     // 传入参数
     getopt_from_command(Ctrl, argc, argv);
@@ -620,7 +620,7 @@ int modsum_main(int argc, char **argv){
     // 读取频散及其中保存的模型
     char *modelname = NULL;
     MODEL1D *mod1d = NULL;
-    EIGENV_INFO *eigmet = (EIGENV_INFO *)calloc(1, sizeof(EIGENV_INFO));
+    EIGENV_INFO *eigmet = GRT_SAFE_CALLOC(1, sizeof(EIGENV_INFO));
     grt_read_dispersion(Ctrl->C.s_filepath, eigmet, &modelname, &mod1d);
 
     // 建立保存目录并检查已有内容

--- a/pygrt/C_extension/src/modal/modal_def.c
+++ b/pygrt/C_extension/src/modal/modal_def.c
@@ -66,17 +66,17 @@ void grt_filter_eigenfn_info(
 {
     // 先申请全部内存，然后再缩
     eigfnmet->nf = 0;
-    eigfnmet->freqs = (real_t *)calloc(eigmet->nf, sizeof(real_t));
+    eigfnmet->freqs = GRT_SAFE_CALLOC(eigmet->nf, sizeof(real_t));
     eigfnmet->nmode = 0;
-    eigfnmet->modes = (size_t *)calloc(eigmet->nmode, sizeof(size_t));
-    eigfnmet->eigv = (EIGENV *)calloc(eigmet->nf, sizeof(EIGENV));
+    eigfnmet->modes = GRT_SAFE_CALLOC(eigmet->nmode, sizeof(size_t));
+    eigfnmet->eigv = GRT_SAFE_CALLOC(eigmet->nf, sizeof(EIGENV));
     eigfnmet->wtype = eigmet->wtype;
 
     const real_t *in_freqs = eigmet->freqs;
 
     // 筛选阶次
     // 保存特定阶次在原数组中的索引位置
-    size_t *idxs_modes = (size_t *)calloc(eigmet->nmode, sizeof(size_t));
+    size_t *idxs_modes = GRT_SAFE_CALLOC(eigmet->nmode, sizeof(size_t));
     for(size_t i = 0; i < eigmet->nmode; ++i){
         bool match = false;
         if(modes == NULL){
@@ -93,8 +93,8 @@ void grt_filter_eigenfn_info(
         }
 
     }
-    eigfnmet->modes = (size_t *)realloc(eigfnmet->modes, sizeof(size_t)*eigfnmet->nmode);
-    idxs_modes = (size_t *)realloc(idxs_modes, sizeof(size_t)*eigfnmet->nmode);
+    eigfnmet->modes = GRT_SAFE_REALLOC(eigfnmet->modes, sizeof(size_t)*eigfnmet->nmode);
+    idxs_modes = GRT_SAFE_REALLOC(idxs_modes, sizeof(size_t)*eigfnmet->nmode);
 
     // 筛选频率
     for(size_t iw = 0; iw < eigmet->nf; ++iw){
@@ -117,9 +117,9 @@ void grt_filter_eigenfn_info(
 
         // 写入频散
         EIGENV *eigvtmp = &eigfnmet->eigv[eigfnmet->nf];
-        eigvtmp->c_roots = (real_t *)calloc(eigmet->nmode, sizeof(real_t));
-        eigvtmp->u_roots  = (real_t *)calloc(eigmet->nmode, sizeof(real_t));
-        eigvtmp->c_roots_iref = (size_t *)calloc(eigmet->nmode, sizeof(size_t));
+        eigvtmp->c_roots = GRT_SAFE_CALLOC(eigmet->nmode, sizeof(real_t));
+        eigvtmp->u_roots  = GRT_SAFE_CALLOC(eigmet->nmode, sizeof(real_t));
+        eigvtmp->c_roots_iref = GRT_SAFE_CALLOC(eigmet->nmode, sizeof(size_t));
         eigvtmp->n = 0;
 
         EIGENV *in_eigv = &eigmet->eigv[iw];
@@ -135,13 +135,13 @@ void grt_filter_eigenfn_info(
 
             eigvtmp->n++;
         }
-        eigvtmp->c_roots = (real_t *)realloc(eigvtmp->c_roots, sizeof(real_t)*eigvtmp->n);
-        eigvtmp->u_roots  = (real_t *)realloc(eigvtmp->u_roots, sizeof(real_t)*eigvtmp->n);
-        eigvtmp->c_roots_iref = (size_t *)realloc(eigvtmp->c_roots_iref, sizeof(size_t)*eigvtmp->n);
+        eigvtmp->c_roots = GRT_SAFE_REALLOC(eigvtmp->c_roots, sizeof(real_t)*eigvtmp->n);
+        eigvtmp->u_roots  = GRT_SAFE_REALLOC(eigvtmp->u_roots, sizeof(real_t)*eigvtmp->n);
+        eigvtmp->c_roots_iref = GRT_SAFE_REALLOC(eigvtmp->c_roots_iref, sizeof(size_t)*eigvtmp->n);
 
         eigfnmet->nf++;
     }
-    eigfnmet->freqs = (real_t *)realloc(eigfnmet->freqs, sizeof(real_t)*eigfnmet->nf);
+    eigfnmet->freqs = GRT_SAFE_REALLOC(eigfnmet->freqs, sizeof(real_t)*eigfnmet->nf);
 
     GRT_SAFE_FREE_PTR(idxs_modes);
 }

--- a/pygrt/C_extension/src/modal/modal_util.c
+++ b/pygrt/C_extension/src/modal/modal_util.c
@@ -73,11 +73,11 @@ static void nc_put_freq_freqmode(
 {
     NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, f_varid, freqs));
 
-    int *cnum = (int *)calloc(nf, sizeof(int));
-    int *mode_vals = (int *)calloc(nmode, sizeof(int));
-    real_t *c_flat = (real_t *)calloc(nfm, sizeof(real_t));
-    real_t *u_flat = (u_varid >= 0) ? (real_t *)calloc(nfm, sizeof(real_t)) : NULL;
-    int *ciref_flat = (ciref_varid >= 0) ? (int *)calloc(nfm, sizeof(int)) : NULL;
+    int *cnum = GRT_SAFE_CALLOC(nf, sizeof(int));
+    int *mode_vals = GRT_SAFE_CALLOC(nmode, sizeof(int));
+    real_t *c_flat = GRT_SAFE_CALLOC(nfm, sizeof(real_t));
+    real_t *u_flat = (u_varid >= 0) ? GRT_SAFE_CALLOC(nfm, sizeof(real_t)) : NULL;
+    int *ciref_flat = (ciref_varid >= 0) ? GRT_SAFE_CALLOC(nfm, sizeof(int)) : NULL;
 
     for(size_t i = 0; i < nmode; ++i){
         mode_vals[i] = (modes != NULL) ? (int)modes[i] : (int)i;
@@ -287,7 +287,7 @@ void grt_output_eigenfns(const char *filepath, const int ncols, EIGENFN_INFO *ei
     countp[1] = eigfnmet->nz;
     countp[2] = nw;
 
-    real_t (*realimag_part)[nw] = (real_t (*)[nw])calloc(eigfnmet->nz, sizeof(real_t)*nw);
+    real_t (*realimag_part)[nw] = GRT_SAFE_CALLOC(eigfnmet->nz, sizeof(real_t)*nw);
 
     size_t k = 0;
     for(size_t iw = 0; iw < eigfnmet->nf; ++iw){
@@ -359,7 +359,7 @@ void grt_output_energy_integrals(const char *filepath, EIGENFN_INFO *eigfnmet)
     startp[1] = 0;
     countp[1] = ne;
 
-    real_t (*realimag_part)[ne] = (real_t (*)[ne])calloc(nmode, sizeof(real_t)*ne);
+    real_t (*realimag_part)[ne] = GRT_SAFE_CALLOC(nmode, sizeof(real_t)*ne);
 
     size_t k = 0;
     for(size_t iw = 0; iw < eigfnmet->nf; ++iw){
@@ -457,7 +457,7 @@ void grt_output_sensitivity(const char *filepath, const char *char_uc, EIGENFN_I
     countp[1] = eigfnmet->cpar_nz;
     countp[2] = nk;
 
-    real_t (*real_part)[nk] = (real_t (*)[nk])calloc(eigfnmet->cpar_nz, sizeof(real_t)*nk);
+    real_t (*real_part)[nk] = GRT_SAFE_CALLOC(eigfnmet->cpar_nz, sizeof(real_t)*nk);
 
     size_t ifm = 0;
     for(size_t iw = 0; iw < eigfnmet->nf; ++iw){
@@ -539,13 +539,13 @@ void grt_read_dispersion(
                 filepath, nlayer, nparam, GRT_MODARR_NCOL);
         }
         NC_CHECK(nc_inq_varid(ncid, "model", &model_varid));
-        real_t (*modarr)[GRT_MODARR_NCOL] = (real_t (*)[GRT_MODARR_NCOL])malloc(
+        real_t (*modarr)[GRT_MODARR_NCOL] = GRT_SAFE_MALLOC(
             sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
         NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, model_varid, (real_t *)modarr));
 
         size_t m_len = 0;
         NC_CHECK(nc_inq_attlen(ncid, NC_GLOBAL, "modelname", &m_len));
-        char *modelname = (char *)calloc(m_len+1, sizeof(char));
+        char *modelname = GRT_SAFE_CALLOC(m_len+1, sizeof(char));
         NC_CHECK(nc_get_att_text(ncid, NC_GLOBAL, "modelname", modelname));
         modelname[m_len] = '\0';
 
@@ -585,11 +585,11 @@ void grt_read_dispersion(
         GRTRaiseError("Invalid dispersion nc \"%s\": empty mode dimension.", filepath);
     }
 
-    eigmet->freqs = (real_t *)calloc(eigmet->nf, sizeof(real_t));
+    eigmet->freqs = GRT_SAFE_CALLOC(eigmet->nf, sizeof(real_t));
     NC_CHECK(nc_inq_varid(ncid, "freq", &f_varid));
     NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, f_varid, eigmet->freqs));
 
-    int *cnum = (int *)calloc(eigmet->nf, sizeof(int));
+    int *cnum = GRT_SAFE_CALLOC(eigmet->nf, sizeof(int));
     NC_CHECK(nc_inq_varid(ncid, "cnum", &cnum_varid));
     NC_CHECK(NC_FUNC_INT(nc_get_var)(ncid, cnum_varid, cnum));
 
@@ -613,10 +613,10 @@ void grt_read_dispersion(
             filepath, cnum_max, nmode);
     }
 
-    int *mode_vals = (int *)calloc(nmode, sizeof(int));
-    real_t *c_flat = (real_t *)calloc(nfm, sizeof(real_t));
-    real_t *u_flat = isGroup ? (real_t *)calloc(nfm, sizeof(real_t)) : NULL;
-    int *ciref_flat = (!isGroup) ? (int *)calloc(nfm, sizeof(int)) : NULL;
+    int *mode_vals = GRT_SAFE_CALLOC(nmode, sizeof(int));
+    real_t *c_flat = GRT_SAFE_CALLOC(nfm, sizeof(real_t));
+    real_t *u_flat = isGroup ? GRT_SAFE_CALLOC(nfm, sizeof(real_t)) : NULL;
+    int *ciref_flat = (!isGroup) ? GRT_SAFE_CALLOC(nfm, sizeof(int)) : NULL;
 
     NC_CHECK(nc_inq_varid(ncid, "mode", &mode_varid));
     NC_CHECK(NC_FUNC_INT(nc_get_var)(ncid, mode_varid, mode_vals));
@@ -630,15 +630,15 @@ void grt_read_dispersion(
         NC_CHECK(NC_FUNC_INT(nc_get_var)(ncid, ciref_varid, ciref_flat));
     }
 
-    eigmet->eigv = (EIGENV *)calloc(eigmet->nf, sizeof(EIGENV));
+    eigmet->eigv = GRT_SAFE_CALLOC(eigmet->nf, sizeof(EIGENV));
 
     // 按频率还原锯齿状频散；第 iw 频的阶为 mode[0 .. cnum[iw]-1]
     size_t k = 0;
     for(size_t iw = 0; iw < eigmet->nf; ++iw){
         eigmet->eigv[iw].n = (size_t)cnum[iw];
-        eigmet->eigv[iw].c_roots = (real_t *)calloc(cnum[iw], sizeof(real_t));
-        eigmet->eigv[iw].u_roots = (real_t *)calloc(cnum[iw], sizeof(real_t));
-        eigmet->eigv[iw].c_roots_iref = (size_t *)calloc(cnum[iw], sizeof(size_t));
+        eigmet->eigv[iw].c_roots = GRT_SAFE_CALLOC(cnum[iw], sizeof(real_t));
+        eigmet->eigv[iw].u_roots = GRT_SAFE_CALLOC(cnum[iw], sizeof(real_t));
+        eigmet->eigv[iw].c_roots_iref = GRT_SAFE_CALLOC(cnum[iw], sizeof(size_t));
 
         for(int ic = 0; ic < cnum[iw]; ++ic){
             eigmet->eigv[iw].c_roots[ic] = c_flat[k];
@@ -652,7 +652,7 @@ void grt_read_dispersion(
     }
 
     eigmet->nmode = nmode;
-    eigmet->modes = (size_t *)calloc(nmode, sizeof(size_t));
+    eigmet->modes = GRT_SAFE_CALLOC(nmode, sizeof(size_t));
     for(size_t i = 0; i < nmode; ++i){
         eigmet->modes[i] = (size_t)mode_vals[i];
     }

--- a/pygrt/C_extension/src/modal/modgrn.c
+++ b/pygrt/C_extension/src/modal/modgrn.c
@@ -274,9 +274,9 @@ void grt_modsum_grn_spec(MODEL1D *mod1d, const DISPER_TYPE wtype, EIGENFN_INFO *
             size_t iref = eigv->c_roots_iref[ic];
 
             // 模型每个物理层介质下方 z_j+ 的垂直波函数
-            cplx_t (*mod_potRaylLove_Down)[ncols] = (cplx_t (*)[ncols])calloc(nlay, sizeof(cplx_t)*ncols);
+            cplx_t (*mod_potRaylLove_Down)[ncols] = GRT_SAFE_CALLOC(nlay, sizeof(cplx_t)*ncols);
             // 模型每个物理层介质上方 z_j- 的垂直波函数，申请 n+1 的内存，方便后续不必讨论“半空间中的上行波场”
-            cplx_t (*mod_potRaylLove_Up)[ncols] = (cplx_t (*)[ncols])calloc(nlay + 1, sizeof(cplx_t)*ncols);
+            cplx_t (*mod_potRaylLove_Up)[ncols] = GRT_SAFE_CALLOC(nlay + 1, sizeof(cplx_t)*ncols);
 
             cplx_t potRaylLove[ncols];  memset(potRaylLove, 0, sizeof(cplx_t)*ncols);
             cplx_t potRaylLoveUp[ncols];  memset(potRaylLoveUp, 0, sizeof(cplx_t)*ncols);

--- a/pygrt/C_extension/src/modal/root.c
+++ b/pygrt/C_extension/src/modal/root.c
@@ -140,7 +140,7 @@ typedef struct {
 
 /** 初始化区间栈 */
 static void stack_init(IntervalStack *stack, int init_capacity) {
-    stack->data = (Interval*)malloc(init_capacity * sizeof(Interval));
+    stack->data = GRT_SAFE_MALLOC(init_capacity * sizeof(Interval));
     stack->size = 0;
     stack->capacity = init_capacity;
 }
@@ -150,7 +150,7 @@ static void stack_push(IntervalStack *stack, Interval item) {
     // 扩容
     if(stack->size >= stack->capacity){
         stack->capacity *= 2;
-        stack->data = (Interval*)realloc(stack->data, stack->capacity * sizeof(Interval));
+        stack->data = GRT_SAFE_REALLOC(stack->data, stack->capacity * sizeof(Interval));
     }
     stack->data[stack->size++] = item;
 }
@@ -398,8 +398,8 @@ static void grt_adaptive_step_secular_roots(
                 if(root_c > 0.0 && !grt_check_vel_in_mod(mstat->mod1d, root_c, eigmet->vgap)){
                     if(eigv->c_roots == NULL){
                         // 需初始化动态内存
-                        eigv->c_roots = (real_t *)realloc(eigv->c_roots, sizeof(real_t)*1);
-                        eigv->c_roots_iref = (size_t *)realloc(eigv->c_roots_iref, sizeof(size_t)*1);
+                        eigv->c_roots = GRT_SAFE_REALLOC(eigv->c_roots, sizeof(real_t)*1);
+                        eigv->c_roots_iref = GRT_SAFE_REALLOC(eigv->c_roots_iref, sizeof(size_t)*1);
                         eigv->c_roots[0] = root_c;
                         eigv->c_roots_iref[0] = iref;
                         eigv->n = 1;
@@ -412,8 +412,8 @@ static void grt_adaptive_step_secular_roots(
                             if(capacity <= 0){
                                 capacity = eigv->n+1;
                             }
-                            eigv->c_roots = (real_t *)realloc(eigv->c_roots, sizeof(real_t)*capacity);
-                            eigv->c_roots_iref = (size_t *)realloc(eigv->c_roots_iref, sizeof(size_t)*capacity);
+                            eigv->c_roots = GRT_SAFE_REALLOC(eigv->c_roots, sizeof(real_t)*capacity);
+                            eigv->c_roots_iref = GRT_SAFE_REALLOC(eigv->c_roots_iref, sizeof(size_t)*capacity);
 
                             ssize_t pos = grt_insertOrdered(eigv->c_roots, &eigv->n, capacity, &root_c, sizeof(real_t), true, grt_compare_real_t);
 
@@ -489,8 +489,8 @@ static void grt_fixed_step_secular_roots(
         if(root_c > 0.0 && !grt_check_vel_in_mod(mstat->mod1d, root_c, eigmet->vgap)){
             if(eigv->c_roots == NULL){
                 // 需初始化动态内存
-                eigv->c_roots = (real_t *)realloc(eigv->c_roots, sizeof(real_t)*1);
-                eigv->c_roots_iref = (size_t *)realloc(eigv->c_roots_iref, sizeof(size_t)*1);
+                eigv->c_roots = GRT_SAFE_REALLOC(eigv->c_roots, sizeof(real_t)*1);
+                eigv->c_roots_iref = GRT_SAFE_REALLOC(eigv->c_roots_iref, sizeof(size_t)*1);
                 eigv->c_roots[0] = root_c;
                 eigv->c_roots_iref[0] = iref;
                 eigv->n = 1;
@@ -503,8 +503,8 @@ static void grt_fixed_step_secular_roots(
                     if(capacity <= 0){
                         capacity = eigv->n+1;
                     }
-                    eigv->c_roots = (real_t *)realloc(eigv->c_roots, sizeof(real_t)*capacity);
-                    eigv->c_roots_iref = (size_t *)realloc(eigv->c_roots_iref, sizeof(size_t)*capacity);
+                    eigv->c_roots = GRT_SAFE_REALLOC(eigv->c_roots, sizeof(real_t)*capacity);
+                    eigv->c_roots_iref = GRT_SAFE_REALLOC(eigv->c_roots_iref, sizeof(size_t)*capacity);
 
                     ssize_t pos = grt_insertOrdered(eigv->c_roots, &eigv->n, capacity, &root_c, sizeof(real_t), true, grt_compare_real_t);
 
@@ -668,7 +668,7 @@ static void get_secular_roots_single_freq(MODEL1D_STATE *mstat, EIGENV_INFO *eig
     rn1 = grt_get_approx_nroots(mstat, freq, wtype, cmin);
     c2 = cmax;
     while(c1 < cmax){
-        cpred = (real_t *)realloc(cpred, sizeof(real_t)*(npred+1));
+        cpred = GRT_SAFE_REALLOC(cpred, sizeof(real_t)*(npred+1));
         cpred[npred++] = c1;
         c2 = GRT_MIN(c1 + dc, cmax);
         rn2 = grt_get_approx_nroots(mstat, freq, wtype, c2);
@@ -678,7 +678,7 @@ static void get_secular_roots_single_freq(MODEL1D_STATE *mstat, EIGENV_INFO *eig
         }
         c1 = c2; rn1 = rn2;
     }
-    cpred = (real_t *)realloc(cpred, sizeof(real_t)*(npred+1));
+    cpred = GRT_SAFE_REALLOC(cpred, sizeof(real_t)*(npred+1));
     cpred[npred++] = c2;
 
     if(! eigmet->manual_crange){
@@ -692,7 +692,7 @@ static void get_secular_roots_single_freq(MODEL1D_STATE *mstat, EIGENV_INFO *eig
             }
             if(iy < mstat->mod1d->n){
                 real_t target = grt_halfspace_Rayleigh_croot(mstat, iy);
-                cpred = (real_t *)realloc(cpred, sizeof(real_t)*(npred+2));
+                cpred = GRT_SAFE_REALLOC(cpred, sizeof(real_t)*(npred+2));
                 grt_insertOrdered(cpred, &npred, npred+1, &target, sizeof(real_t), true, grt_compare_real_t);
                 target *= 0.95;
                 grt_insertOrdered(cpred, &npred, npred+1, &target, sizeof(real_t), true, grt_compare_real_t);
@@ -713,7 +713,7 @@ static void get_secular_roots_single_freq(MODEL1D_STATE *mstat, EIGENV_INFO *eig
                         iref_liquid++;
                     }
                     real_t target = grt_halfspace_Scholte_croot(mstat, iref_liquid, iref_solid);
-                    cpred = (real_t *)realloc(cpred, sizeof(real_t)*(npred+2));
+                    cpred = GRT_SAFE_REALLOC(cpred, sizeof(real_t)*(npred+2));
                     grt_insertOrdered(cpred, &npred, npred+1, &target, sizeof(real_t), true, grt_compare_real_t);
                     target *= 0.95;
                     grt_insertOrdered(cpred, &npred, npred+1, &target, sizeof(real_t), true, grt_compare_real_t);

--- a/pygrt/C_extension/src/static/grt_okada.c
+++ b/pygrt/C_extension/src/static/grt_okada.c
@@ -229,8 +229,7 @@ static void parse_axis(const char *text, char option, size_t *n, real_t **values
         GRTRaiseError("Error in \"-%c\". expected x1/x2/dx with x1 <= x2 and dx > 0. Use \"-h\" for help.\n", option);
     }
     *n = (size_t)floor((a2 - a1) / delta) + 1;
-    *values = (real_t *)calloc(*n, sizeof(real_t));
-    if(*values == NULL) GRTRaiseError("failed to allocate receiver axis.");
+    *values = GRT_SAFE_CALLOC(*n, sizeof(real_t));
     for(size_t i = 0; i < *n; ++i) (*values)[i] = a1 + i * delta;
 }
 
@@ -701,7 +700,7 @@ static void save_nc(
 /** Okada 子模块主函数 */
 int okada_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = (GRT_MODULE_CTRL *)calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
     parse_command(Ctrl, argc, argv);
     OKADA_MEDIUM_PARAMS medium = {
         .vp = Ctrl->I.vp,
@@ -717,9 +716,8 @@ int okada_main(int argc, char **argv)
     const real_t *norths = rcv->norths;
     const real_t *easts = rcv->easts;
     const real_t *depths = rcv->depths;
-    real_t (*syn)[3] = (real_t (*)[3])calloc(npts, sizeof(*syn));
-    real_t (*syn_d)[3][3] = (real_t (*)[3][3])calloc(npts, sizeof(*syn_d));
-    if((syn == NULL) || (syn_d == NULL)) GRTRaiseError("failed to allocate Okada output.");
+    real_t (*syn)[3] = GRT_SAFE_CALLOC(npts, sizeof(*syn));
+    real_t (*syn_d)[3][3] = GRT_SAFE_CALLOC(npts, sizeof(*syn_d));
 
     // 按源类型计算位移场
     if(Ctrl->C.active){

--- a/pygrt/C_extension/src/static/grt_static_coulomb.c
+++ b/pygrt/C_extension/src/static/grt_static_coulomb.c
@@ -202,7 +202,7 @@ static void write_coulomb_variable(
  */
 int static_coulomb_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
     getopt_from_command(Ctrl, argc, argv);
 
     GRTCheckFileExist(Ctrl->G.s_ingrid);
@@ -218,9 +218,9 @@ int static_coulomb_main(int argc, char **argv)
 
     int sigma_n_varid = get_projection_var(ncid, "sigma_n", ndims, rcv_info.dimids);
     int tau_s_varid = get_projection_var(ncid, "tau_s", ndims, rcv_info.dimids);
-    real_t *sigma_n = (real_t *)calloc(npts, sizeof(real_t));
-    real_t *tau_s = (real_t *)calloc(npts, sizeof(real_t));
-    real_t *coulomb = (real_t *)calloc(npts, sizeof(real_t));
+    real_t *sigma_n = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    real_t *tau_s = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    real_t *coulomb = GRT_SAFE_CALLOC(npts, sizeof(real_t));
 
     // 读取两个投影应力分量，并按点应用 Coulomb 应力公式
     NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, sigma_n_varid, sigma_n));

--- a/pygrt/C_extension/src/static/grt_static_greenfn.c
+++ b/pygrt/C_extension/src/static/grt_static_greenfn.c
@@ -314,8 +314,8 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
                     Ctrl->D.ndepsrc = 1;
                     Ctrl->D.ndeprcv = 1;
-                    Ctrl->D.depsrcs = (real_t *)calloc(1, sizeof(real_t));
-                    Ctrl->D.deprcvs = (real_t *)calloc(1, sizeof(real_t));
+                    Ctrl->D.depsrcs = GRT_SAFE_CALLOC(1, sizeof(real_t));
+                    Ctrl->D.deprcvs = GRT_SAFE_CALLOC(1, sizeof(real_t));
                     Ctrl->D.depsrcs[0] = depsrc;
                     Ctrl->D.deprcvs[0] = deprcv;
                 }
@@ -468,7 +468,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
 
                     Ctrl->X.nnorth = floor((a2-a1)/delta) + 1;
-                    Ctrl->X.norths = (real_t*)calloc(Ctrl->X.nnorth, sizeof(real_t));
+                    Ctrl->X.norths = GRT_SAFE_CALLOC(Ctrl->X.nnorth, sizeof(real_t));
                     for(size_t i=0; i<Ctrl->X.nnorth; ++i){
                         Ctrl->X.norths[i] = a1 + delta*i;
                     }
@@ -491,7 +491,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
 
                     Ctrl->Y.neast = floor((a2-a1)/delta) + 1;
-                    Ctrl->Y.easts = (real_t*)calloc(Ctrl->Y.neast, sizeof(real_t));
+                    Ctrl->Y.easts = GRT_SAFE_CALLOC(Ctrl->Y.neast, sizeof(real_t));
                     for(size_t i=0; i<Ctrl->Y.neast; ++i){
                         Ctrl->Y.easts[i] = a1 + delta*i;
                     }
@@ -505,7 +505,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                 {
                     Ctrl->Y.easts = grt_parse_real_array(optarg, &Ctrl->Y.neast, NULL, 'R');
                     Ctrl->X.nnorth = 1;
-                    Ctrl->X.norths = (real_t*)calloc(Ctrl->X.nnorth, sizeof(real_t));
+                    Ctrl->X.norths = GRT_SAFE_CALLOC(Ctrl->X.nnorth, sizeof(real_t));
                     Ctrl->X.norths[0] = 0.0;
                 }
                 break;
@@ -548,7 +548,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
     // 设置震中距数组
     Ctrl->nr = Ctrl->X.nnorth*Ctrl->Y.neast;
-    Ctrl->rs = (real_t*)calloc(Ctrl->nr, sizeof(real_t));
+    Ctrl->rs = GRT_SAFE_CALLOC(Ctrl->nr, sizeof(real_t));
     for(size_t inorth=0; inorth<Ctrl->X.nnorth; ++inorth){
         for(size_t ieast=0; ieast<Ctrl->Y.neast; ++ieast){
             Ctrl->rs[ieast + inorth*Ctrl->Y.neast] = hypot(Ctrl->X.norths[inorth], Ctrl->Y.easts[ieast]);
@@ -662,9 +662,9 @@ static void compute_stgrnlib_to_nc(
     size_t nr = lib->nr;
     real_t *rs = lib->rs;
 
-    realChnlGrid *grn = (realChnlGrid *)calloc(nr, sizeof(*grn));
-    realChnlGrid *grn_uiz = calc_upar ? (realChnlGrid *)calloc(nr, sizeof(*grn_uiz)) : NULL;
-    realChnlGrid *grn_uir = calc_upar ? (realChnlGrid *)calloc(nr, sizeof(*grn_uir)) : NULL;
+    realChnlGrid *grn = GRT_SAFE_CALLOC(nr, sizeof(*grn));
+    realChnlGrid *grn_uiz = calc_upar ? GRT_SAFE_CALLOC(nr, sizeof(*grn_uiz)) : NULL;
+    realChnlGrid *grn_uir = calc_upar ? GRT_SAFE_CALLOC(nr, sizeof(*grn_uir)) : NULL;
 
     size_t ntot = ndepsrc * ndeprcv;
     size_t idone = 0;
@@ -731,7 +731,7 @@ static void compute_stgrnlib_to_nc(
 
 /** 子模块主函数 */
 int static_greenfn_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 

--- a/pygrt/C_extension/src/static/grt_static_rotation.c
+++ b/pygrt/C_extension/src/static/grt_static_rotation.c
@@ -104,7 +104,7 @@ static void compute_rotation(
 
 /** 子模块主函数 */
 int static_rotation_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 
@@ -185,11 +185,11 @@ int static_rotation_main(int argc, char **argv){
     // 计算结果
     real_t *res[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM];
     for(int c=0; c<GRT_CHANNEL_NUM; ++c){
-        u[c] = (real_t *)calloc(npts, sizeof(real_t));
+        u[c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
         NC_CHECK(NC_FUNC_REAL(nc_get_var) (in_ncid, in_syn_varids[c], u[c]));
         for(int c2=0; c2<GRT_CHANNEL_NUM; ++c2){
-            res[c2][c] = (real_t *)calloc(npts, sizeof(real_t));
-            upar[c2][c] = (real_t *)calloc(npts, sizeof(real_t));
+            res[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+            upar[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
             NC_CHECK(NC_FUNC_REAL(nc_get_var) (in_ncid, in_syn_upar_varids[c2][c], upar[c2][c]));
         }
     }

--- a/pygrt/C_extension/src/static/grt_static_sproj.c
+++ b/pygrt/C_extension/src/static/grt_static_sproj.c
@@ -394,7 +394,7 @@ static real_t *read_point_depths(int ncid, const GRT_RCV_NC_INFO *rcv_info)
 {
     int depth_varid;
     // 深度只用于核对 -Q 文件中的点顺序，不参与应力投影
-    real_t *depths = (real_t *)calloc(rcv_info->npts, sizeof(real_t));
+    real_t *depths = GRT_SAFE_CALLOC(rcv_info->npts, sizeof(real_t));
     if(!find_optional_var(ncid, "depth", &depth_varid)){
         GRT_SAFE_FREE_PTR(depths);
         GRTRaiseError("Points input file does not contain variable \"depth\".");
@@ -579,10 +579,10 @@ static void load_geometry_from_finite_points(
     check_var_dimensions(ncid, dip_varid, "dip", 1, &nfault_dimid);
     check_var_dimensions(ncid, offset_varid, "offset", 1, &nfault_dimid);
 
-    real_t *fault_strikes = (real_t *)calloc(nfault, sizeof(real_t));
-    real_t *fault_dips = (real_t *)calloc(nfault, sizeof(real_t));
-    real_t *fault_rakes = (real_t *)calloc(nfault, sizeof(real_t));
-    int *offsets = (int *)calloc(nfault, sizeof(int));
+    real_t *fault_strikes = GRT_SAFE_CALLOC(nfault, sizeof(real_t));
+    real_t *fault_dips = GRT_SAFE_CALLOC(nfault, sizeof(real_t));
+    real_t *fault_rakes = GRT_SAFE_CALLOC(nfault, sizeof(real_t));
+    int *offsets = GRT_SAFE_CALLOC(nfault, sizeof(int));
     NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, strike_varid, fault_strikes));
     NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, dip_varid, fault_dips));
     NC_CHECK(nc_get_var_int(ncid, offset_varid, offsets));
@@ -804,7 +804,7 @@ static void write_projection_variables(
  */
 int static_sproj_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
     getopt_from_command(Ctrl, argc, argv);
 
     GRTCheckFileExist(Ctrl->G.s_ingrid);
@@ -831,19 +831,19 @@ int static_sproj_main(int argc, char **argv)
     bool rot2ZNE = get_input_rot2ZNE(ncid);
     const char *channels = rot2ZNE ? GRT_ZNE_CODES : GRT_ZRT_CODES;
     // 先把应力分量读入内存，避免在计算过程中反复访问 NetCDF
-    real_t *stress6 = (real_t *)calloc(6 * npts, sizeof(real_t));
+    real_t *stress6 = GRT_SAFE_CALLOC(6 * npts, sizeof(real_t));
     read_stress_components(ncid, channels, npts, ndims, rcv_info.dimids, stress6);
 
-    real_t *strikes = (real_t *)calloc(npts, sizeof(real_t));
-    real_t *dips = (real_t *)calloc(npts, sizeof(real_t));
-    real_t *rakes = (real_t *)calloc(npts, sizeof(real_t));
+    real_t *strikes = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    real_t *dips = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    real_t *rakes = GRT_SAFE_CALLOC(npts, sizeof(real_t));
     // 根据布局和命令行选项确定每个 point 的接收断层形态
     load_receiver_geometry(
         ncid, &rcv_info, Ctrl, finite_points, nfault_dimid,
         strikes, dips, rakes);
 
-    real_t *sigma_n = (real_t *)calloc(npts, sizeof(real_t));
-    real_t *tau_s = (real_t *)calloc(npts, sizeof(real_t));
+    real_t *sigma_n = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    real_t *tau_s = GRT_SAFE_CALLOC(npts, sizeof(real_t));
     // 逐点完成坐标转换、方向构造和应力投影
     for(size_t i = 0; i < npts; ++i){
         real_t stress[6] = {

--- a/pygrt/C_extension/src/static/grt_static_strain.c
+++ b/pygrt/C_extension/src/static/grt_static_strain.c
@@ -109,7 +109,7 @@ static void compute_strain(
 
 /** 子模块主函数 */
 int static_strain_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 
@@ -190,11 +190,11 @@ int static_strain_main(int argc, char **argv){
     // 计算结果
     real_t *res[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM];
     for(int c=0; c<GRT_CHANNEL_NUM; ++c){
-        u[c] = (real_t *)calloc(npts, sizeof(real_t));
+        u[c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
         NC_CHECK(NC_FUNC_REAL(nc_get_var) (in_ncid, in_syn_varids[c], u[c]));
         for(int c2=0; c2<GRT_CHANNEL_NUM; ++c2){
-            res[c2][c] = (real_t *)calloc(npts, sizeof(real_t));
-            upar[c2][c] = (real_t *)calloc(npts, sizeof(real_t));
+            res[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+            upar[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
             NC_CHECK(NC_FUNC_REAL(nc_get_var) (in_ncid, in_syn_upar_varids[c2][c], upar[c2][c]));
         }
     }

--- a/pygrt/C_extension/src/static/grt_static_stress.c
+++ b/pygrt/C_extension/src/static/grt_static_stress.c
@@ -142,7 +142,7 @@ static void fill_mu_lam_from_global_atts(int ncid, size_t npts, real_t *mu, real
 
 /** 子模块主函数 */
 int static_stress_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 
@@ -189,15 +189,15 @@ int static_stress_main(int argc, char **argv){
     int out_dimids[2] = {rcv_info.dimids[0], rcv_info.dimids[1]};
 
     // 逐点物性参数 mu/lam
-    real_t *mu  = (real_t *)calloc(npts, sizeof(real_t));
-    real_t *lam = (real_t *)calloc(npts, sizeof(real_t));
+    real_t *mu  = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    real_t *lam = GRT_SAFE_CALLOC(npts, sizeof(real_t));
     if(rcv_info.layout == GRT_RCV_NC_LAYOUT_POINTS){
         int va_varid;
         if(nc_inq_varid(in_ncid, "rcv_va", &va_varid) == NC_NOERR){
             int vb_varid, rho_varid;
-            real_t *rcv_va  = (real_t *)calloc(npts, sizeof(real_t));
-            real_t *rcv_vb  = (real_t *)calloc(npts, sizeof(real_t));
-            real_t *rcv_rho = (real_t *)calloc(npts, sizeof(real_t));
+            real_t *rcv_va  = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+            real_t *rcv_vb  = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+            real_t *rcv_rho = GRT_SAFE_CALLOC(npts, sizeof(real_t));
             NC_CHECK(NC_FUNC_REAL(nc_get_var) (in_ncid, va_varid, rcv_va));
             NC_CHECK(nc_inq_varid(in_ncid, "rcv_vb", &vb_varid));
             NC_CHECK(NC_FUNC_REAL(nc_get_var) (in_ncid, vb_varid, rcv_vb));
@@ -253,11 +253,11 @@ int static_stress_main(int argc, char **argv){
     // 计算结果
     real_t *res[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM];
     for(int c=0; c<GRT_CHANNEL_NUM; ++c){
-        u[c] = (real_t *)calloc(npts, sizeof(real_t));
+        u[c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
         NC_CHECK(NC_FUNC_REAL(nc_get_var) (in_ncid, in_syn_varids[c], u[c]));
         for(int c2=0; c2<GRT_CHANNEL_NUM; ++c2){
-            res[c2][c] = (real_t *)calloc(npts, sizeof(real_t));
-            upar[c2][c] = (real_t *)calloc(npts, sizeof(real_t));
+            res[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+            upar[c2][c] = GRT_SAFE_CALLOC(npts, sizeof(real_t));
             NC_CHECK(NC_FUNC_REAL(nc_get_var) (in_ncid, in_syn_upar_varids[c2][c], upar[c2][c]));
         }
     }

--- a/pygrt/C_extension/src/static/grt_static_syn.c
+++ b/pygrt/C_extension/src/static/grt_static_syn.c
@@ -497,7 +497,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
 
                     Ctrl->X.nnorth = floor((a2-a1)/delta) + 1;
-                    Ctrl->X.norths = (real_t*)calloc(Ctrl->X.nnorth, sizeof(real_t));
+                    Ctrl->X.norths = GRT_SAFE_CALLOC(Ctrl->X.nnorth, sizeof(real_t));
                     for(size_t i=0; i<Ctrl->X.nnorth; ++i){
                         Ctrl->X.norths[i] = a1 + delta*i;
                     }
@@ -520,7 +520,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
 
                     Ctrl->Y.neast = floor((a2-a1)/delta) + 1;
-                    Ctrl->Y.easts = (real_t*)calloc(Ctrl->Y.neast, sizeof(real_t));
+                    Ctrl->Y.easts = GRT_SAFE_CALLOC(Ctrl->Y.neast, sizeof(real_t));
                     for(size_t i=0; i<Ctrl->Y.neast; ++i){
                         Ctrl->Y.easts[i] = a1 + delta*i;
                     }
@@ -939,11 +939,8 @@ static void static_syn_from_gf_PS(
 
     // 单角点合成缓冲：共面时容量 npts，逐点时容量 1
     size_t nbuf = shared_depth ? npts : 1;
-    real_t (*tmp)[GRT_CHANNEL_NUM] =
-        (real_t (*)[GRT_CHANNEL_NUM])calloc(nbuf, sizeof(real_t) * GRT_CHANNEL_NUM);
-    real_t (*tmp_upar)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM] =
-        (real_t (*)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM])calloc(
-            nbuf, sizeof(real_t) * GRT_CHANNEL_NUM * GRT_CHANNEL_NUM);
+    real_t (*tmp)[GRT_CHANNEL_NUM] = GRT_SAFE_CALLOC(nbuf, sizeof(real_t) * GRT_CHANNEL_NUM);
+    real_t (*tmp_upar)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM] = GRT_SAFE_CALLOC(nbuf, sizeof(real_t) * GRT_CHANNEL_NUM * GRT_CHANNEL_NUM);
 
     if(shared_depth){
         // 网格：统一深度 depths[0]，一次括号 + 批量震中距合成
@@ -1020,13 +1017,10 @@ static void static_syn_one_finite_fault(
     size_t nsub = loop_nW * loop_nL;
     #pragma omp parallel default(shared) if(nsub > 1)
     {
-        real_t *rcv_norths = (real_t *)calloc(npts, sizeof(real_t));
-        real_t *rcv_easts = (real_t *)calloc(npts, sizeof(real_t));
-        real_t (*local_syn)[GRT_CHANNEL_NUM] =
-            (real_t (*)[GRT_CHANNEL_NUM])calloc(npts, sizeof(real_t) * GRT_CHANNEL_NUM);
-        real_t (*local_syn_upar)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM] =
-            (real_t (*)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM])calloc(
-                npts, sizeof(real_t) * GRT_CHANNEL_NUM * GRT_CHANNEL_NUM);
+        real_t *rcv_norths = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+        real_t *rcv_easts = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+        real_t (*local_syn)[GRT_CHANNEL_NUM] = GRT_SAFE_CALLOC(npts, sizeof(real_t) * GRT_CHANNEL_NUM);
+        real_t (*local_syn_upar)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM] = GRT_SAFE_CALLOC(npts, sizeof(real_t) * GRT_CHANNEL_NUM * GRT_CHANNEL_NUM);
 
         #pragma omp for collapse(2) schedule(guided)
         for(size_t iW = 0; iW < loop_nW; ++iW){
@@ -1355,7 +1349,7 @@ static void save_syn_nc(
 }
 /** 子模块主函数 */
 int static_syn_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
     getopt_from_command(Ctrl, argc, argv);
 
     STGRNLIB *lib = grt_stgrnlib_load_nc(Ctrl->G.s_ingrid);
@@ -1380,9 +1374,8 @@ int static_syn_main(int argc, char **argv){
     const real_t *depths = rcv->depths;
     bool shared_depth = rcv->is_grid;
 
-    real_t (*syn)[GRT_CHANNEL_NUM] = (real_t (*)[GRT_CHANNEL_NUM])calloc(npts, sizeof(real_t) * GRT_CHANNEL_NUM);
-    real_t (*syn_upar)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM] =
-        (real_t (*)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM])calloc(npts, sizeof(real_t) * GRT_CHANNEL_NUM * GRT_CHANNEL_NUM);
+    real_t (*syn)[GRT_CHANNEL_NUM] = GRT_SAFE_CALLOC(npts, sizeof(real_t) * GRT_CHANNEL_NUM);
+    real_t (*syn_upar)[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM] = GRT_SAFE_CALLOC(npts, sizeof(real_t) * GRT_CHANNEL_NUM * GRT_CHANNEL_NUM);
 
     // depsrc 仅点源需要；有限断层由各子断层几何提供
     real_t depsrc = 0.0;

--- a/pygrt/C_extension/src/static/grt_xy2geo_geo2xy.c
+++ b/pygrt/C_extension/src/static/grt_xy2geo_geo2xy.c
@@ -397,14 +397,8 @@ static void convert_output_coordinates(
     NC_CHECK(nc_inq_varid(ncid, first_name, &first_varid));
     NC_CHECK(nc_inq_varid(ncid, second_name, &second_varid));
 
-    real_t *firsts = (real_t *)calloc(info->first_count, sizeof(real_t));
-    real_t *seconds = (real_t *)calloc(info->second_count, sizeof(real_t));
-    if(((firsts == NULL) && (info->first_count != 0)) ||
-        ((seconds == NULL) && (info->second_count != 0))){
-        GRT_SAFE_FREE_PTR(firsts);
-        GRT_SAFE_FREE_PTR(seconds);
-        GRTRaiseError("Unable to allocate memory for coordinate variables.");
-    }
+    real_t *firsts = GRT_SAFE_CALLOC(info->first_count, sizeof(real_t));
+    real_t *seconds = GRT_SAFE_CALLOC(info->second_count, sizeof(real_t));
     NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, first_varid, firsts));
     NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, second_varid, seconds));
 
@@ -636,7 +630,7 @@ static void convert_text_file(
 static int coordinate_transform_main(
     int argc, char **argv, GRT_TRANSFORM_DIRECTION direction)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
     getopt_from_command(Ctrl, argc, argv, direction);
 
     const char *input_path = Ctrl->G.active ? Ctrl->G.s_path : Ctrl->Q.s_path;

--- a/pygrt/C_extension/src/static/rcv_points.c
+++ b/pygrt/C_extension/src/static/rcv_points.c
@@ -61,14 +61,14 @@ GRT_RCV_POINTS *grt_rcv_points_from_grid(
         GRTRaiseError("Negative receiver depth is not supported.");
     }
 
-    GRT_RCV_POINTS *pts = (GRT_RCV_POINTS *)calloc(1, sizeof(GRT_RCV_POINTS));
+    GRT_RCV_POINTS *pts = GRT_SAFE_CALLOC(1, sizeof(GRT_RCV_POINTS));
     pts->is_grid = true;
     pts->nnorth = nnorth;
     pts->neast = neast;
     pts->npts = nnorth * neast;
-    pts->norths = (real_t *)calloc(pts->npts, sizeof(real_t));
-    pts->easts  = (real_t *)calloc(pts->npts, sizeof(real_t));
-    pts->depths = (real_t *)calloc(pts->npts, sizeof(real_t));
+    pts->norths = GRT_SAFE_CALLOC(pts->npts, sizeof(real_t));
+    pts->easts  = GRT_SAFE_CALLOC(pts->npts, sizeof(real_t));
+    pts->depths = GRT_SAFE_CALLOC(pts->npts, sizeof(real_t));
 
     for(size_t inorth = 0; inorth < nnorth; ++inorth){
         for(size_t ieast = 0; ieast < neast; ++ieast){
@@ -130,19 +130,19 @@ GRT_RCV_POINTS *grt_rcv_points_from_file(const char *path)
         GRTRaiseError("No receiver points found in \"%s\".", path);
     }
 
-    GRT_RCV_POINTS *pts = (GRT_RCV_POINTS *)calloc(1, sizeof(GRT_RCV_POINTS));
+    GRT_RCV_POINTS *pts = GRT_SAFE_CALLOC(1, sizeof(GRT_RCV_POINTS));
     pts->is_grid = false;
     pts->nnorth = 0;
     pts->neast = 0;
     pts->npts = npts;
-    pts->norths = (real_t *)calloc(npts, sizeof(real_t));
-    pts->easts  = (real_t *)calloc(npts, sizeof(real_t));
-    pts->depths = (real_t *)calloc(npts, sizeof(real_t));
+    pts->norths = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    pts->easts  = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    pts->depths = GRT_SAFE_CALLOC(npts, sizeof(real_t));
     pts->has_geometry = ncolumns == 6;
     if(pts->has_geometry){
-        pts->strikes = (real_t *)calloc(npts, sizeof(real_t));
-        pts->dips    = (real_t *)calloc(npts, sizeof(real_t));
-        pts->rakes   = (real_t *)calloc(npts, sizeof(real_t));
+        pts->strikes = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+        pts->dips    = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+        pts->rakes   = GRT_SAFE_CALLOC(npts, sizeof(real_t));
     }
 
     rewind(fp);
@@ -219,16 +219,16 @@ GRT_RCV_POINTS *grt_rcv_points_from_faults(
         GRTRaiseError("finite receiver dL and dW must both be positive or both be omitted.");
     }
 
-    GRT_RCV_POINTS *pts = (GRT_RCV_POINTS *)calloc(1, sizeof(*pts));
+    GRT_RCV_POINTS *pts = GRT_SAFE_CALLOC(1, sizeof(*pts));
     pts->is_fault = true;
     pts->nfault = nfault;
-    pts->nsubs = (size_t *)calloc(nfault, sizeof(*pts->nsubs));
-    pts->offsets = (size_t *)calloc(nfault, sizeof(*pts->offsets));
-    pts->fstrikes = (real_t *)calloc(nfault, sizeof(*pts->fstrikes));
-    pts->fdips = (real_t *)calloc(nfault, sizeof(*pts->fdips));
-    pts->frakes = (real_t *)calloc(nfault, sizeof(*pts->frakes));
-    pts->stksizes = (size_t *)calloc(nfault, sizeof(*pts->stksizes));
-    pts->dipsizes = (size_t *)calloc(nfault, sizeof(*pts->dipsizes));
+    pts->nsubs = GRT_SAFE_CALLOC(nfault, sizeof(*pts->nsubs));
+    pts->offsets = GRT_SAFE_CALLOC(nfault, sizeof(*pts->offsets));
+    pts->fstrikes = GRT_SAFE_CALLOC(nfault, sizeof(*pts->fstrikes));
+    pts->fdips = GRT_SAFE_CALLOC(nfault, sizeof(*pts->fdips));
+    pts->frakes = GRT_SAFE_CALLOC(nfault, sizeof(*pts->frakes));
+    pts->stksizes = GRT_SAFE_CALLOC(nfault, sizeof(*pts->stksizes));
+    pts->dipsizes = GRT_SAFE_CALLOC(nfault, sizeof(*pts->dipsizes));
 
     // 遍历每条有限断层，统一调用公共几何函数并追加子断层中心点
     for(size_t ifault = 0; ifault < nfault; ++ifault){
@@ -246,9 +246,9 @@ GRT_RCV_POINTS *grt_rcv_points_from_faults(
         pts->frakes[ifault] = fault->rake;
         pts->stksizes[ifault] = nL;
         pts->dipsizes[ifault] = nW;
-        pts->norths = (real_t *)realloc(pts->norths, new_npts * sizeof(*pts->norths));
-        pts->easts = (real_t *)realloc(pts->easts, new_npts * sizeof(*pts->easts));
-        pts->depths = (real_t *)realloc(pts->depths, new_npts * sizeof(*pts->depths));
+        pts->norths = GRT_SAFE_REALLOC(pts->norths, new_npts * sizeof(*pts->norths));
+        pts->easts = GRT_SAFE_REALLOC(pts->easts, new_npts * sizeof(*pts->easts));
+        pts->depths = GRT_SAFE_REALLOC(pts->depths, new_npts * sizeof(*pts->depths));
         pts->npts = new_npts;
 
         // 将当前有限断层的子断层中心按 point 顺序追加
@@ -277,7 +277,7 @@ GRT_RCV_NC_LAYOUT grt_rcv_nc_get_layout(int ncid)
     }
 
     // 所有静态输出文件都显式保存 layout 属性，直接按属性确定布局
-    char *layout = (char *)calloc(len + 1, 1);
+    char *layout = GRT_SAFE_CALLOC(len + 1, 1);
     NC_CHECK(nc_get_att_text(ncid, NC_GLOBAL, "layout", layout));
 
     GRT_RCV_NC_LAYOUT result;
@@ -310,11 +310,11 @@ void grt_rcv_nc_info_load(int ncid, GRT_RCV_NC_INFO *info)
         NC_CHECK(nc_inq_dimid(ncid, "east", &info->dimids[1]));
         NC_CHECK(nc_inq_dimlen(ncid, info->dimids[1], &neast));
         info->npts = nnorth * neast;
-        info->norths = (real_t *)calloc(info->npts, sizeof(real_t));
-        info->easts = (real_t *)calloc(info->npts, sizeof(real_t));
+        info->norths = GRT_SAFE_CALLOC(info->npts, sizeof(real_t));
+        info->easts = GRT_SAFE_CALLOC(info->npts, sizeof(real_t));
 
-        real_t *north_axis = (real_t *)calloc(nnorth, sizeof(real_t));
-        real_t *east_axis = (real_t *)calloc(neast, sizeof(real_t));
+        real_t *north_axis = GRT_SAFE_CALLOC(nnorth, sizeof(real_t));
+        real_t *east_axis = GRT_SAFE_CALLOC(neast, sizeof(real_t));
         // 网格文件按两个坐标轴保存，读取后展开为 point 顺序
         NC_CHECK(nc_inq_varid(ncid, "north", &north_varid));
         NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, north_varid, north_axis));
@@ -337,8 +337,8 @@ void grt_rcv_nc_info_load(int ncid, GRT_RCV_NC_INFO *info)
         // 一维接收点文件的坐标已经展平，可以直接读取到输出数组
         NC_CHECK(nc_inq_dimid(ncid, "point", &info->dimids[0]));
         NC_CHECK(nc_inq_dimlen(ncid, info->dimids[0], &info->npts));
-        info->norths = (real_t *)calloc(info->npts, sizeof(real_t));
-        info->easts = (real_t *)calloc(info->npts, sizeof(real_t));
+        info->norths = GRT_SAFE_CALLOC(info->npts, sizeof(real_t));
+        info->easts = GRT_SAFE_CALLOC(info->npts, sizeof(real_t));
         NC_CHECK(nc_inq_varid(ncid, "north", &north_varid));
         NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, north_varid, info->norths));
         NC_CHECK(nc_inq_varid(ncid, "east", &east_varid));

--- a/pygrt/C_extension/src/static/static_grn.c
+++ b/pygrt/C_extension/src/static/static_grn.c
@@ -40,7 +40,7 @@ static void recordin_GRN(
     realChnlGrid grn[nr])
 {
     // 局部变量，将某个频点的格林函数谱临时存放
-    cplxChnlGrid *tmp_grn = (cplxChnlGrid *)calloc(nr, sizeof(*tmp_grn));
+    cplxChnlGrid *tmp_grn = GRT_SAFE_CALLOC(nr, sizeof(*tmp_grn));
 
     for(size_t ir=0; ir<nr; ++ir){
         grt_merge_Pk(sumJ[ir], tmp_grn[ir]);
@@ -69,8 +69,8 @@ void grt_integ_static_grn(
 {
     // 根据静态解传入的震中距形式，有必要对震中距去重，从而减少不必要的计算量
     size_t uniq_nr = nr;
-    real_t *uniq_rs = (real_t *)calloc(nr, sizeof(real_t));
-    size_t *rs_refidx = (size_t *)calloc(nr, sizeof(size_t));
+    real_t *uniq_rs = GRT_SAFE_CALLOC(nr, sizeof(real_t));
+    size_t *rs_refidx = GRT_SAFE_CALLOC(nr, sizeof(size_t));
     memcpy(uniq_rs, rs, sizeof(real_t)*nr);
     uniq_nr = 1;
     for(size_t ir = 1; ir < nr; ++ir){

--- a/pygrt/C_extension/src/static/static_output.c
+++ b/pygrt/C_extension/src/static/static_output.c
@@ -76,7 +76,7 @@ static void write_fields(
     const int vars[GRT_CHANNEL_NUM],
     const int dvars[GRT_CHANNEL_NUM][GRT_CHANNEL_NUM])
 {
-    real_t *buffer = (real_t *)calloc(npts, sizeof(real_t));
+    real_t *buffer = GRT_SAFE_CALLOC(npts, sizeof(real_t));
     // NetCDF 变量按分量写入，临时数组用于提取每个分量的点序列
     for(int c = 0; c < GRT_CHANNEL_NUM; ++c){
         for(size_t i = 0; i < npts; ++i){
@@ -131,8 +131,8 @@ static void write_grid_layout(
     // 结束定义模式后写入坐标轴和位移数据
     NC_CHECK(nc_enddef(ncid));
 
-    real_t *north_axis = (real_t *)calloc(rcv->nnorth, sizeof(real_t));
-    real_t *east_axis = (real_t *)calloc(rcv->neast, sizeof(real_t));
+    real_t *north_axis = GRT_SAFE_CALLOC(rcv->nnorth, sizeof(real_t));
+    real_t *east_axis = GRT_SAFE_CALLOC(rcv->neast, sizeof(real_t));
     // 接收点坐标在内存中按 point 展平，写网格文件时恢复为两个坐标轴
     for(size_t inorth = 0; inorth < rcv->nnorth; ++inorth){
         north_axis[inorth] = rcv->norths[inorth * rcv->neast];
@@ -200,9 +200,9 @@ static void write_points_layout(
     // 完成变量定义后，按点查询接收介质参数并准备写入
     NC_CHECK(nc_enddef(ncid));
 
-    real_t *rcv_va = (real_t *)calloc(npts, sizeof(real_t));
-    real_t *rcv_vb = (real_t *)calloc(npts, sizeof(real_t));
-    real_t *rcv_rho = (real_t *)calloc(npts, sizeof(real_t));
+    real_t *rcv_va = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    real_t *rcv_vb = GRT_SAFE_CALLOC(npts, sizeof(real_t));
+    real_t *rcv_rho = GRT_SAFE_CALLOC(npts, sizeof(real_t));
     for(size_t i = 0; i < npts; ++i){
         output->get_medium(
             output->medium_context, depths[i], &rcv_va[i], &rcv_vb[i], &rcv_rho[i]);
@@ -217,9 +217,9 @@ static void write_points_layout(
     NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, rho_varid, rcv_rho));
     if(rcv->is_fault){
         // offset 保存每条有限断层点范围的排他性结束索引，最后一个值等于 point
-        int *offsets = (int *)calloc(rcv->nfault, sizeof(int));
-        int *stksizes = (int *)calloc(rcv->nfault, sizeof(int));
-        int *dipsizes = (int *)calloc(rcv->nfault, sizeof(int));
+        int *offsets = GRT_SAFE_CALLOC(rcv->nfault, sizeof(int));
+        int *stksizes = GRT_SAFE_CALLOC(rcv->nfault, sizeof(int));
+        int *dipsizes = GRT_SAFE_CALLOC(rcv->nfault, sizeof(int));
         for(size_t ifault = 0; ifault < rcv->nfault; ++ifault){
             if(rcv->offsets[ifault] > (size_t)INT_MAX){
                 GRTRaiseError("receiver point offset exceeds the NetCDF integer range.");

--- a/pygrt/C_extension/src/static/stgrnlib.c
+++ b/pygrt/C_extension/src/static/stgrnlib.c
@@ -33,9 +33,9 @@ static void require_strictly_ascending(const real_t *a, size_t n, const char *na
 static void fill_rs_meta(STGRNLIB *lib)
 {
     lib->nr = lib->nnorth * lib->neast;
-    lib->rs = (real_t *)malloc(lib->nr * sizeof(real_t));
-    lib->sort_rs = (real_t *)malloc(lib->nr * sizeof(real_t));
-    lib->sort_rs_idx = (size_t *)malloc(lib->nr * sizeof(size_t));
+    lib->rs = GRT_SAFE_MALLOC(lib->nr * sizeof(real_t));
+    lib->sort_rs = GRT_SAFE_MALLOC(lib->nr * sizeof(real_t));
+    lib->sort_rs_idx = GRT_SAFE_MALLOC(lib->nr * sizeof(size_t));
 
     for(size_t inorth = 0; inorth < lib->nnorth; ++inorth){
         for(size_t ieast = 0; ieast < lib->neast; ++ieast){
@@ -73,21 +73,21 @@ static void fill_rs_meta(STGRNLIB *lib)
 static void allocate_u(STGRNLIB *lib)
 {
     size_t nr = lib->nr;
-    lib->u = (realChnlGrid ***)calloc(lib->ndepsrc, sizeof(*lib->u));
-    lib->uiz = lib->calc_upar ? (realChnlGrid ***)calloc(lib->ndepsrc, sizeof(*lib->uiz)) : NULL;
-    lib->uir = lib->calc_upar ? (realChnlGrid ***)calloc(lib->ndepsrc, sizeof(*lib->uir)) : NULL;
+    lib->u = GRT_SAFE_CALLOC(lib->ndepsrc, sizeof(*lib->u));
+    lib->uiz = lib->calc_upar ? GRT_SAFE_CALLOC(lib->ndepsrc, sizeof(*lib->uiz)) : NULL;
+    lib->uir = lib->calc_upar ? GRT_SAFE_CALLOC(lib->ndepsrc, sizeof(*lib->uir)) : NULL;
 
     for(size_t is = 0; is < lib->ndepsrc; ++is){
-        lib->u[is] = (realChnlGrid **)calloc(lib->ndeprcv, sizeof(*lib->u[is]));
+        lib->u[is] = GRT_SAFE_CALLOC(lib->ndeprcv, sizeof(*lib->u[is]));
         if(lib->calc_upar){
-            lib->uiz[is] = (realChnlGrid **)calloc(lib->ndeprcv, sizeof(*lib->uiz[is]));
-            lib->uir[is] = (realChnlGrid **)calloc(lib->ndeprcv, sizeof(*lib->uir[is]));
+            lib->uiz[is] = GRT_SAFE_CALLOC(lib->ndeprcv, sizeof(*lib->uiz[is]));
+            lib->uir[is] = GRT_SAFE_CALLOC(lib->ndeprcv, sizeof(*lib->uir[is]));
         }
         for(size_t ir = 0; ir < lib->ndeprcv; ++ir){
-            lib->u[is][ir] = (realChnlGrid *)calloc(nr, sizeof(realChnlGrid));
+            lib->u[is][ir] = GRT_SAFE_CALLOC(nr, sizeof(realChnlGrid));
             if(lib->calc_upar){
-                lib->uiz[is][ir] = (realChnlGrid *)calloc(nr, sizeof(realChnlGrid));
-                lib->uir[is][ir] = (realChnlGrid *)calloc(nr, sizeof(realChnlGrid));
+                lib->uiz[is][ir] = GRT_SAFE_CALLOC(nr, sizeof(realChnlGrid));
+                lib->uir[is][ir] = GRT_SAFE_CALLOC(nr, sizeof(realChnlGrid));
             }
         }
     }
@@ -134,17 +134,17 @@ STGRNLIB *grt_stgrnlib_alloc(
     require_strictly_ascending(norths, nnorth, "norths");
     require_strictly_ascending(easts, neast, "easts");
 
-    STGRNLIB *lib = (STGRNLIB *)calloc(1, sizeof(*lib));
+    STGRNLIB *lib = GRT_SAFE_CALLOC(1, sizeof(*lib));
     lib->ndepsrc = ndepsrc;
     lib->ndeprcv = ndeprcv;
     lib->nnorth = nnorth;
     lib->neast = neast;
     lib->calc_upar = calc_upar;
 
-    lib->depsrcs = (real_t *)malloc(ndepsrc * sizeof(real_t));
-    lib->deprcvs = (real_t *)malloc(ndeprcv * sizeof(real_t));
-    lib->norths = (real_t *)malloc(nnorth * sizeof(real_t));
-    lib->easts = (real_t *)malloc(neast * sizeof(real_t));
+    lib->depsrcs = GRT_SAFE_MALLOC(ndepsrc * sizeof(real_t));
+    lib->deprcvs = GRT_SAFE_MALLOC(ndeprcv * sizeof(real_t));
+    lib->norths = GRT_SAFE_MALLOC(nnorth * sizeof(real_t));
+    lib->easts = GRT_SAFE_MALLOC(neast * sizeof(real_t));
     memcpy(lib->depsrcs, depsrcs, ndepsrc * sizeof(real_t));
     memcpy(lib->deprcvs, deprcvs, ndeprcv * sizeof(real_t));
     memcpy(lib->norths, norths, nnorth * sizeof(real_t));
@@ -153,12 +153,12 @@ STGRNLIB *grt_stgrnlib_alloc(
     fill_rs_meta(lib);
 
     // 介质参数由调用方随后填入
-    lib->src_va = (real_t *)calloc(ndepsrc, sizeof(real_t));
-    lib->src_vb = (real_t *)calloc(ndepsrc, sizeof(real_t));
-    lib->src_rho = (real_t *)calloc(ndepsrc, sizeof(real_t));
-    lib->rcv_va = (real_t *)calloc(ndeprcv, sizeof(real_t));
-    lib->rcv_vb = (real_t *)calloc(ndeprcv, sizeof(real_t));
-    lib->rcv_rho = (real_t *)calloc(ndeprcv, sizeof(real_t));
+    lib->src_va = GRT_SAFE_CALLOC(ndepsrc, sizeof(real_t));
+    lib->src_vb = GRT_SAFE_CALLOC(ndepsrc, sizeof(real_t));
+    lib->src_rho = GRT_SAFE_CALLOC(ndepsrc, sizeof(real_t));
+    lib->rcv_va = GRT_SAFE_CALLOC(ndeprcv, sizeof(real_t));
+    lib->rcv_vb = GRT_SAFE_CALLOC(ndeprcv, sizeof(real_t));
+    lib->rcv_rho = GRT_SAFE_CALLOC(ndeprcv, sizeof(real_t));
     lib->nlayer = 0;
     lib->modarr = NULL;
 
@@ -197,11 +197,7 @@ void grt_stgrnlib_set_modarr(
         GRTRaiseError("nlayer and modarr must be non-empty.");
     }
     GRT_SAFE_FREE_PTR(lib->modarr);
-    lib->modarr = (real_t (*)[GRT_MODARR_NCOL])malloc(
-        sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
-    if(lib->modarr == NULL){
-        GRTRaiseError("Failed to allocate modarr.");
-    }
+    lib->modarr = GRT_SAFE_MALLOC(sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
     memcpy(lib->modarr, modarr, sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
     lib->nlayer = nlayer;
 }
@@ -255,7 +251,7 @@ real_t grt_stgrnlib_default_subfault_size(const STGRNLIB *lib)
 static void read_nc_channels_slice(STGRNLIB *lib, size_t is, size_t ir, int ncid)
 {
     size_t nr = lib->nr;
-    real_t *buf = (real_t *)calloc(nr, sizeof(real_t));
+    real_t *buf = GRT_SAFE_CALLOC(nr, sizeof(real_t));
     size_t start[4] = {is, ir, 0, 0};
     size_t count[4] = {1, 1, lib->nnorth, lib->neast};
 
@@ -323,10 +319,10 @@ STGRNLIB *grt_stgrnlib_load_nc(const char *path)
     NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "calc_upar", &int_calc_upar));
 
     // 坐标轴读入后经 grt_stgrnlib_alloc 建壳
-    real_t *depsrcs = (real_t *)calloc(ndepsrc, sizeof(real_t));
-    real_t *deprcvs = (real_t *)calloc(ndeprcv, sizeof(real_t));
-    real_t *norths = (real_t *)calloc(nnorth, sizeof(real_t));
-    real_t *easts = (real_t *)calloc(neast, sizeof(real_t));
+    real_t *depsrcs = GRT_SAFE_CALLOC(ndepsrc, sizeof(real_t));
+    real_t *deprcvs = GRT_SAFE_CALLOC(ndeprcv, sizeof(real_t));
+    real_t *norths = GRT_SAFE_CALLOC(nnorth, sizeof(real_t));
+    real_t *easts = GRT_SAFE_CALLOC(neast, sizeof(real_t));
 
     int varid;
     NC_CHECK(nc_inq_varid(ncid, "depsrc", &varid));
@@ -382,8 +378,7 @@ STGRNLIB *grt_stgrnlib_load_nc(const char *path)
                 path, nlayer, nparam, GRT_MODARR_NCOL);
         }
         NC_CHECK(nc_inq_varid(ncid, "model", &varid));
-        real_t (*modarr)[GRT_MODARR_NCOL] = (real_t (*)[GRT_MODARR_NCOL])malloc(
-            sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
+        real_t (*modarr)[GRT_MODARR_NCOL] = GRT_SAFE_MALLOC(sizeof(real_t) * GRT_MODARR_NCOL * nlayer);
         NC_CHECK(NC_FUNC_REAL(nc_get_var)(ncid, varid, (real_t *)modarr));
         grt_stgrnlib_set_modarr(lib, nlayer, (const real_t (*)[GRT_MODARR_NCOL])modarr);
         GRT_SAFE_FREE_PTR(modarr);
@@ -489,7 +484,7 @@ void grt_stgrnlib_save_nc(const STGRNLIB *lib, const char *path)
     NC_CHECK(NC_FUNC_REAL(nc_put_var)(ncid, model_varid, (const real_t *)lib->modarr));
 
     size_t nr = lib->nr;
-    real_t *tmpdata = (real_t *)calloc(nr, sizeof(real_t));
+    real_t *tmpdata = GRT_SAFE_CALLOC(nr, sizeof(real_t));
     for(size_t is = 0; is < lib->ndepsrc; ++is){
         for(size_t ir = 0; ir < lib->ndeprcv; ++ir){
             size_t start[4] = {is, ir, 0, 0};

--- a/pygrt/C_extension/src/tools/grt_disp2asc.c
+++ b/pygrt/C_extension/src/tools/grt_disp2asc.c
@@ -152,7 +152,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                         }
                     }
                     Ctrl->N.nmode = floor((a2-a1)/dif) + 1;
-                    Ctrl->N.modes = (size_t *)calloc(Ctrl->N.nmode, sizeof(size_t));
+                    Ctrl->N.modes = GRT_SAFE_CALLOC(Ctrl->N.nmode, sizeof(size_t));
                     for(size_t i=0; i < Ctrl->N.nmode; ++i){
                         Ctrl->N.modes[i] = a1 + dif*i;
                     }
@@ -213,7 +213,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
                     if(nscan == 3 || nscan == 1){
                         Ctrl->F.nf = floor((a2-a1)/df) + 1;
-                        Ctrl->F.freqs = (real_t*)calloc(Ctrl->F.nf, sizeof(real_t));
+                        Ctrl->F.freqs = GRT_SAFE_CALLOC(Ctrl->F.nf, sizeof(real_t));
                         for(size_t i=0; i<Ctrl->F.nf; ++i){
                             if(isperiod){
                                 Ctrl->F.freqs[Ctrl->F.nf-1 - i] = 1.0/(a1 + df*i);
@@ -225,7 +225,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     else if(nscan == 2){
                         // 只约束最大值和最小值，内存申请由读取频散文件的过程中进行
                         Ctrl->F.nf = 2;
-                        Ctrl->F.freqs = (real_t*)calloc(Ctrl->F.nf, sizeof(real_t));
+                        Ctrl->F.freqs = GRT_SAFE_CALLOC(Ctrl->F.nf, sizeof(real_t));
                         Ctrl->F.freqs[0] = a1;
                         Ctrl->F.freqs[1] = a2;
                         Ctrl->F.def_range = true;
@@ -252,7 +252,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
     // -N 的默认项，仅处理基阶
     if( ! Ctrl->N.active ){
         Ctrl->N.nmode = 1;
-        Ctrl->N.modes = (size_t *)calloc(Ctrl->N.nmode, sizeof(size_t));
+        Ctrl->N.modes = GRT_SAFE_CALLOC(Ctrl->N.nmode, sizeof(size_t));
         Ctrl->N.modes[0] = 0;
     }
 }
@@ -261,13 +261,13 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 /** 子模块主函数 */
 int disp2asc_main(int argc, char **argv)
 {
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     // 传入参数 
     getopt_from_command(Ctrl, argc, argv);
 
     // 读取频散
-    EIGENV_INFO *eigmet = (EIGENV_INFO *)calloc(1, sizeof(EIGENV_INFO));
+    EIGENV_INFO *eigmet = GRT_SAFE_CALLOC(1, sizeof(EIGENV_INFO));
 
     if(Ctrl->C.active){
         grt_read_dispersion(Ctrl->C.s_phasepath, eigmet, NULL, NULL);
@@ -279,7 +279,7 @@ int disp2asc_main(int argc, char **argv)
     
 
     // 根据命令行参数确定出所需的部分频散信息
-    EIGENFN_INFO *eigfnmet = (EIGENFN_INFO *)calloc(1, sizeof(EIGENFN_INFO));
+    EIGENFN_INFO *eigfnmet = GRT_SAFE_CALLOC(1, sizeof(EIGENFN_INFO));
     grt_filter_eigenfn_info(
         Ctrl->F.nf, Ctrl->F.freqs, Ctrl->F.def_range,
         Ctrl->N.nmode, Ctrl->N.modes, eigmet, eigfnmet);

--- a/pygrt/C_extension/src/tools/grt_ker2asc.c
+++ b/pygrt/C_extension/src/tools/grt_ker2asc.c
@@ -93,7 +93,7 @@ static void print_PTAM(FILE *fp){
 
 /** 子模块主函数 */
 int ker2asc_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 

--- a/pygrt/C_extension/src/tools/grt_sac2asc.c
+++ b/pygrt/C_extension/src/tools/grt_sac2asc.c
@@ -56,7 +56,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
 /** 子模块主函数 */
 int sac2asc_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 

--- a/pygrt/C_extension/src/tools/grt_travt.c
+++ b/pygrt/C_extension/src/tools/grt_travt.c
@@ -116,8 +116,8 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
             // 震源和场点深度， -Ddepsrc/deprcv
             case 'D':
                 Ctrl->D.active = true;
-                Ctrl->D.s_depsrc = (char*)malloc(sizeof(char)*(strlen(optarg)+1));
-                Ctrl->D.s_deprcv = (char*)malloc(sizeof(char)*(strlen(optarg)+1));
+                Ctrl->D.s_depsrc = GRT_SAFE_MALLOC(sizeof(char)*(strlen(optarg)+1));
+                Ctrl->D.s_deprcv = GRT_SAFE_MALLOC(sizeof(char)*(strlen(optarg)+1));
                 if(2 != sscanf(optarg, "%[^/]/%s", Ctrl->D.s_depsrc, Ctrl->D.s_deprcv)){
                     GRTBadOptionError(D, "");
                 };
@@ -172,7 +172,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                         } while (place < 8);  // 最多小数点后 8 位
 
                         Ctrl->R.nr = floor((a2-a1)/delta) + 1;
-                        Ctrl->R.s_rs = (char **)calloc(Ctrl->R.nr, sizeof(char*) * Ctrl->R.nr);
+                        Ctrl->R.s_rs = GRT_SAFE_CALLOC(Ctrl->R.nr, sizeof(char*) * Ctrl->R.nr);
                         for(size_t ir = 0; ir < Ctrl->R.nr; ++ir){
                             GRT_SAFE_ASPRINTF(&Ctrl->R.s_rs[ir], "%.*f", place, a1 + delta*ir);
                         }
@@ -185,7 +185,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
                     }
                         
                     // 转为浮点数
-                    Ctrl->R.rs = (real_t*)realloc(Ctrl->R.rs, sizeof(real_t)*(Ctrl->R.nr));
+                    Ctrl->R.rs = GRT_SAFE_REALLOC(Ctrl->R.rs, sizeof(real_t)*(Ctrl->R.nr));
                     for(size_t i=0; i<Ctrl->R.nr; ++i){
                         Ctrl->R.rs[i] = atof(Ctrl->R.s_rs[i]);
                         if(Ctrl->R.rs[i] < 0.0){
@@ -216,7 +216,7 @@ static void getopt_from_command(GRT_MODULE_CTRL *Ctrl, int argc, char **argv){
 
 /** 子模块主函数 */
 int travt_main(int argc, char **argv){
-    GRT_MODULE_CTRL *Ctrl = calloc(1, sizeof(*Ctrl));
+    GRT_MODULE_CTRL *Ctrl = GRT_SAFE_CALLOC(1, sizeof(*Ctrl));
 
     getopt_from_command(Ctrl, argc, argv);
 


### PR DESCRIPTION
This PR centralizes heap-allocation failure handling in the C code. It adds `GRT_SAFE_MALLOC`, `GRT_SAFE_CALLOC`, and `GRT_SAFE_REALLOC` to `const.h`, migrates all `malloc`, `calloc`, and `realloc` calls in the C sources, and removes redundant allocation-result checks. It also eliminates unnecessary casts around the allocation wrappers while preserving zero-size allocation behavior and unrelated NULL checks.
